### PR TITLE
Cactus test plugin htlc eth besu erc20/refund endpoint

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -43,7 +43,6 @@ files:
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/withdraw-endpoint.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-single-status-endpoint-invalid.test.ts
   - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts
-  - ./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts
   - ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -48,7 +48,6 @@ module.exports = {
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/withdraw-endpoint.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-single-status-endpoint-invalid.test.ts`,
     `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts`,
-    `./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install.test.ts`,
     `./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts`,

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts
@@ -1,7 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import http from "http";
-import type { AddressInfo } from "net";
-import test, { Test } from "tape-promise/tape";
+import { AddressInfo } from "net";
 import { v4 as uuidv4 } from "uuid";
+import "jest-extended";
 import express from "express";
 import bodyParser from "body-parser";
 import {
@@ -37,545 +38,256 @@ import TestTokenJSON from "../../../solidity/token-erc20-contract/Test_Token.jso
 import DemoHelperJSON from "../../../solidity/token-erc20-contract/DemoHelpers.json";
 import HashTimeLockJSON from "../../../../../../cactus-plugin-htlc-eth-besu-erc20/src/main/solidity/contracts/HashedTimeLockContract.json";
 
-const logLevel: LogLevelDesc = "INFO";
-const estimatedGas = 6721975;
-const besuTestLedger = new BesuTestLedger({ logLevel });
-const receiver = besuTestLedger.getGenesisAccountPubKey();
-const hashLock =
-  "0x3c335ba7f06a8b01d0596589f73c19069e21c81e5013b91f408165d1bf623d32";
-const firstHighNetWorthAccount = "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1";
-const privateKey =
-  "0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d";
-const connectorId = uuidv4();
-const web3SigningCredential: Web3SigningCredential = {
-  ethAccount: firstHighNetWorthAccount,
-  secret: privateKey,
-  type: Web3SigningCredentialType.PrivateKeyHex,
-} as Web3SigningCredential;
-
-const timeout = (ms: number) => {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-};
-
 const testCase = "Test refund endpoint";
 
-test("BEFORE " + testCase, async (t: Test) => {
-  const pruning = pruneDockerAllIfGithubAction({ logLevel });
-  await t.doesNotReject(pruning, "Pruning did not throw OK");
-  t.end();
-});
-
-test(testCase, async (t: Test) => {
-  t.comment("Starting Besu Test Ledger");
+describe(testCase, () => {
+  const logLevel: LogLevelDesc = "INFO";
+  const estimatedGas = 6721975;
   const besuTestLedger = new BesuTestLedger({
     logLevel,
     envVars: [...BESU_TEST_LEDGER_DEFAULT_OPTIONS.envVars, "BESU_LOGGING=ALL"],
   });
-  await besuTestLedger.start();
+  const receiver = besuTestLedger.getGenesisAccountPubKey();
+  const hashLock =
+    "0x3c335ba7f06a8b01d0596589f73c19069e21c81e5013b91f408165d1bf623d32";
+  const firstHighNetWorthAccount = "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1";
+  const privateKey =
+    "0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d";
+  const connectorId = uuidv4();
+  const web3SigningCredential: Web3SigningCredential = {
+    ethAccount: firstHighNetWorthAccount,
+    secret: privateKey,
+    type: Web3SigningCredentialType.PrivateKeyHex,
+  } as Web3SigningCredential;
 
-  test.onFinish(async () => {
-    await besuTestLedger.stop();
-    await besuTestLedger.destroy();
-    await pruneDockerAllIfGithubAction({ logLevel });
-  });
-
-  const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
-  const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
-  const keychainId = uuidv4();
-  const keychainPlugin = new PluginKeychainMemory({
-    instanceId: uuidv4(),
-    keychainId,
-    // pre-provision keychain with mock backend holding the private key of the
-    // test account that we'll reference while sending requests with the
-    // signing credential pointing to this keychain entry.
-    backend: new Map([
-      [TestTokenJSON.contractName, JSON.stringify(TestTokenJSON)],
-    ]),
-    logLevel,
-  });
-  keychainPlugin.set(
-    DemoHelperJSON.contractName,
-    JSON.stringify(DemoHelperJSON),
-  );
-  keychainPlugin.set(
-    HashTimeLockJSON.contractName,
-    JSON.stringify(HashTimeLockJSON),
-  );
-  const factory = new PluginFactoryLedgerConnector({
-    pluginImportType: PluginImportType.Local,
-  });
-
-  const pluginRegistry = new PluginRegistry({});
-  const connector: PluginLedgerConnectorBesu = await factory.create({
-    rpcApiHttpHost,
-    rpcApiWsHost,
-    logLevel,
-    instanceId: connectorId,
-    pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
-  });
-
-  pluginRegistry.add(connector);
-  const pluginOptions: IPluginHtlcEthBesuErc20Options = {
-    instanceId: uuidv4(),
-    logLevel,
-    pluginRegistry,
+  const timeout = (ms: number) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   };
-
-  const factoryHTLC = new PluginFactoryHtlcEthBesuErc20({
-    pluginImportType: PluginImportType.Local,
-  });
-  const pluginHtlc = await factoryHTLC.create(pluginOptions);
-  pluginRegistry.add(pluginHtlc);
-
   const expressApp = express();
   expressApp.use(bodyParser.json({ limit: "250mb" }));
   const server = http.createServer(expressApp);
-  const listenOptions: IListenOptions = {
-    hostname: "0.0.0.0",
-    port: 0,
-    server,
-  };
-  const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
-  test.onFinish(async () => await Servers.shutdown(server));
-  const { address, port } = addressInfo;
-  const apiHost = `http://${address}:${port}`;
-
-  const configuration = new Configuration({ basePath: apiHost });
-  const api = new BesuApi(configuration);
-
-  await pluginHtlc.getOrCreateWebServices();
-  await pluginHtlc.registerWebServices(expressApp);
-
-  t.comment("Deploys HashTimeLock via .json file on initialize function");
-  const initRequest: InitializeRequest = {
-    connectorId,
-    keychainId,
-    constructorArgs: [],
-    web3SigningCredential,
-    gas: estimatedGas,
-  };
-  const deployOut = await pluginHtlc.initialize(initRequest);
-
-  t.ok(deployOut, "pluginHtlc.initialize() output is truthy OK");
-  t.ok(
-    deployOut.transactionReceipt,
-    "pluginHtlc.initialize() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOut.transactionReceipt.contractAddress,
-    "pluginHtlc.initialize() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const hashTimeLockAddress = deployOut.transactionReceipt
-    .contractAddress as string;
-
-  t.comment("Deploys TestToken via .json file on deployContract function");
-  const deployOutToken = await connector.deployContract({
-    contractName: TestTokenJSON.contractName,
-    contractAbi: TestTokenJSON.abi,
-    bytecode: TestTokenJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: ["100", "token", "2", "TKN"],
-    gas: estimatedGas,
+  const keychainId = uuidv4();
+  let addressInfo,
+    address: string,
+    port: number,
+    apiHost,
+    configuration,
+    api: BesuApi;
+  beforeAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).resolves.toBeTruthy();
   });
-  t.ok(deployOutToken, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutToken.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutToken.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const tokenAddress = deployOutToken.transactionReceipt
-    .contractAddress as string;
 
-  t.comment("Deploys DemoHelpers via .json file on deployContract function");
-  const deployOutDemo = await connector.deployContract({
-    contractName: DemoHelperJSON.contractName,
-    contractAbi: DemoHelperJSON.abi,
-    bytecode: DemoHelperJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: [],
-    gas: estimatedGas,
-  });
-  t.ok(deployOutDemo, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutDemo.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutDemo.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
-
-  t.comment("Approve 10 Tokens to HashTimeLockAddress");
-  const { success } = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Send,
-    methodName: "approve",
-    params: [hashTimeLockAddress, "10"],
-    gas: estimatedGas,
-  });
-  t.equal(success, true, "approve() transactionReceipt.status is true OK");
-
-  t.comment("Get account balance");
-  const responseBalance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
-  });
-  t.equal(responseBalance.callOutput, "100", "balance of account is 100 OK");
-
-  t.comment("Get current timestamp");
-  const { callOutput } = await connector.invokeContract({
-    contractName: DemoHelperJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "getTimestamp",
-    params: [],
-  });
-  t.ok(callOutput, "callOutput() output.callOutput is truthy OK");
-  let timestamp = 0;
-  timestamp = callOutput as number;
-  timestamp = +timestamp + +10;
-
-  t.comment("Get HashTimeLock contract and account allowance");
-  const responseAllowance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "allowance",
-    params: [firstHighNetWorthAccount, hashTimeLockAddress],
-  });
-  t.equal(responseAllowance.callOutput, "10", "callOutput() is 10 OK");
-
-  t.comment("Create new contract for HTLC");
-  const request: NewContractRequest = {
-    contractAddress: hashTimeLockAddress,
-    inputAmount: 10,
-    outputAmount: 1,
-    expiration: timestamp,
-    hashLock,
-    tokenAddress,
-    receiver,
-    outputNetwork: "BTC",
-    outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
-    connectorId,
-    keychainId,
-    web3SigningCredential,
-    gas: estimatedGas,
-  };
-  const res = await api.newContractV1(request);
-  t.equal(res.status, 200, "response status is 200 OK");
-
-  t.comment("Get account balance");
-  const responseBalance2 = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
-  });
-  t.equal(responseBalance2.callOutput, "90", "balance of account is 90 OK");
-
-  t.comment("Get HTLC Id from DemoHelper");
-  const responseTxId = await connector.invokeContract({
-    contractName: DemoHelperJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "getTxId",
-    params: [
-      firstHighNetWorthAccount,
-      receiver,
-      10,
-      hashLock,
-      timestamp,
-      tokenAddress,
-    ],
-  });
-  t.ok(responseTxId.callOutput, "result is truthy OK");
-  const id = responseTxId.callOutput as string;
-
-  t.comment("Refund HTLC");
-  await timeout(6000);
-  const refundRequest: RefundRequest = {
-    id,
-    web3SigningCredential,
-    connectorId,
-    keychainId,
-  };
-  const resRefund = await api.refundV1(refundRequest);
-  t.equal(resRefund.status, 200, "response status is 200 OK");
-
-  t.comment("Get account balance");
-  const responseFinalBalance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
-  });
-  t.equal(
-    responseFinalBalance.callOutput,
-    "100",
-    "balance of account is 100 OK",
-  );
-  t.comment("Get status of HTLC");
-  const resStatus = await api.getSingleStatusV1({
-    id,
-    web3SigningCredential,
-    connectorId,
-    keychainId,
-  });
-  t.equal(resStatus.status, 200, "response status is 200 OK");
-  t.equal(resStatus.data, 2, "the contract status is 2 - Refunded");
-  t.end();
-});
-
-test("Test invalid refund with invalid time", async (t: Test) => {
-  t.comment("Starting Besu Test Ledger");
-  const besuTestLedger = new BesuTestLedger({
-    logLevel,
-    envVars: [...BESU_TEST_LEDGER_DEFAULT_OPTIONS.envVars, "BESU_LOGGING=ALL"],
-  });
-  await besuTestLedger.start();
-
-  test.onFinish(async () => {
+  afterAll(async () => {
     await besuTestLedger.stop();
     await besuTestLedger.destroy();
   });
-
-  const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
-  const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
-  const keychainId = uuidv4();
-  const keychainPlugin = new PluginKeychainMemory({
-    instanceId: uuidv4(),
-    keychainId,
-    // pre-provision keychain with mock backend holding the private key of the
-    // test account that we'll reference while sending requests with the
-    // signing credential pointing to this keychain entry.
-    backend: new Map([
-      [TestTokenJSON.contractName, JSON.stringify(TestTokenJSON)],
-    ]),
-    logLevel,
-  });
-  keychainPlugin.set(
-    DemoHelperJSON.contractName,
-    JSON.stringify(DemoHelperJSON),
-  );
-  keychainPlugin.set(
-    HashTimeLockJSON.contractName,
-    JSON.stringify(HashTimeLockJSON),
-  );
-  const factory = new PluginFactoryLedgerConnector({
-    pluginImportType: PluginImportType.Local,
+  afterAll(async () => await Servers.shutdown(server));
+  afterAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel });
+    await expect(pruning).resolves.toBeTruthy();
   });
 
-  const pluginRegistry = new PluginRegistry({});
-  const connector: PluginLedgerConnectorBesu = await factory.create({
-    rpcApiHttpHost,
-    rpcApiWsHost,
-    logLevel,
-    instanceId: connectorId,
-    pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
+  beforeAll(async () => {
+    await besuTestLedger.start();
+
+    const listenOptions: IListenOptions = {
+      hostname: "0.0.0.0",
+      port: 0,
+      server,
+    };
+    addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
+    ({ address, port } = addressInfo);
+    apiHost = `http://${address}:${port}`;
+    configuration = new Configuration({ basePath: apiHost });
+    api = new BesuApi(configuration);
   });
 
-  pluginRegistry.add(connector);
-  const pluginOptions: IPluginHtlcEthBesuErc20Options = {
-    instanceId: uuidv4(),
-    logLevel,
-    pluginRegistry,
-  };
+  test(testCase, async () => {
+    await besuTestLedger.start();
+    const rpcApiHttpHost = await besuTestLedger.getRpcApiHttpHost();
+    const rpcApiWsHost = await besuTestLedger.getRpcApiWsHost();
+    const keychainPlugin = new PluginKeychainMemory({
+      instanceId: uuidv4(),
+      keychainId,
+      // pre-provision keychain with mock backend holding the private key of the
+      // test account that we'll reference while sending requests with the
+      // signing credential pointing to this keychain entry.
+      backend: new Map([
+        [TestTokenJSON.contractName, JSON.stringify(TestTokenJSON)],
+      ]),
+      logLevel,
+    });
+    keychainPlugin.set(
+      DemoHelperJSON.contractName,
+      JSON.stringify(DemoHelperJSON),
+    );
+    keychainPlugin.set(
+      HashTimeLockJSON.contractName,
+      JSON.stringify(HashTimeLockJSON),
+    );
+    const factory = new PluginFactoryLedgerConnector({
+      pluginImportType: PluginImportType.Local,
+    });
 
-  const factoryHTLC = new PluginFactoryHtlcEthBesuErc20({
-    pluginImportType: PluginImportType.Local,
-  });
-  const pluginHtlc = await factoryHTLC.create(pluginOptions);
-  pluginRegistry.add(pluginHtlc);
+    const pluginRegistry = new PluginRegistry({});
+    const connector: PluginLedgerConnectorBesu = await factory.create({
+      rpcApiHttpHost,
+      rpcApiWsHost,
+      logLevel,
+      instanceId: connectorId,
+      pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
+    });
 
-  const expressApp = express();
-  expressApp.use(bodyParser.json({ limit: "250mb" }));
-  const server = http.createServer(expressApp);
-  const listenOptions: IListenOptions = {
-    hostname: "0.0.0.0",
-    port: 0,
-    server,
-  };
-  const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
-  test.onFinish(async () => await Servers.shutdown(server));
-  const { address, port } = addressInfo;
-  const apiHost = `http://${address}:${port}`;
+    pluginRegistry.add(connector);
+    const pluginOptions: IPluginHtlcEthBesuErc20Options = {
+      instanceId: uuidv4(),
+      logLevel,
+      pluginRegistry,
+    };
 
-  const configuration = new Configuration({ basePath: apiHost });
-  const api = new BesuApi(configuration);
+    const factoryHTLC = new PluginFactoryHtlcEthBesuErc20({
+      pluginImportType: PluginImportType.Local,
+    });
+    const pluginHtlc = await factoryHTLC.create(pluginOptions);
+    pluginRegistry.add(pluginHtlc);
 
-  await pluginHtlc.getOrCreateWebServices();
-  await pluginHtlc.registerWebServices(expressApp);
+    await pluginHtlc.getOrCreateWebServices();
+    await pluginHtlc.registerWebServices(expressApp);
 
-  t.comment("Deploys HashTimeLock via .json file on initialize function");
-  const initRequest: InitializeRequest = {
-    connectorId,
-    keychainId,
-    constructorArgs: [],
-    web3SigningCredential,
-    gas: estimatedGas,
-  };
-  const deployOut = await pluginHtlc.initialize(initRequest);
+    const initRequest: InitializeRequest = {
+      connectorId,
+      keychainId,
+      constructorArgs: [],
+      web3SigningCredential,
+      gas: estimatedGas,
+    };
+    const deployOut = await pluginHtlc.initialize(initRequest);
 
-  t.ok(deployOut, "pluginHtlc.initialize() output is truthy OK");
-  t.ok(
-    deployOut.transactionReceipt,
-    "pluginHtlc.initialize() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOut.transactionReceipt.contractAddress,
-    "pluginHtlc.initialize() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const hashTimeLockAddress = deployOut.transactionReceipt
-    .contractAddress as string;
+    expect(deployOut).toBeTruthy();
+    expect(deployOut.transactionReceipt).toBeTruthy();
+    expect(deployOut.transactionReceipt.contractAddress).toBeTruthy();
 
-  t.comment("Deploys TestToken via .json file on deployContract function");
-  const deployOutToken = await connector.deployContract({
-    contractName: TestTokenJSON.contractName,
-    contractAbi: TestTokenJSON.abi,
-    bytecode: TestTokenJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: ["100", "token", "2", "TKN"],
-    gas: estimatedGas,
-  });
-  t.ok(deployOutToken, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutToken.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutToken.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
-  const tokenAddress = deployOutToken.transactionReceipt
-    .contractAddress as string;
+    const hashTimeLockAddress = deployOut.transactionReceipt
+      .contractAddress as string;
 
-  t.comment("Deploys DemoHelpers via .json file on deployContract function");
-  const deployOutDemo = await connector.deployContract({
-    contractName: DemoHelperJSON.contractName,
-    contractAbi: DemoHelperJSON.abi,
-    bytecode: DemoHelperJSON.bytecode,
-    web3SigningCredential,
-    keychainId,
-    constructorArgs: [],
-    gas: estimatedGas,
-  });
-  t.ok(deployOutDemo, "deployContract() output is truthy OK");
-  t.ok(
-    deployOutDemo.transactionReceipt,
-    "deployContract() output.transactionReceipt is truthy OK",
-  );
-  t.ok(
-    deployOutDemo.transactionReceipt.contractAddress,
-    "deployContract() output.transactionReceipt.contractAddress is truthy OK",
-  );
+    const deployOutToken = await connector.deployContract({
+      contractName: TestTokenJSON.contractName,
+      contractAbi: TestTokenJSON.abi,
+      bytecode: TestTokenJSON.bytecode,
+      web3SigningCredential,
+      keychainId,
+      constructorArgs: ["100", "token", "2", "TKN"],
+      gas: estimatedGas,
+    });
+    expect(deployOutToken).toBeTruthy();
+    expect(deployOutToken.transactionReceipt).toBeTruthy();
+    expect(deployOutToken.transactionReceipt.contractAddress).toBeTruthy();
+    const tokenAddress = deployOutToken.transactionReceipt
+      .contractAddress as string;
 
-  t.comment("Approve 10 Tokens to HashTimeLockAddress");
-  const { success } = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Send,
-    methodName: "approve",
-    params: [hashTimeLockAddress, "10"],
-    gas: estimatedGas,
-  });
-  t.equal(success, true, "approve() transactionReceipt.status is true OK");
+    const deployOutDemo = await connector.deployContract({
+      contractName: DemoHelperJSON.contractName,
+      contractAbi: DemoHelperJSON.abi,
+      bytecode: DemoHelperJSON.bytecode,
+      web3SigningCredential,
+      keychainId,
+      constructorArgs: [],
+      gas: estimatedGas,
+    });
+    expect(deployOutDemo).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt).toBeTruthy();
+    expect(deployOutDemo.transactionReceipt.contractAddress).toBeTruthy();
 
-  t.comment("Get account balance");
-  const responseBalance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
-  });
-  t.equal(responseBalance.callOutput, "100", "balance of account is 100 OK");
+    const { success } = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Send,
+      methodName: "approve",
+      params: [hashTimeLockAddress, "10"],
+      gas: estimatedGas,
+    });
+    expect(success).toBe(true);
+    const responseBalance = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "balanceOf",
+      params: [firstHighNetWorthAccount],
+    });
+    expect(responseBalance.callOutput).toEqual("100");
+    const { callOutput } = await connector.invokeContract({
+      contractName: DemoHelperJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "getTimestamp",
+      params: [],
+    });
+    expect(callOutput).toBeTruthy();
+    let timestamp = 0;
+    timestamp = callOutput as number;
+    timestamp = +timestamp + +10;
 
-  t.comment("Get current timestamp");
-  const { callOutput } = await connector.invokeContract({
-    contractName: DemoHelperJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "getTimestamp",
-    params: [],
-  });
-  t.ok(callOutput, "callOutput() output.callOutput is truthy OK");
-  let timestamp = 0;
-  timestamp = callOutput as number;
-  timestamp = +timestamp + +10;
+    const responseAllowance = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "allowance",
+      params: [firstHighNetWorthAccount, hashTimeLockAddress],
+    });
+    expect(responseAllowance.callOutput).toEqual("10");
 
-  t.comment("Get HashTimeLock contract and account allowance");
-  const responseAllowance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "allowance",
-    params: [firstHighNetWorthAccount, hashTimeLockAddress],
-  });
-  t.equal(responseAllowance.callOutput, "10", "callOutput() is 10 OK");
-
-  t.comment("Create new contract for HTLC");
-  const request: NewContractRequest = {
-    contractAddress: hashTimeLockAddress,
-    inputAmount: 10,
-    outputAmount: 1,
-    expiration: timestamp,
-    hashLock,
-    tokenAddress,
-    receiver,
-    outputNetwork: "BTC",
-    outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
-    connectorId,
-    keychainId,
-    web3SigningCredential,
-    gas: estimatedGas,
-  };
-  const res = await api.newContractV1(request);
-  t.equal(res.status, 200, "response status is 200 OK");
-
-  t.comment("Get HTLC Id from DemoHelper");
-  const responseTxId = await connector.invokeContract({
-    contractName: DemoHelperJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "getTxId",
-    params: [
-      firstHighNetWorthAccount,
-      receiver,
-      10,
+    const request: NewContractRequest = {
+      contractAddress: hashTimeLockAddress,
+      inputAmount: 10,
+      outputAmount: 1,
+      expiration: timestamp,
       hashLock,
-      timestamp,
       tokenAddress,
-    ],
-  });
-  t.ok(responseTxId.callOutput, "result is truthy OK");
-  const id = responseTxId.callOutput as string;
+      receiver,
+      outputNetwork: "BTC",
+      outputAddress: "1AcVYm7M3kkJQH28FXAvyBFQzFRL6xPKu8",
+      connectorId,
+      keychainId,
+      web3SigningCredential,
+      gas: estimatedGas,
+    };
+    const res = await api.newContractV1(request);
+    expect(res.status).toEqual(200);
 
-  t.comment("Refund HTLC when it is not possible yet");
-  try {
+    const responseBalance2 = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "balanceOf",
+      params: [firstHighNetWorthAccount],
+    });
+    expect(responseBalance2.callOutput).toEqual("90");
+
+    const responseTxId = await connector.invokeContract({
+      contractName: DemoHelperJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "getTxId",
+      params: [
+        firstHighNetWorthAccount,
+        receiver,
+        10,
+        hashLock,
+        timestamp,
+        tokenAddress,
+      ],
+    });
+    expect(responseTxId.callOutput).toBeTruthy;
+    const id = responseTxId.callOutput as string;
+
+    await timeout(6000);
     const refundRequest: RefundRequest = {
       id,
       web3SigningCredential,
@@ -583,20 +295,25 @@ test("Test invalid refund with invalid time", async (t: Test) => {
       keychainId,
     };
     const resRefund = await api.refundV1(refundRequest);
-    t.equal(resRefund.status, 400, "response status is 400");
-  } catch (error) {
-    t.equal(error.response.status, 400, "response status is 400");
-  }
+    expect(resRefund.status).toEqual(200);
 
-  t.comment("Get balance of account");
-  const responseFinalBalance = await connector.invokeContract({
-    contractName: TestTokenJSON.contractName,
-    keychainId,
-    signingCredential: web3SigningCredential,
-    invocationType: EthContractInvocationType.Call,
-    methodName: "balanceOf",
-    params: [firstHighNetWorthAccount],
+    const responseFinalBalance = await connector.invokeContract({
+      contractName: TestTokenJSON.contractName,
+      keychainId,
+      signingCredential: web3SigningCredential,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "balanceOf",
+      params: [firstHighNetWorthAccount],
+    });
+    expect(responseFinalBalance.callOutput).toEqual("100");
+
+    const resStatus = await api.getSingleStatusV1({
+      id,
+      web3SigningCredential,
+      connectorId,
+      keychainId,
+    });
+    expect(resStatus.status).toEqual(200);
+    expect(resStatus.data).toEqual(2);
   });
-  t.equal(responseFinalBalance.callOutput, "90", "balance of account is 90 OK");
-  t.end();
 });


### PR DESCRIPTION
Migrated test from Tap to Jest.

File Path:
packages/cactus-test-plugin-htlc-eth-besu-erc20/src/
test/typescript/integration/plugin-htlc-eth-besu-erc20/
refund-endpoint.test.ts

This is a PARTIAL resolution to issue #238

This PR is the other half of the already merged, and can be found at https://github.com/hyperledger/cactus/pull/1545

This test has been flaky in the past, as noted in https://github.com/hyperledger/cactus/issues/1150

Signed-off-by: awadhana <awadhana2021@gmail.com>