### PR TITLE
feat(connector-go-ethereum): add getBlock and getTransactionReceipt methods to connector

### DIFF
--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/main/typescript/common/core/bin/www.ts
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/main/typescript/common/core/bin/www.ts
@@ -252,19 +252,20 @@ export async function startGoEthereumSocketIOConnector() {
      * startMonitor: starting block generation event monitoring
      **/
     client.on("startMonitor", function (monitorOptions) {
-
-      monitorOptions = monitorOptions ?? {allBlocks: false};
-      logger.debug("monitorOptions", monitorOptions);
-      Smonitor.startMonitor(client.id, monitorOptions.allBlocks, (event) => {
-        let emitType = "";
-        if (event.status == 200) {
-          emitType = "eventReceived";
-          logger.info("event data callbacked.");
-        } else {
-          emitType = "monitor_error";
-        }
-        client.emit(emitType, event);
-      });
+      Smonitor.startMonitor(
+        client.id,
+        monitorOptions?.allBlocks ?? false,
+        (event) => {
+          let emitType = "";
+          if (event.status == 200) {
+            emitType = "eventReceived";
+            logger.info("event data callbacked.");
+          } else {
+            emitType = "monitor_error";
+          }
+          client.emit(emitType, event);
+        },
+      );
     });
 
     /**

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/main/typescript/public-api.ts
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/main/typescript/public-api.ts
@@ -1,1 +1,2 @@
-export { startGoEthereumSocketIOConnector } from "./common/core/bin/www"
+export { startGoEthereumSocketIOConnector } from "./common/core/bin/www";
+export { shutdown } from "./connector/ServerPlugin";


### PR DESCRIPTION
- getBlock and getTransactionReceipt added in go-ethereum-socketio-connector
- Added nullish coalescing in monitor options

Closes: #2255
Signed-off-by: tomasz awramski <tomasz.awramski@fujitsu.com>