### PR TITLE
docs(maintainers/codeowners): update Sandeep's GH user to sandeepnRES

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @petermetz @takeutak @izuru0 @jagpreetsinghsasan @vramakrishna @sanvendev
+* @petermetz @takeutak @izuru0 @jagpreetsinghsasan @vramakrishna @sandeepnRES
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,7 @@ Maintainers
 | Takuma TAKEUCHI | [takeutak][takeutak] | takeutak#7220 |
 | Jagpreet Singh Sasan | [jagpreetsinghsasan][jagpreetsinghsasan] | jagpreetsinghsasan |
 | Venkatraman Ramakrishna | [VRamakrishna][VRamakrishna] | Ramakrishna#6645 |
-| Sandeep Nishad | [sanvenDev][sanvenDev] | sanven#1092 |
+| Sandeep Nishad | [sandeepnRES][sandeepnRES] | sanven#1092 |
 
 [jonathan-m-hamilton]: https://github.com/jonathan-m-hamilton
 [izuru0]: https://github.com/izuru0
@@ -19,4 +19,4 @@ Maintainers
 [takeutak]: https://github.com/takeutak
 [jagpreetsinghsasan]: https://github.com/jagpreetsinghsasan
 [VRamakrishna]: https://github.com/VRamakrishna/
-[sanvenDev]: https://github.com/sanvenDev
+[sandeepnRES]: https://github.com/sandeepnRES


### PR DESCRIPTION
Housekeeping of the documents that mention usernames.

Had to skip changing the username in the ./weaver/*.md because of the
newline index corruption problem explained in
https://github.com/hyperledger/cacti/issues/2302

Resolves #2304

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>