### PR TITLE
test(connector-fabric): fix v2-2-x/deploy-lock-asset.test.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ site/
 !packages/cactus-plugin-ledger-connector-*-socketio/src/main/typescript/common/core/bin
 
 tools/docker/geth-testnet/data-geth1/
+
+.history/

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/lock-asset/chaincode-typescript/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/lock-asset/chaincode-typescript/tsconfig.json
@@ -7,7 +7,8 @@
         "moduleResolution": "node",
         "module": "commonjs",
         "declaration": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "skipLibCheck": true
     },
     "include": [
         "./src/**/*"


### PR DESCRIPTION
Telling the typescript compiler to skip the library code check so that
auto-updating dependencies don't break the test fixture chain code
compilation.

The root cause and the fix are equivalent as they were for:
https://github.com/hyperledger/cacti/issues/2322
https://github.com/hyperledger/cacti/pull/2323
Commit SHA: dfb727861b5e26a15dbef0729a2a14dd26b4655f

Fixes #2341

Also sneaking in a .gitignore change with this: there is a VSCode
extension that stores local editing history of files in a .history/
sub-folder and that needs to be ignored in git otherwise it just keeps
popping up in the git index which is annoying sometimes.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>