### PR TITLE
test: jestify remote-plugin-imports test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -111,7 +111,6 @@ files:
   - ./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/benchmark/artillery-api-benchmark.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-socketio-endpoint-authorization.test.ts
-  - ./packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts
   - ./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-keychain-memory.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -117,7 +117,6 @@ module.exports = {
     `./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/benchmark/artillery-api-benchmark.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/jwt-socketio-endpoint-authorization.test.ts`,
-    `./packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts`,
     `./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-keychain-memory.test.ts`,

--- a/packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
+++ b/packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts
@@ -1,12 +1,10 @@
-import test, { Test } from "tape-promise/tape";
 import { v4 as uuidv4 } from "uuid";
-
+import "jest-extended";
 import {
   ApiServer,
   AuthorizationProtocol,
   ConfigService,
 } from "../../../main/typescript/public-api";
-
 import {
   CactusKeychainVaultServer,
   Containers,
@@ -23,93 +21,97 @@ import {
 } from "@hyperledger/cactus-core-api";
 import path from "path";
 
-test("NodeJS API server + Rust plugin work together", async (t: Test) => {
+const testCase = "NodeJS API server + Rust plugin work together";
+describe(testCase, () => {
+  let apiServer: ApiServer,
+    pluginContainer: CactusKeychainVaultServer,
+    apiClient: DefaultApi;
   const vaultTestContainer = new VaultTestServer({});
-  await vaultTestContainer.start();
 
-  const ci = await Containers.getById(vaultTestContainer.containerId);
-  const vaultIpAddr = await Containers.getContainerInternalIp(ci);
-  t.comment(`Container VaultTestServer has IPv4: ${vaultIpAddr}`);
+  afterAll(() => apiServer.shutdown());
 
-  test.onFinish(async () => {
-    await vaultTestContainer.stop();
-    await vaultTestContainer.destroy();
-  });
-
-  const hostPortVault = await vaultTestContainer.getHostPortHttp();
-  t.comment(`Container VaultTestServer (Port=${hostPortVault}) started OK`);
-  const vaultHost = `http://${vaultIpAddr}:${K_DEFAULT_VAULT_HTTP_PORT}`;
-
-  const pluginContainer = new CactusKeychainVaultServer({
-    envVars: [
-      `VAULT_HOST=${vaultHost}`,
-      `VAULT_TOKEN=${K_DEFAULT_VAULT_DEV_ROOT_TOKEN}`,
-      "HOST=0.0.0.0:8080",
-    ],
-  });
-  await pluginContainer.start();
-
-  test.onFinish(async () => {
+  afterAll(async () => {
     await pluginContainer.stop();
     await pluginContainer.destroy();
   });
 
-  const hostPort = await pluginContainer.getHostPortHttp();
-  t.comment(`CactusKeychainVaultServer (Port=${hostPort}) started OK`);
-
-  const configuration = new Configuration({
-    basePath: `http://localhost:${hostPort}`,
+  afterAll(async () => {
+    await vaultTestContainer.stop();
+    await vaultTestContainer.destroy();
   });
-  const apiClient = new DefaultApi(configuration);
+  beforeAll(async () => {
+    await vaultTestContainer.start();
+    const pluginsPath = path.join(
+      __dirname, // start at the current file's path
+      "../../../../../../", // walk back up to the project root
+      ".tmp/test/cmd-api-server/remote-plugin-imports_test", // the dir path from the root
+      uuidv4(), // then a random directory to ensure proper isolation
+    );
+    const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
 
-  const pluginsPath = path.join(
-    __dirname, // start at the current file's path
-    "../../../../../../", // walk back up to the project root
-    ".tmp/test/cmd-api-server/remote-plugin-imports_test", // the dir path from the root
-    uuidv4(), // then a random directory to ensure proper isolation
-  );
-  const pluginManagerOptionsJson = JSON.stringify({ pluginsPath });
+    const ci = await Containers.getById(vaultTestContainer.containerId);
+    const vaultIpAddr = await Containers.getContainerInternalIp(ci);
+    const configService = new ConfigService();
+    const apiServerOptions = await configService.newExampleConfig();
+    apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
+    apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
+    apiServerOptions.configFile = "";
+    apiServerOptions.apiCorsDomainCsv = "*";
+    apiServerOptions.apiPort = 0;
+    apiServerOptions.cockpitPort = 0;
+    apiServerOptions.grpcPort = 0;
+    apiServerOptions.apiTlsEnabled = false;
 
-  const configService = new ConfigService();
-  const apiServerOptions = await configService.newExampleConfig();
-  apiServerOptions.authorizationProtocol = AuthorizationProtocol.NONE;
-  apiServerOptions.pluginManagerOptionsJson = pluginManagerOptionsJson;
-  apiServerOptions.configFile = "";
-  apiServerOptions.apiCorsDomainCsv = "*";
-  apiServerOptions.apiPort = 0;
-  apiServerOptions.cockpitPort = 0;
-  apiServerOptions.grpcPort = 0;
-  apiServerOptions.apiTlsEnabled = false;
-  apiServerOptions.plugins = [
-    {
-      packageName: "@hyperledger/cactus-plugin-keychain-vault",
-      type: PluginImportType.Remote,
-      action: PluginImportAction.Install,
-      options: {
-        keychainId: "_keychainId_",
-        instanceId: "_instanceId_",
-        remoteConfig: configuration,
+    const config = await configService.newExampleConfigConvict(
+      apiServerOptions,
+    );
+
+    apiServer = new ApiServer({
+      config: config.getProperties(),
+    });
+
+    // const hostPortVault = await vaultTestContainer.getHostPortHttp();
+    const vaultHost = `http://${vaultIpAddr}:${K_DEFAULT_VAULT_HTTP_PORT}`;
+
+    pluginContainer = new CactusKeychainVaultServer({
+      envVars: [
+        `VAULT_HOST=${vaultHost}`,
+        `VAULT_TOKEN=${K_DEFAULT_VAULT_DEV_ROOT_TOKEN}`,
+        "HOST=0.0.0.0:8080",
+      ],
+    });
+    await pluginContainer.start();
+    const hostPort = await pluginContainer.getHostPortHttp();
+
+    const configuration = new Configuration({
+      basePath: `http://localhost:${hostPort}`,
+    });
+    apiClient = new DefaultApi(configuration);
+
+    apiServerOptions.plugins = [
+      {
+        packageName: "@hyperledger/cactus-plugin-keychain-vault",
+        type: PluginImportType.Remote,
+        action: PluginImportAction.Install,
+        options: {
+          keychainId: "_keychainId_",
+          instanceId: "_instanceId_",
+          remoteConfig: configuration,
+        },
       },
-    },
-  ];
-  const config = await configService.newExampleConfigConvict(apiServerOptions);
+    ];
 
-  const apiServer = new ApiServer({
-    config: config.getProperties(),
+    await expect(apiServer.start()).not.toReject;
   });
+  test(testCase, async () => {
+    const key = uuidv4();
+    const expected = uuidv4();
 
-  await t.doesNotReject(apiServer.start(), "Started API server OK");
-  test.onFinish(() => apiServer.shutdown());
+    await apiClient.setKeychainEntryV1({ key, value: expected });
+    const {
+      data: { value: actual },
+    } = await apiClient.getKeychainEntryV1({ key });
 
-  const key = uuidv4();
-  const expected = uuidv4();
-
-  await apiClient.setKeychainEntryV1({ key, value: expected });
-  const {
-    data: { value: actual },
-  } = await apiClient.getKeychainEntryV1({ key });
-
-  t.equal(actual, expected, "Keychain stored value matches input OK");
-
-  t.end();
+    expect(actual).toEqual(expected);
+  });
 });


### PR DESCRIPTION
Migrated test from Tap to Jest.

File Path:
packages/cactus-cmd-api-server/src/test/typescript/
integration/remote-plugin-imports.test.ts

This is a PARTIAL resolution to issue #238 

Signed-off-by: awadhana awadhana2021@gmail.com