### PR TITLE
test(connector-fabric): fix v2-2-x/deploy-cc-from-typescript-source

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/basic-asset-transfer/chaincode-typescript/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/basic-asset-transfer/chaincode-typescript/tsconfig.json
@@ -7,7 +7,8 @@
         "moduleResolution": "node",
         "module": "commonjs",
         "declaration": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "skipLibCheck": true
     },
     "include": [
         "./src/**/*"


### PR DESCRIPTION
The test case [1] uses the "standard" basic-asset-transfer example for
verifying contract deployment functionality and in this instance, the
problem was traced back to the NodeJS flavor of the contract having
a transitive dependency (fabric-contract-api => winston => logform) which
was probably being auto-upgraded (due to our test fixture lacking a
package-lock.json or yarn.lock file) and leading to the typescript
compilation of the project failing because of updates that must've been
pushed into the index.d.ts file of the logform transitive dependency.

The fix applied here is to just disable the lib checking of the compiler
so that the typescript code of dependencies is not type-checked at all.

This would be a no-go if we were talking about the code of the Cacti
framework itself, but should be fine in a test fixture project which is
not used in production at all and instead only exists to support the
test execution.

Fixes #2322

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>