### PR TITLE
feat(connector-iroha): add tls encryption

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/Dockerfile
+++ b/packages/cactus-plugin-ledger-connector-besu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/cactus-cmd-api-server:2022-05-12-2330a96
+FROM ghcr.io/hyperledger/cactus-cmd-api-server:2022-08-05-7309f2a
 RUN npm install -g yarn@1.22.17
 
 ENV NODE_ENV=production

--- a/packages/cactus-plugin-ledger-connector-iroha/package.json
+++ b/packages/cactus-plugin-ledger-connector-iroha/package.json
@@ -60,12 +60,13 @@
     "@types/google-protobuf": "3.15.5",
     "axios": "0.21.4",
     "express": "4.17.1",
+    "fast-safe-stringify": "2.1.1",
     "grpc": "1.24.11",
     "iroha-helpers-ts": "0.9.25-ss",
-    "fast-safe-stringify": "2.1.1",
-    "sanitize-html": "2.7.0",
+    "node-forge": "^1.3.1",
     "openapi-types": "7.0.1",
     "prom-client": "13.1.0",
+    "sanitize-html": "2.7.0",
     "typescript-optional": "2.0.1"
   },
   "devDependencies": {

--- a/packages/cactus-plugin-ledger-connector-iroha/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-iroha/src/main/json/openapi.json
@@ -261,6 +261,9 @@
             "type": "boolean",
             "nullable": false,
             "description": "Can only be set to false for an insecure grpc connection."
+          },
+          "tlsCertificate": {
+            "type": "string"
           }
         }
       },

--- a/packages/cactus-plugin-ledger-connector-iroha/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -158,6 +158,12 @@ export interface IrohaBaseConfig {
      * @memberof IrohaBaseConfig
      */
     tls?: boolean;
+    /**
+     * 
+     * @type {string}
+     * @memberof IrohaBaseConfig
+     */
+    tlsCertificate?: string;
 }
 /**
  * 

--- a/packages/cactus-plugin-ledger-connector-iroha/src/main/typescript/plugin-ledger-connector-iroha.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha/src/main/typescript/plugin-ledger-connector-iroha.ts
@@ -685,8 +685,10 @@ export class PluginLedgerConnectorIroha
     const irohaHostPort = `${baseConfig.irohaHost}:${baseConfig.irohaPort}`;
 
     let grpcCredentials;
-    if (baseConfig.tls) {
-      throw new RuntimeError("TLS option is not supported");
+    if (baseConfig.tls && baseConfig.tlsCertificate) {
+      const certificate = baseConfig.tlsCertificate;
+      const buf = Buffer.from(certificate, "utf8");
+      grpcCredentials = grpc.credentials.createSsl(buf);
     } else {
       grpcCredentials = grpc.credentials.createInsecure();
     }

--- a/packages/cactus-plugin-ledger-connector-iroha/src/test/typescript/integration/certificate.test.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha/src/test/typescript/integration/certificate.test.ts
@@ -1,0 +1,142 @@
+import { pki, md } from "node-forge";
+import { v4 as uuidV4 } from "uuid";
+import { Strings } from "@hyperledger/cactus-common";
+
+export type ForgeKeyPair = pki.rsa.KeyPair;
+export type ForgePrivateKey = pki.rsa.PrivateKey;
+export type ForgeCertificate = pki.Certificate;
+export type ForgeCertificateField = pki.CertificateField;
+
+export interface IPki {
+  keyPair: ForgeKeyPair;
+  certificate: ForgeCertificate;
+  certificatePem: string;
+  privateKeyPem: string;
+}
+
+export class SelfSignedPkiGenerator {
+  public create(commonName: string, parent?: IPki): IPki {
+    const keyPair: pki.rsa.KeyPair = pki.rsa.generateKeyPair(4096);
+    const privateKeyPem: string = pki.privateKeyToPem(keyPair.privateKey);
+    const certificate = pki.createCertificate();
+
+    this.configureCertificateParameters(keyPair, certificate, commonName);
+    if (parent) {
+      certificate.setIssuer(parent.certificate.subject.attributes);
+      certificate.publicKey = keyPair.publicKey;
+      // certificate.privateKey = keyPair.privateKey;
+      certificate.sign(parent.keyPair.privateKey, md.sha512.create());
+
+      if (!parent.certificate.verify(certificate)) {
+        throw new Error("Could not verify newly generated certificate");
+      }
+    } else {
+      certificate.sign(keyPair.privateKey, md.sha512.create());
+    }
+
+    const certificatePem = pki.certificateToPem(certificate);
+    return { keyPair, certificate, certificatePem, privateKeyPem };
+  }
+
+  public configureCertificateParameters(
+    keyPair: pki.rsa.KeyPair,
+    certificate: pki.Certificate,
+    commonName: string,
+  ): pki.Certificate {
+    // 20 octets max for serial numbers of certs as per the standard
+    const serialNumber = Strings.replaceAll(uuidV4(), "-", "").substring(0, 19);
+    certificate.serialNumber = serialNumber;
+    certificate.publicKey = keyPair.publicKey;
+    certificate.privateKey = keyPair.privateKey;
+    certificate.validity.notBefore = new Date();
+    certificate.validity.notAfter = new Date();
+
+    const nextYear = certificate.validity.notBefore.getFullYear() + 1;
+    certificate.validity.notAfter.setFullYear(nextYear);
+
+    const certificateFields: ForgeCertificateField[] = [
+      {
+        shortName: "CN",
+        name: "commonName",
+        value: commonName,
+      },
+      {
+        name: "countryName",
+        value: "Universe",
+      },
+      {
+        shortName: "ST",
+        value: "Milky Way",
+      },
+      {
+        shortName: "L",
+        name: "localityName",
+        value: "Planet Earth",
+      },
+      {
+        shortName: "O",
+        name: "organizationName",
+        value: "Hyperledger",
+      },
+      {
+        shortName: "OU",
+        value: "Cactus",
+      },
+      {
+        name: "unstructuredName",
+        value: "Cactus Dummy Self Signed Certificates",
+      },
+    ];
+
+    certificate.setSubject(certificateFields);
+
+    certificate.setIssuer(certificateFields);
+
+    certificate.setExtensions([
+      {
+        name: "basicConstraints",
+        cA: true,
+      },
+      {
+        name: "keyUsage",
+        keyCertSign: true,
+        digitalSignature: true,
+        nonRepudiation: true,
+        keyEncipherment: true,
+        dataEncipherment: true,
+      },
+      {
+        name: "extKeyUsage",
+        serverAuth: true,
+        clientAuth: true,
+        codeSigning: true,
+        emailProtection: true,
+        timeStamping: true,
+      },
+      {
+        name: "nsCertType",
+        client: true,
+        server: true,
+        email: true,
+        objsign: true,
+        sslCA: true,
+        emailCA: true,
+        objCA: true,
+      },
+      {
+        name: "subjectAltName",
+        altNames: [
+          {
+            type: 7, // IP
+            ip: "127.0.0.1",
+          },
+        ],
+      },
+      {
+        name: "subjectKeyIdentifier",
+      },
+    ]);
+
+    return certificate;
+  }
+}

--- a/packages/cactus-test-tooling/src/main/typescript/iroha/iroha-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/iroha/iroha-test-ledger.ts
@@ -10,7 +10,7 @@ import {
 } from "@hyperledger/cactus-common";
 import { ITestLedger } from "../i-test-ledger";
 import { IKeyPair } from "../i-key-pair";
-import { Containers } from "../common/containers";
+import { Containers, IPushFileFromFsOptions } from "../common/containers";
 
 /*
  * Contains options for Iroha container
@@ -170,6 +170,32 @@ export class IrohaTestLedger implements ITestLedger {
    */
   public getDefaultToriiPort(): number {
     return 50051;
+  }
+
+  public async addCertificateToIrohaContainer(
+    cert: string,
+    key: string,
+  ): Promise<void> {
+    if (!this.container) {
+      const fnTag = `IrohaTestLedger#addCertificates()`;
+      throw new Error(`${fnTag} this.container cannot be falsy.`);
+    }
+    let containerOptions: IPushFileFromFsOptions = {
+      containerOrId: this.container,
+      srcFileName: "server.crt",
+      dstFileName: "server.crt",
+      srcFileAsString: cert,
+      dstFileDir: "/opt/iroha_data/torii_tls",
+    };
+    await Containers.putFile(containerOptions);
+    containerOptions = {
+      containerOrId: this.container,
+      srcFileName: "server.key",
+      dstFileName: "server.key",
+      srcFileAsString: key,
+      dstFileDir: "/opt/iroha_data/torii_tls",
+    };
+    await Containers.putFile(containerOptions);
   }
 
   /**


### PR DESCRIPTION
Enable TLS encryption in the Iroha-cactus connector plugin.
Referred: https://iroha.readthedocs.io/en/develop/configure/torii-tls.html

Signed-off-by: yashrajdesai <yashrajdesai30@gmail.com>