### PR TITLE
fabric-watch-blocks-v1-endpoint.test.ts fix var names

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-v1-endpoint.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-v1-endpoint.test.ts
@@ -366,12 +366,12 @@ describe("watchBlocksV1 of fabric connector tests", () => {
           );
         }
 
-        const fullBlock = event.privateBlock;
-        expect(fullBlock.blockNumber).toBeTruthy();
-        expect(fullBlock.blockData).toBeTruthy();
-        expect(fullBlock.blockData.header).toBeTruthy();
-        expect(fullBlock.blockData.data).toBeTruthy();
-        expect(fullBlock.blockData.metadata).toBeTruthy();
+        const privateBlock = event.privateBlock;
+        expect(privateBlock.blockNumber).toBeTruthy();
+        expect(privateBlock.blockData).toBeTruthy();
+        expect(privateBlock.blockData.header).toBeTruthy();
+        expect(privateBlock.blockData.data).toBeTruthy();
+        expect(privateBlock.blockData.metadata).toBeTruthy();
       },
     );
 


### PR DESCRIPTION
in plugin connector fabric changes names of variables , some minor change It is not critical change.

barnaba.pawelczak@fujitsu.com

Signed-off-by: barneyshyperethers <109078012+barneyshyperethers@users.noreply.github.com>