### PR TITLE
fix(tools/quorum-all-in-one): address CVE-2021-36159 and CVE-2022-28391

### DIFF
--- a/tools/docker/quorum-all-in-one/Dockerfile
+++ b/tools/docker/quorum-all-in-one/Dockerfile
@@ -1,5 +1,5 @@
-ARG QUORUM_VERSION=21.4.1
-ARG TESSERA_VERSION=21.1.1
+ARG QUORUM_VERSION=22.7.4
+ARG TESSERA_VERSION=22.1.7
 
 FROM quorumengineering/quorum:$QUORUM_VERSION AS quorum
 FROM quorumengineering/tessera:$TESSERA_VERSION AS tessera
@@ -8,10 +8,10 @@ COPY --from=quorum /usr/local/bin/geth /usr/local/bin/
 COPY --from=quorum /usr/local/bin/bootnode /usr/local/bin/
 
 # BASH
-RUN apk update && apk add --no-cache bash
+RUN apt update && apt-get -y install bash
 
 # SUPERVISORD
-RUN apk update && apk add --no-cache supervisor
+RUN apt update && apt-get -y install supervisor
 RUN mkdir -p /var/log/supervisor
 COPY supervisord.conf /etc/supervisord.conf
 


### PR DESCRIPTION
Other, lower severity vulnerabilities are also being addressed by this
change but the two big ones are the critical severity ones mentioned
in the commit subject.

Most of the vulnerabilities are now fixed in quorum-all-in-one but
there are still some that are not because most of the remaining
vulnerabilities are still new and is still waiting for the new changes
to be pulled in and released on their respective package versions.

And we tried to ask on the quorum discussions on github as you can
see here. (ConsenSys/quorum#1513).

Here are the remaining vulnerabilities for quorum-all-in-one:
CVE-2022-3602
CVE-2022-3786
CVE-2022-3602
CVE-2022-3786
CVE-2022-42003
CVE-2022-42004
CVE-2022-45868
CVE-2022-1471
CVE-2022-21698
CVE-2022-27664
CVE-2022-32149
CVE-2022-21698
CVE-2022-27664
CVE-2022-32149

Fixes #2059

Signed-off-by: aldousalvarez <aldousss.alvarez@gmail.com>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>