### PR TITLE
test(ghcr-rust-compiler): fix image rust build openssl-src v111.25.1

### DIFF
--- a/tools/docker/rust-compiler/Dockerfile
+++ b/tools/docker/rust-compiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.57.0-slim-bullseye
+FROM rust:1.68.0-slim-bullseye
 
 RUN apt update
 


### PR DESCRIPTION
Upgraded the container image's base image so that the Rust compiler
that is being used is now v1.68.0 instead of v1.57.0.

Fixes #2325

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>