### PR TITLE
fix: part 2 of lint warnings resolved for batch 7/26 #1356 : Commit to be reviewed

### DIFF
--- a/packages/cactus-common/src/main/typescript/checks.ts
+++ b/packages/cactus-common/src/main/typescript/checks.ts
@@ -9,7 +9,7 @@ export class Checks {
    * @param code The code of the error if `checkResult is falsy.
    */
   public static truthy(
-    checkResult: any,
+    checkResult: unknown,
     subjectOfCheck = "variable",
     code = "-1",
   ): void {
@@ -28,7 +28,7 @@ export class Checks {
    * @param code The code of the error if `checkResult is falsy.
    */
   public static nonBlankString(
-    value: any,
+    value: unknown,
     subject = "variable",
     code = "-1",
   ): void {

--- a/packages/cactus-common/src/main/typescript/logging/logger-provider.ts
+++ b/packages/cactus-common/src/main/typescript/logging/logger-provider.ts
@@ -26,7 +26,7 @@ export class LoggerProvider {
     LoggerProvider.logLevel = logLevel;
     if (applyToCachedLoggers) {
       LoggerProvider.loggers.forEach((logger: Logger) =>
-        logger.setLogLevel(logLevel as any),
+        logger.setLogLevel(logLevel as LogLevelDesc),
       );
     }
   }

--- a/packages/cactus-common/src/main/typescript/objects.ts
+++ b/packages/cactus-common/src/main/typescript/objects.ts
@@ -29,18 +29,19 @@ export class Objects {
    *
    * @param anObject
    */
-  public static getAllMethodNames(anObject: any): string[] {
+  public static getAllMethodNames(anObject: unknown): string[] {
+    let aRecord = anObject as Readonly<Record<string, unknown>>;
     let properties: string[] = [];
     do {
-      const symbols = Object.getOwnPropertySymbols(anObject);
+      const symbols = Object.getOwnPropertySymbols(aRecord);
       const symbolPropertyNames = symbols.map((aSymbol) => aSymbol.toString());
 
-      const propertyNamesCurrent = Object.getOwnPropertyNames(anObject)
+      const propertyNamesCurrent = Object.getOwnPropertyNames(aRecord)
         .concat(symbolPropertyNames)
         .sort()
         .filter((propertyName: string, index: number, arr) => {
           return (
-            typeof anObject[propertyName] === "function" &&
+            typeof aRecord[propertyName] === "function" &&
             propertyName !== "constructor" &&
             (index === 0 || propertyName !== arr[index - 1]) &&
             properties.indexOf(propertyName) === -1
@@ -48,12 +49,12 @@ export class Objects {
         });
 
       properties = properties.concat(propertyNamesCurrent);
-      anObject = Object.getPrototypeOf(anObject);
-    } while (anObject && Object.getPrototypeOf(anObject));
+      aRecord = Object.getPrototypeOf(aRecord);
+    } while (aRecord && Object.getPrototypeOf(aRecord));
     return properties;
   }
 
-  public static getAllFieldNames(anObject: any): string[] {
+  public static getAllFieldNames(anObject: Record<string, unknown>): string[] {
     const allFieldNames = [];
     for (const propertyKey in anObject) {
       if (Object.prototype.hasOwnProperty.call(anObject, propertyKey)) {

--- a/packages/cactus-common/src/main/typescript/public-api.ts
+++ b/packages/cactus-common/src/main/typescript/public-api.ts
@@ -25,3 +25,5 @@ export {
   IJoseFittingJwtParams,
   isIJoseFittingJwtParams,
 } from "./authzn/i-jose-fitting-jwt-params";
+
+export { isRecord } from "./types/is-record";

--- a/packages/cactus-common/src/main/typescript/secp256k1-keys.ts
+++ b/packages/cactus-common/src/main/typescript/secp256k1-keys.ts
@@ -2,8 +2,8 @@ import crypto from "crypto";
 import secp256k1 from "secp256k1";
 
 export interface ISignerKeyPair {
-  privateKey: any;
-  publicKey: any;
+  privateKey: Buffer;
+  publicKey: Uint8Array;
 }
 
 export class Secp256k1Keys {
@@ -12,7 +12,7 @@ export class Secp256k1Keys {
    * @return Generated key pair
    */
   static generateKeyPairsBuffer(): ISignerKeyPair {
-    let privKey: any;
+    let privKey: Buffer;
     // generate secp256K1 private key
     do {
       privKey = crypto.randomBytes(32);

--- a/packages/cactus-common/src/main/typescript/types/is-record.ts
+++ b/packages/cactus-common/src/main/typescript/types/is-record.ts
@@ -1,0 +1,3 @@
+export function isRecord(x: unknown): x is Record<string, unknown> {
+  return !!x && typeof x === "object" && x !== null;
+}


### PR DESCRIPTION
[style(common): fix batch 7/26 of linter warnings](https://github.com/hyperledger/cacti/pull/2098/commits/fda1910eac5289f56fa3ec30cba24e6a73d09afe)

Changes made:
- Fixed lint warnings associated with any-type for truthyness and nonBlankString checking
- Fixed lint warnings associated with type-aliases in logger
- Fixed lint warnings associated with  non-any type in getAllMethodNames and getAllFieldNames
- Fixed lint errors associated with unexpected any for private-public keypairs
- Added an isRecord user-defined type guard in the common package that
can narrow `unknown` types into `Record<string, unknown>`

Fixes https://github.com/hyperledger/cacti/issues/1356

Co-authored-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Signed-off-by: akankshadixit <akanksha.dixit12@gmail.com>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>