### PR TITLE
feat(connector-quorum): split web3 endpoints

### DIFF
--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/json/openapi.json
@@ -441,6 +441,114 @@
                     }
                 }
             },
+            "RunTransactionGethKeychainRequest": {
+                "type": "object",
+                "required": [
+                    "web3SigningCredential",
+                    "transactionConfig"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "web3SigningCredential": {
+                        "$ref": "#/components/schemas/Web3SigningCredential",
+                        "nullable": false
+                    },
+                    "transactionConfig": {
+                        "$ref": "#/components/schemas/QuorumTransactionConfig",
+                        "nullable": false
+                    },
+                    "timeoutMs": {
+                        "type": "number",
+                        "description": "The amount of milliseconds to wait for a transaction receipt with thehash of the transaction(which indicates successful execution) beforegiving up and crashing.",
+                        "minimum": 0,
+                        "default": 60000,
+                        "nullable": false
+                    }
+                }
+            },
+            "RunTransactionGethKeychainResponse": {
+                "type": "object",
+                "required": [
+                    "transactionReceipt"
+                ],
+                "properties": {
+                    "transactionReceipt": {
+                        "$ref": "#/components/schemas/Web3TransactionReceipt"
+                    }
+                }
+            },
+            "RunTransactionPrivateKeyRequest": {
+                "type": "object",
+                "required": [
+                    "web3SigningCredential",
+                    "transactionConfig"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "web3SigningCredential": {
+                        "$ref": "#/components/schemas/Web3SigningCredential",
+                        "nullable": false
+                    },
+                    "transactionConfig": {
+                        "$ref": "#/components/schemas/QuorumTransactionConfig",
+                        "nullable": false
+                    },
+                    "timeoutMs": {
+                        "type": "number",
+                        "description": "The amount of milliseconds to wait for a transaction receipt with thehash of the transaction(which indicates successful execution) beforegiving up and crashing.",
+                        "minimum": 0,
+                        "default": 60000,
+                        "nullable": false
+                    }
+                }
+            },
+            "RunTransactionPrivateKeyResponse": {
+                "type": "object",
+                "required": [
+                    "transactionReceipt"
+                ],
+                "properties": {
+                    "transactionReceipt": {
+                        "$ref": "#/components/schemas/Web3TransactionReceipt"
+                    }
+                }
+            },
+            "RunTransactionCactusKeychainRefRequest": {
+                "type": "object",
+                "required": [
+                    "web3SigningCredential",
+                    "transactionConfig"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "web3SigningCredential": {
+                        "$ref": "#/components/schemas/Web3SigningCredential",
+                        "nullable": false
+                    },
+                    "transactionConfig": {
+                        "$ref": "#/components/schemas/QuorumTransactionConfig",
+                        "nullable": false
+                    },
+                    "timeoutMs": {
+                        "type": "number",
+                        "description": "The amount of milliseconds to wait for a transaction receipt with thehash of the transaction(which indicates successful execution) beforegiving up and crashing.",
+                        "minimum": 0,
+                        "default": 60000,
+                        "nullable": false
+                    }
+                }
+            },
+            "RunTransactionCactusKeychainRefResponse": {
+                "type": "object",
+                "required": [
+                    "transactionReceipt"
+                ],
+                "properties": {
+                    "transactionReceipt": {
+                        "$ref": "#/components/schemas/Web3TransactionReceipt"
+                    }
+                }
+            },
             "DeployContractSolidityBytecodeV1Request": {
                 "type": "object",
                 "required": [
@@ -838,6 +946,108 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/RunTransactionResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-geth-keychain": {
+            "post": {
+                "x-hyperledger-cactus": {
+                    "http": {
+                        "verbLowerCase": "post",
+                        "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-geth-keychain"
+                    }
+                },
+                "operationId": "runTransactionGethKeychainV1",
+                "summary": "Executes a transaction on a quorum ledger using geth keychain.",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunTransactionGethKeychainRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RunTransactionGethKeychainResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-private-key": {
+            "post": {
+                "x-hyperledger-cactus": {
+                    "http": {
+                        "verbLowerCase": "post",
+                        "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-private-key"
+                    }
+                },
+                "operationId": "runTransactionPrivateKeyV1",
+                "summary": "Executes a transaction on a quorum ledger using private key.",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunTransactionPrivateKeyRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RunTransactionPrivateKeyResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-cactus-keychain-ref": {
+            "post": {
+                "x-hyperledger-cactus": {
+                    "http": {
+                        "verbLowerCase": "post",
+                        "path": "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-cacus-keychain-ref"
+                    }
+                },
+                "operationId": "runTransactionCactusKeychainRefV1",
+                "summary": "Executes a transaction on a quorum ledger using cactus keychain ref.",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunTransactionCactusKeychainRefRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RunTransactionCactusKeychainRefResponse"
                                 }
                             }
                         }

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -461,6 +461,120 @@ export interface QuorumTransactionConfig {
 /**
  * 
  * @export
+ * @interface RunTransactionCactusKeychainRefRequest
+ */
+export interface RunTransactionCactusKeychainRefRequest {
+    /**
+     * 
+     * @type {Web3SigningCredential}
+     * @memberof RunTransactionCactusKeychainRefRequest
+     */
+    web3SigningCredential: Web3SigningCredential;
+    /**
+     * 
+     * @type {QuorumTransactionConfig}
+     * @memberof RunTransactionCactusKeychainRefRequest
+     */
+    transactionConfig: QuorumTransactionConfig;
+    /**
+     * The amount of milliseconds to wait for a transaction receipt with thehash of the transaction(which indicates successful execution) beforegiving up and crashing.
+     * @type {number}
+     * @memberof RunTransactionCactusKeychainRefRequest
+     */
+    timeoutMs?: number;
+}
+/**
+ * 
+ * @export
+ * @interface RunTransactionCactusKeychainRefResponse
+ */
+export interface RunTransactionCactusKeychainRefResponse {
+    /**
+     * 
+     * @type {Web3TransactionReceipt}
+     * @memberof RunTransactionCactusKeychainRefResponse
+     */
+    transactionReceipt: Web3TransactionReceipt;
+}
+/**
+ * 
+ * @export
+ * @interface RunTransactionGethKeychainRequest
+ */
+export interface RunTransactionGethKeychainRequest {
+    /**
+     * 
+     * @type {Web3SigningCredential}
+     * @memberof RunTransactionGethKeychainRequest
+     */
+    web3SigningCredential: Web3SigningCredential;
+    /**
+     * 
+     * @type {QuorumTransactionConfig}
+     * @memberof RunTransactionGethKeychainRequest
+     */
+    transactionConfig: QuorumTransactionConfig;
+    /**
+     * The amount of milliseconds to wait for a transaction receipt with thehash of the transaction(which indicates successful execution) beforegiving up and crashing.
+     * @type {number}
+     * @memberof RunTransactionGethKeychainRequest
+     */
+    timeoutMs?: number;
+}
+/**
+ * 
+ * @export
+ * @interface RunTransactionGethKeychainResponse
+ */
+export interface RunTransactionGethKeychainResponse {
+    /**
+     * 
+     * @type {Web3TransactionReceipt}
+     * @memberof RunTransactionGethKeychainResponse
+     */
+    transactionReceipt: Web3TransactionReceipt;
+}
+/**
+ * 
+ * @export
+ * @interface RunTransactionPrivateKeyRequest
+ */
+export interface RunTransactionPrivateKeyRequest {
+    /**
+     * 
+     * @type {Web3SigningCredential}
+     * @memberof RunTransactionPrivateKeyRequest
+     */
+    web3SigningCredential: Web3SigningCredential;
+    /**
+     * 
+     * @type {QuorumTransactionConfig}
+     * @memberof RunTransactionPrivateKeyRequest
+     */
+    transactionConfig: QuorumTransactionConfig;
+    /**
+     * The amount of milliseconds to wait for a transaction receipt with thehash of the transaction(which indicates successful execution) beforegiving up and crashing.
+     * @type {number}
+     * @memberof RunTransactionPrivateKeyRequest
+     */
+    timeoutMs?: number;
+}
+/**
+ * 
+ * @export
+ * @interface RunTransactionPrivateKeyResponse
+ */
+export interface RunTransactionPrivateKeyResponse {
+    /**
+     * 
+     * @type {Web3TransactionReceipt}
+     * @memberof RunTransactionPrivateKeyResponse
+     */
+    transactionReceipt: Web3TransactionReceipt;
+}
+/**
+ * 
+ * @export
  * @interface RunTransactionRequest
  */
 export interface RunTransactionRequest {
@@ -914,6 +1028,108 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
+         * @summary Executes a transaction on a quorum ledger using cactus keychain ref.
+         * @param {RunTransactionCactusKeychainRefRequest} [runTransactionCactusKeychainRefRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        runTransactionCactusKeychainRefV1: async (runTransactionCactusKeychainRefRequest?: RunTransactionCactusKeychainRefRequest, options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-cactus-keychain-ref`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(runTransactionCactusKeychainRefRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Executes a transaction on a quorum ledger using geth keychain.
+         * @param {RunTransactionGethKeychainRequest} [runTransactionGethKeychainRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        runTransactionGethKeychainV1: async (runTransactionGethKeychainRequest?: RunTransactionGethKeychainRequest, options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-geth-keychain`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(runTransactionGethKeychainRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Executes a transaction on a quorum ledger using private key.
+         * @param {RunTransactionPrivateKeyRequest} [runTransactionPrivateKeyRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        runTransactionPrivateKeyV1: async (runTransactionPrivateKeyRequest?: RunTransactionPrivateKeyRequest, options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-private-key`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(runTransactionPrivateKeyRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Executes a transaction on a quorum ledger
          * @param {RunTransactionRequest} [runTransactionRequest] 
          * @param {*} [options] Override http request option.
@@ -1012,6 +1228,39 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Executes a transaction on a quorum ledger using cactus keychain ref.
+         * @param {RunTransactionCactusKeychainRefRequest} [runTransactionCactusKeychainRefRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async runTransactionCactusKeychainRefV1(runTransactionCactusKeychainRefRequest?: RunTransactionCactusKeychainRefRequest, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RunTransactionCactusKeychainRefResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.runTransactionCactusKeychainRefV1(runTransactionCactusKeychainRefRequest, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @summary Executes a transaction on a quorum ledger using geth keychain.
+         * @param {RunTransactionGethKeychainRequest} [runTransactionGethKeychainRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async runTransactionGethKeychainV1(runTransactionGethKeychainRequest?: RunTransactionGethKeychainRequest, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RunTransactionGethKeychainResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.runTransactionGethKeychainV1(runTransactionGethKeychainRequest, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @summary Executes a transaction on a quorum ledger using private key.
+         * @param {RunTransactionPrivateKeyRequest} [runTransactionPrivateKeyRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async runTransactionPrivateKeyV1(runTransactionPrivateKeyRequest?: RunTransactionPrivateKeyRequest, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RunTransactionPrivateKeyResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.runTransactionPrivateKeyV1(runTransactionPrivateKeyRequest, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @summary Executes a transaction on a quorum ledger
          * @param {RunTransactionRequest} [runTransactionRequest] 
          * @param {*} [options] Override http request option.
@@ -1079,6 +1328,36 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         invokeContractV1NoKeychain(invokeContractJsonObjectV1Request?: InvokeContractJsonObjectV1Request, options?: any): AxiosPromise<InvokeContractV1Response> {
             return localVarFp.invokeContractV1NoKeychain(invokeContractJsonObjectV1Request, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Executes a transaction on a quorum ledger using cactus keychain ref.
+         * @param {RunTransactionCactusKeychainRefRequest} [runTransactionCactusKeychainRefRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        runTransactionCactusKeychainRefV1(runTransactionCactusKeychainRefRequest?: RunTransactionCactusKeychainRefRequest, options?: any): AxiosPromise<RunTransactionCactusKeychainRefResponse> {
+            return localVarFp.runTransactionCactusKeychainRefV1(runTransactionCactusKeychainRefRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Executes a transaction on a quorum ledger using geth keychain.
+         * @param {RunTransactionGethKeychainRequest} [runTransactionGethKeychainRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        runTransactionGethKeychainV1(runTransactionGethKeychainRequest?: RunTransactionGethKeychainRequest, options?: any): AxiosPromise<RunTransactionGethKeychainResponse> {
+            return localVarFp.runTransactionGethKeychainV1(runTransactionGethKeychainRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Executes a transaction on a quorum ledger using private key.
+         * @param {RunTransactionPrivateKeyRequest} [runTransactionPrivateKeyRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        runTransactionPrivateKeyV1(runTransactionPrivateKeyRequest?: RunTransactionPrivateKeyRequest, options?: any): AxiosPromise<RunTransactionPrivateKeyResponse> {
+            return localVarFp.runTransactionPrivateKeyV1(runTransactionPrivateKeyRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -1157,6 +1436,42 @@ export class DefaultApi extends BaseAPI {
      */
     public invokeContractV1NoKeychain(invokeContractJsonObjectV1Request?: InvokeContractJsonObjectV1Request, options?: any) {
         return DefaultApiFp(this.configuration).invokeContractV1NoKeychain(invokeContractJsonObjectV1Request, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Executes a transaction on a quorum ledger using cactus keychain ref.
+     * @param {RunTransactionCactusKeychainRefRequest} [runTransactionCactusKeychainRefRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public runTransactionCactusKeychainRefV1(runTransactionCactusKeychainRefRequest?: RunTransactionCactusKeychainRefRequest, options?: any) {
+        return DefaultApiFp(this.configuration).runTransactionCactusKeychainRefV1(runTransactionCactusKeychainRefRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Executes a transaction on a quorum ledger using geth keychain.
+     * @param {RunTransactionGethKeychainRequest} [runTransactionGethKeychainRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public runTransactionGethKeychainV1(runTransactionGethKeychainRequest?: RunTransactionGethKeychainRequest, options?: any) {
+        return DefaultApiFp(this.configuration).runTransactionGethKeychainV1(runTransactionGethKeychainRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Executes a transaction on a quorum ledger using private key.
+     * @param {RunTransactionPrivateKeyRequest} [runTransactionPrivateKeyRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public runTransactionPrivateKeyV1(runTransactionPrivateKeyRequest?: RunTransactionPrivateKeyRequest, options?: any) {
+        return DefaultApiFp(this.configuration).runTransactionPrivateKeyV1(runTransactionPrivateKeyRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/plugin-ledger-connector-quorum.ts
@@ -46,6 +46,12 @@ import {
   InvokeContractV1Response,
   RunTransactionRequest,
   RunTransactionResponse,
+  RunTransactionGethKeychainRequest,
+  RunTransactionGethKeychainResponse,
+  RunTransactionPrivateKeyRequest,
+  RunTransactionPrivateKeyResponse,
+  RunTransactionCactusKeychainRefRequest,
+  RunTransactionCactusKeychainRefResponse,
   Web3SigningCredentialGethKeychainPassword,
   Web3SigningCredentialCactusKeychainRef,
   Web3SigningCredentialPrivateKeyHex,
@@ -53,6 +59,9 @@ import {
 } from "./generated/openapi/typescript-axios/";
 
 import { RunTransactionEndpoint } from "./web-services/run-transaction-endpoint";
+import { RunTransactionGethKeychainEndpoint } from "./web-services/run-transaction-geth-keychain-endpoint";
+import { RunTransactionPrivateKeyEndpoint } from "./web-services/run-transaction-private-key-endpoint";
+import { RunTransactionCactusKeychainRefEndpoint } from "./web-services/run-transaction-cactus-keychain-ref-endpoint";
 import { InvokeContractEndpoint } from "./web-services/invoke-contract-endpoint";
 import { InvokeContractJsonObjectEndpoint } from "./web-services/invoke-contract-endpoint-json-object";
 import { isWeb3SigningCredentialNone } from "./model-type-guards";
@@ -176,6 +185,27 @@ export class PluginLedgerConnectorQuorum
     }
     {
       const endpoint = new RunTransactionEndpoint({
+        connector: this,
+        logLevel: this.options.logLevel,
+      });
+      endpoints.push(endpoint);
+    }
+    {
+      const endpoint = new RunTransactionGethKeychainEndpoint({
+        connector: this,
+        logLevel: this.options.logLevel,
+      });
+      endpoints.push(endpoint);
+    }
+    {
+      const endpoint = new RunTransactionPrivateKeyEndpoint({
+        connector: this,
+        logLevel: this.options.logLevel,
+      });
+      endpoints.push(endpoint);
+    }
+    {
+      const endpoint = new RunTransactionCactusKeychainRefEndpoint({
         connector: this,
         logLevel: this.options.logLevel,
       });
@@ -403,8 +433,8 @@ export class PluginLedgerConnectorQuorum
   }
 
   public async transactGethKeychain(
-    txIn: RunTransactionRequest,
-  ): Promise<RunTransactionResponse> {
+    txIn: RunTransactionGethKeychainRequest,
+  ): Promise<RunTransactionGethKeychainResponse> {
     const fnTag = `${this.className}#transactGethKeychain()`;
     const { sendTransaction } = this.web3.eth.personal;
     const { transactionConfig, web3SigningCredential } = txIn;
@@ -424,8 +454,8 @@ export class PluginLedgerConnectorQuorum
   }
 
   public async transactPrivateKey(
-    req: RunTransactionRequest,
-  ): Promise<RunTransactionResponse> {
+    req: RunTransactionPrivateKeyRequest,
+  ): Promise<RunTransactionPrivateKeyResponse> {
     const fnTag = `${this.className}#transactPrivateKey()`;
     const { transactionConfig, web3SigningCredential } = req;
     const {
@@ -448,8 +478,8 @@ export class PluginLedgerConnectorQuorum
   }
 
   public async transactCactusKeychainRef(
-    req: RunTransactionRequest,
-  ): Promise<RunTransactionResponse> {
+    req: RunTransactionCactusKeychainRefRequest,
+  ): Promise<RunTransactionCactusKeychainRefResponse> {
     const fnTag = `${this.className}#transactCactusKeychainRef()`;
     const { transactionConfig, web3SigningCredential } = req;
     const {

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/run-transaction-cactus-keychain-ref-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/run-transaction-cactus-keychain-ref-endpoint.ts
@@ -1,0 +1,104 @@
+import { Express, Request, Response } from "express";
+
+import {
+  Logger,
+  Checks,
+  LogLevelDesc,
+  LoggerProvider,
+  IAsyncProvider,
+} from "@hyperledger/cactus-common";
+import {
+  IEndpointAuthzOptions,
+  IExpressRequestHandler,
+  IWebServiceEndpoint,
+} from "@hyperledger/cactus-core-api";
+import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
+
+import { PluginLedgerConnectorQuorum } from "../plugin-ledger-connector-quorum";
+
+import OAS from "../../json/openapi.json";
+
+export interface IRunTransactionCactusKeychainRefEndpointOptions {
+  logLevel?: LogLevelDesc;
+  connector: PluginLedgerConnectorQuorum;
+}
+
+export class RunTransactionCactusKeychainRefEndpoint
+  implements IWebServiceEndpoint {
+  public static readonly CLASS_NAME = "RunTransactionCactusKeychainRefEndpoint";
+
+  private readonly log: Logger;
+
+  public get className(): string {
+    return RunTransactionCactusKeychainRefEndpoint.CLASS_NAME;
+  }
+
+  constructor(
+    public readonly options: IRunTransactionCactusKeychainRefEndpointOptions,
+  ) {
+    const fnTag = `${this.className}#constructor()`;
+    Checks.truthy(options, `${fnTag} arg options`);
+    Checks.truthy(options.connector, `${fnTag} arg options.connector`);
+
+    const level = this.options.logLevel || "INFO";
+    const label = this.className;
+    this.log = LoggerProvider.getOrCreate({ level, label });
+  }
+
+  public get oasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-cactus-keychain-ref"] {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-cactus-keychain-ref"
+    ];
+  }
+
+  public getPath(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.path;
+  }
+
+  public getVerbLowerCase(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.verbLowerCase;
+  }
+
+  public getOperationId(): string {
+    return this.oasPath.post.operationId;
+  }
+
+  getAuthorizationOptionsProvider(): IAsyncProvider<IEndpointAuthzOptions> {
+    // TODO: make this an injectable dependency in the constructor
+    return {
+      get: async () => ({
+        isProtected: true,
+        requiredRoles: [],
+      }),
+    };
+  }
+
+  public async registerExpress(
+    expressApp: Express,
+  ): Promise<IWebServiceEndpoint> {
+    await registerWebServiceEndpoint(expressApp, this);
+    return this;
+  }
+
+  public getExpressRequestHandler(): IExpressRequestHandler {
+    return this.handleRequest.bind(this);
+  }
+
+  public async handleRequest(req: Request, res: Response): Promise<void> {
+    const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
+    this.log.debug(reqTag);
+    const reqBody = req.body;
+    try {
+      const resBody = await this.options.connector.transactCactusKeychainRef(
+        reqBody,
+      );
+      res.json({ success: true, data: resBody });
+    } catch (ex) {
+      this.log.error(`Crash while serving ${reqTag}`, ex);
+      res.status(500).json({
+        message: "Internal Server Error",
+        error: ex?.stack || ex?.message,
+      });
+    }
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/run-transaction-geth-keychain-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/run-transaction-geth-keychain-endpoint.ts
@@ -1,0 +1,103 @@
+import { Express, Request, Response } from "express";
+
+import {
+  Logger,
+  Checks,
+  LogLevelDesc,
+  LoggerProvider,
+  IAsyncProvider,
+} from "@hyperledger/cactus-common";
+import {
+  IEndpointAuthzOptions,
+  IExpressRequestHandler,
+  IWebServiceEndpoint,
+} from "@hyperledger/cactus-core-api";
+import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
+
+import { PluginLedgerConnectorQuorum } from "../plugin-ledger-connector-quorum";
+
+import OAS from "../../json/openapi.json";
+
+export interface IRunTransactionGethKeychainEndpointOptions {
+  logLevel?: LogLevelDesc;
+  connector: PluginLedgerConnectorQuorum;
+}
+
+export class RunTransactionGethKeychainEndpoint implements IWebServiceEndpoint {
+  public static readonly CLASS_NAME = "RunTransactionGethKeychainEndpoint";
+
+  private readonly log: Logger;
+
+  public get className(): string {
+    return RunTransactionGethKeychainEndpoint.CLASS_NAME;
+  }
+
+  constructor(
+    public readonly options: IRunTransactionGethKeychainEndpointOptions,
+  ) {
+    const fnTag = `${this.className}#constructor()`;
+    Checks.truthy(options, `${fnTag} arg options`);
+    Checks.truthy(options.connector, `${fnTag} arg options.connector`);
+
+    const level = this.options.logLevel || "INFO";
+    const label = this.className;
+    this.log = LoggerProvider.getOrCreate({ level, label });
+  }
+
+  public get oasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-geth-keychain"] {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-geth-keychain"
+    ];
+  }
+
+  public getPath(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.path;
+  }
+
+  public getVerbLowerCase(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.verbLowerCase;
+  }
+
+  public getOperationId(): string {
+    return this.oasPath.post.operationId;
+  }
+
+  getAuthorizationOptionsProvider(): IAsyncProvider<IEndpointAuthzOptions> {
+    // TODO: make this an injectable dependency in the constructor
+    return {
+      get: async () => ({
+        isProtected: true,
+        requiredRoles: [],
+      }),
+    };
+  }
+
+  public async registerExpress(
+    expressApp: Express,
+  ): Promise<IWebServiceEndpoint> {
+    await registerWebServiceEndpoint(expressApp, this);
+    return this;
+  }
+
+  public getExpressRequestHandler(): IExpressRequestHandler {
+    return this.handleRequest.bind(this);
+  }
+
+  public async handleRequest(req: Request, res: Response): Promise<void> {
+    const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
+    this.log.debug(reqTag);
+    const reqBody = req.body;
+    try {
+      const resBody = await this.options.connector.transactGethKeychain(
+        reqBody,
+      );
+      res.json({ success: true, data: resBody });
+    } catch (ex) {
+      this.log.error(`Crash while serving ${reqTag}`, ex);
+      res.status(500).json({
+        message: "Internal Server Error",
+        error: ex?.stack || ex?.message,
+      });
+    }
+  }
+}

--- a/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/run-transaction-private-key-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/main/typescript/web-services/run-transaction-private-key-endpoint.ts
@@ -1,0 +1,101 @@
+import { Express, Request, Response } from "express";
+
+import {
+  Logger,
+  Checks,
+  LogLevelDesc,
+  LoggerProvider,
+  IAsyncProvider,
+} from "@hyperledger/cactus-common";
+import {
+  IEndpointAuthzOptions,
+  IExpressRequestHandler,
+  IWebServiceEndpoint,
+} from "@hyperledger/cactus-core-api";
+import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
+
+import { PluginLedgerConnectorQuorum } from "../plugin-ledger-connector-quorum";
+
+import OAS from "../../json/openapi.json";
+
+export interface IRunTransactionPrivateKeyEndpointOptions {
+  logLevel?: LogLevelDesc;
+  connector: PluginLedgerConnectorQuorum;
+}
+
+export class RunTransactionPrivateKeyEndpoint implements IWebServiceEndpoint {
+  public static readonly CLASS_NAME = "RunTransactionPrivateKeyEndpoint";
+
+  private readonly log: Logger;
+
+  public get className(): string {
+    return RunTransactionPrivateKeyEndpoint.CLASS_NAME;
+  }
+
+  constructor(
+    public readonly options: IRunTransactionPrivateKeyEndpointOptions,
+  ) {
+    const fnTag = `${this.className}#constructor()`;
+    Checks.truthy(options, `${fnTag} arg options`);
+    Checks.truthy(options.connector, `${fnTag} arg options.connector`);
+
+    const level = this.options.logLevel || "INFO";
+    const label = this.className;
+    this.log = LoggerProvider.getOrCreate({ level, label });
+  }
+
+  public get oasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-private-key"] {
+    return OAS.paths[
+      "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-quorum/run-transaction-private-key"
+    ];
+  }
+
+  public getPath(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.path;
+  }
+
+  public getVerbLowerCase(): string {
+    return this.oasPath.post["x-hyperledger-cactus"].http.verbLowerCase;
+  }
+
+  public getOperationId(): string {
+    return this.oasPath.post.operationId;
+  }
+
+  getAuthorizationOptionsProvider(): IAsyncProvider<IEndpointAuthzOptions> {
+    // TODO: make this an injectable dependency in the constructor
+    return {
+      get: async () => ({
+        isProtected: true,
+        requiredRoles: [],
+      }),
+    };
+  }
+
+  public async registerExpress(
+    expressApp: Express,
+  ): Promise<IWebServiceEndpoint> {
+    await registerWebServiceEndpoint(expressApp, this);
+    return this;
+  }
+
+  public getExpressRequestHandler(): IExpressRequestHandler {
+    return this.handleRequest.bind(this);
+  }
+
+  public async handleRequest(req: Request, res: Response): Promise<void> {
+    const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
+    this.log.debug(reqTag);
+    const reqBody = req.body;
+    try {
+      const resBody = await this.options.connector.transactPrivateKey(reqBody);
+      res.json({ success: true, data: resBody });
+    } catch (ex) {
+      this.log.error(`Crash while serving ${reqTag}`, ex);
+      res.status(500).json({
+        message: "Internal Server Error",
+        error: ex?.stack || ex?.message,
+      });
+    }
+  }
+}


### PR DESCRIPTION
Splits the web3 runTransaction endpoint into 4 respective endpoints based on signing type.

**Added**
- runTransactionGethKeychain, runTransactionCactusKeychainRef and runTransactionPrivateKey endpoint and corresponding entries in the openAPI etc.

**Updated**
- The corresponding methods for the signing credentials to use the new endpoints respectively.

resolve #1248 