### PR TITLE
fix(relay): rust build fails after tokio bump from 0.2.25 to 1.18.5

### DIFF
--- a/.github/workflows/test_weaver-asset-exchange-fabric.yml
+++ b/.github/workflows/test_weaver-asset-exchange-fabric.yml
@@ -122,8 +122,8 @@ jobs:
         run: |
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
-          go install google.golang.org/protobuf/cmd/protoc-gen-go
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
           
       # PROTOS
       - name: Build JS Protos

--- a/.github/workflows/test_weaver-asset-transfer.yml
+++ b/.github/workflows/test_weaver-asset-transfer.yml
@@ -454,8 +454,8 @@ jobs:
         run: |
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
-          go install google.golang.org/protobuf/cmd/protoc-gen-go
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
       # PROTOS
       - name: Build GO Protos

--- a/.github/workflows/test_weaver-data-sharing.yml
+++ b/.github/workflows/test_weaver-data-sharing.yml
@@ -368,8 +368,8 @@ jobs:
         run: |
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
-          go install google.golang.org/protobuf/cmd/protoc-gen-go
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
       # PROTOS
       - name: Build GO Protos
@@ -748,8 +748,8 @@ jobs:
         run: |
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
-          go install google.golang.org/protobuf/cmd/protoc-gen-go
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
       # PROTOS
       - name: Build GO Protos

--- a/.github/workflows/test_weaver-relay.yml
+++ b/.github/workflows/test_weaver-relay.yml
@@ -21,84 +21,176 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
+
       - name: Install RUST Toolchain minimal stable with clippy and rustfmt
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
-            
+
       - name: Use Protoc 3.15
         run: |
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
-            
+
       - name: Build Protos RS
-        run: make build
+        run: |
+          export PATH="$PATH:${GITHUB_WORKSPACE}/protoc/bin"
+          make build
         working-directory: weaver/common/protos-rs
-          
+
       - name: Get Latest Relay Dependencies
         run: |
           make protos-local
           cargo update -p nom
           cargo update -p lexical-core
         working-directory: weaver/core/relay
-          
+
       - name: Build Image
         run: make
         working-directory: weaver/core/relay
-    
+
       - name: Run Dummy Relay
         run: RELAY_CONFIG=config/Dummy_Relay.toml  cargo run --bin server &> relay-dummy.out &
         working-directory: weaver/core/relay
-    
+
       - name: Run Dummy Driver
         run: RELAY_CONFIG=config/Dummy_Relay.toml  cargo run --bin dummy-driver &> driver-dummy.out &
         working-directory: weaver/core/relay
-    
+
       - name: Mock Client Test
         run: |
             echo "Waiting for Dummy Relay and Driver to come up"
             sleep 30
             cargo run --bin client 9085 localhost:9085/Dummy_Network/abc:abc:abc:abc
         working-directory: weaver/core/relay
-        
-  relay:
+
+  relay-tls-local:
     # if: ${{ false }}
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
+
       - name: Install RUST Toolchain minimal stable with clippy and rustfmt
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
-          
+
+      - name: Use Protoc 3.15
+        run: |
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
+          unzip protoc-3.15.6-linux-x86_64.zip -d protoc
+
+      - name: Build Protos RS
+        run: |
+          export PATH="$PATH:${GITHUB_WORKSPACE}/protoc/bin"
+          make build
+        working-directory: weaver/common/protos-rs
+
+      - name: Get Latest Relay Dependencies
+        run: |
+          make protos-local
+          cargo update -p nom
+          cargo update -p lexical-core
+        working-directory: weaver/core/relay
+
+      - name: Build Image
+        run: make
+        working-directory: weaver/core/relay
+
+      - name: Run Dummy Relay
+        run: RELAY_CONFIG=config/Dummy_Relay_tls.toml cargo run --bin server &> relay-dummy.out &
+        working-directory: weaver/core/relay
+
+      - name: Run Dummy Driver
+        run: RELAY_CONFIG=config/Dummy_Relay_tls.toml cargo run --bin dummy-driver &> driver-dummy.out &
+        working-directory: weaver/core/relay
+
+      - name: Mock Client Test
+        run: |
+            echo "Waiting for Dummy Relay and Driver to come up"
+            sleep 30
+            cargo run --bin client-tls 9085 localhost:9085/Dummy_Network/abc:abc:abc:abc
+        working-directory: weaver/core/relay
+
+  relay:
+    if: ${{ false }}
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install RUST Toolchain minimal stable with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+
       - name: Get Latest Relay Dependencies
         run: |
           cargo update -p nom
           cargo update -p lexical-core
         working-directory: weaver/core/relay
-          
+
       - name: Build Image
         run: make build
         working-directory: weaver/core/relay
-    
+
       - name: Run Dummy Relay
         run: RELAY_CONFIG=config/Dummy_Relay.toml  cargo run --bin server &> relay-dummy.out &
         working-directory: weaver/core/relay
-    
+
       - name: Run Dummy Driver
         run: RELAY_CONFIG=config/Dummy_Relay.toml  cargo run --bin dummy-driver &> driver-dummy.out &
         working-directory: weaver/core/relay
-    
+
       - name: Mock Client Test
         run: |
             echo "Waiting for Dummy Relay and Driver to come up"
             sleep 30
             cargo run --bin client 9085 localhost:9085/Dummy_Network/abc:abc:abc:abc
+        working-directory: weaver/core/relay
+
+  relay-tls:
+    if: ${{ false }}
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install RUST Toolchain minimal stable with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Get Latest Relay Dependencies
+        run: |
+          cargo update -p nom
+          cargo update -p lexical-core
+        working-directory: weaver/core/relay
+
+      - name: Build Image
+        run: make build
+        working-directory: weaver/core/relay
+
+      - name: Run Dummy Relay
+        run: RELAY_CONFIG=config/Dummy_Relay_tls.toml cargo run --bin server &> relay-dummy.out &
+        working-directory: weaver/core/relay
+
+      - name: Run Dummy Driver
+        run: RELAY_CONFIG=config/Dummy_Relay_tls.toml cargo run --bin dummy-driver &> driver-dummy.out &
+        working-directory: weaver/core/relay
+
+      - name: Mock Client Test
+        run: |
+            echo "Waiting for Dummy Relay and Driver to come up"
+            sleep 30
+            cargo run --bin client-tls 9085 localhost:9085/Dummy_Network/abc:abc:abc:abc
         working-directory: weaver/core/relay

--- a/weaver/common/protos-rs/Cargo.lock
+++ b/weaver/common/protos-rs/Cargo.lock
@@ -10,23 +10,24 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "async-stream"
-version = "0.2.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.2.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -37,7 +38,7 @@ checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -47,10 +48,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.11.0"
+name = "axum"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"
@@ -64,7 +117,7 @@ version = "0.0.1"
 dependencies = [
  "prost",
  "serde",
- "tokio 1.8.4",
+ "tokio",
  "tonic",
  "tonic-build",
 ]
@@ -77,12 +130,6 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
@@ -92,12 +139,6 @@ name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -122,31 +163,15 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures-channel"
@@ -183,28 +208,28 @@ checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
  "futures-task",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "pin-utils",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -212,10 +237,9 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.25",
+ "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -226,12 +250,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "http"
@@ -239,20 +260,27 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.3.0",
+ "bytes",
  "fnv",
- "itoa 1.0.4",
+ "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "http",
+ "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -262,17 +290,17 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.13.10"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -281,13 +309,25 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
- "pin-project 1.0.12",
+ "itoa",
+ "pin-project-lite",
  "socket2",
- "tokio 0.2.25",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -306,32 +346,17 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
+ "cfg-if",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -349,16 +374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,9 +381,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "log"
@@ -376,8 +391,14 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -386,34 +407,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "mio"
-version = "0.6.23"
+name = "mime"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "miow"
-version = "0.2.2"
+name = "mio"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -421,17 +429,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "net2"
-version = "0.2.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "once_cell"
@@ -447,21 +444,12 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
-]
-
-[[package]]
-name = "pin-project"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
-dependencies = [
- "pin-project-internal 0.4.30",
 ]
 
 [[package]]
@@ -470,18 +458,7 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
- "pin-project-internal 1.0.12",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -492,14 +469,8 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -520,93 +491,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.47"
+name = "prettyplease"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.6.1"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "heck",
  "itertools",
+ "lazy_static",
  "log",
  "multimap",
  "petgraph",
+ "prettyplease",
  "prost",
  "prost-types",
+ "regex",
+ "syn 1.0.103",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
- "bytes 0.5.6",
  "prost",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
- "rand_pcg",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -614,29 +595,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -649,12 +612,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -669,16 +647,15 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.17.0"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
- "base64",
  "log",
  "ring",
  "sct",
@@ -686,10 +663,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.6.1"
+name = "rustls-pemfile"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -697,22 +689,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -726,13 +718,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -753,110 +744,138 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "memchr",
- "mio",
- "pin-project-lite 0.1.12",
- "slab",
-]
-
-[[package]]
-name = "tokio"
-version = "1.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dae83881bc9b0403dd5b44ea9deed3e939856cc8722d5be37f0d6e5c6d53dd"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
- "pin-project-lite 0.2.9",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.13.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "futures-core",
  "rustls",
- "tokio 0.2.25",
+ "tokio",
  "webpki",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.3.1"
+name = "tokio-stream"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
- "bytes 0.5.6",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+dependencies = [
+ "bytes",
  "futures-core",
  "futures-sink",
- "log",
- "pin-project-lite 0.1.12",
- "tokio 0.2.25",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.2.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afef9ce97ea39593992cf3fa00ff33b1ad5eb07665b31355df63a690e38c736"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
- "bytes 0.5.6",
+ "axum",
+ "base64 0.13.1",
+ "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
+ "hyper-timeout",
  "percent-encoding",
- "pin-project 0.4.30",
+ "pin-project",
  "prost",
  "prost-derive",
- "tokio 0.2.25",
+ "rustls-pemfile",
+ "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "tokio-util",
  "tower",
- "tower-balance",
- "tower-load",
- "tower-make",
+ "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -864,78 +883,53 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.2.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
+ "prettyplease",
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "tower"
-version = "0.3.1"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3169017c090b7a28fce80abaad0ab4f5566423677c9331bb320af7e49cfe62"
-dependencies = [
- "futures-core",
- "tower-buffer",
- "tower-discover",
- "tower-layer",
- "tower-limit",
- "tower-load-shed",
- "tower-retry",
- "tower-service",
- "tower-timeout",
- "tower-util",
-]
-
-[[package]]
-name = "tower-balance"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a792277613b7052448851efcf98a2c433e6f1d01460832dc60bef676bc275d4c"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 0.4.30",
+ "pin-project",
+ "pin-project-lite",
  "rand",
  "slab",
- "tokio 0.2.25",
- "tower-discover",
- "tower-layer",
- "tower-load",
- "tower-make",
- "tower-ready-cache",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-buffer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.30",
- "tokio 0.2.25",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "tower-discover"
-version = "0.3.0"
+name = "tower-http"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
+ "bitflags",
+ "bytes",
  "futures-core",
- "pin-project 0.4.30",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
  "tower-service",
 ]
 
@@ -946,111 +940,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
-name = "tower-limit"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
-dependencies = [
- "futures-core",
- "pin-project 0.4.30",
- "tokio 0.2.25",
- "tower-layer",
- "tower-load",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
-dependencies = [
- "futures-core",
- "log",
- "pin-project 0.4.30",
- "tokio 0.2.25",
- "tower-discover",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load-shed"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
-dependencies = [
- "futures-core",
- "pin-project 0.4.30",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-make"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
-dependencies = [
- "tokio 0.2.25",
- "tower-service",
-]
-
-[[package]]
-name = "tower-ready-cache"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eabb6620e5481267e2ec832c780b31cad0c15dcb14ed825df5076b26b591e1f"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap",
- "log",
- "tokio 0.2.25",
- "tower-service",
-]
-
-[[package]]
-name = "tower-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
-dependencies = [
- "futures-core",
- "pin-project 0.4.30",
- "tokio 0.2.25",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
-name = "tower-timeout"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
-dependencies = [
- "pin-project 0.4.30",
- "tokio 0.2.25",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project 0.4.30",
- "tower-service",
-]
 
 [[package]]
 name = "tracing"
@@ -1058,9 +951,9 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "log",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -1073,7 +966,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1091,7 +984,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.12",
+ "pin-project",
  "tracing",
 ]
 
@@ -1106,12 +999,6 @@ name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "untrusted"
@@ -1131,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1141,7 +1028,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -1156,7 +1043,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -1178,7 +1065,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1201,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
@@ -1211,18 +1098,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
+ "either",
  "libc",
+ "once_cell",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
@@ -1233,12 +1116,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1253,11 +1130,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "windows-targets",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/weaver/common/protos-rs/Cargo.toml
+++ b/weaver/common/protos-rs/Cargo.toml
@@ -9,10 +9,10 @@ name = "weaverpb"
 path = "pkg/src/lib.rs"
 
 [dependencies]
-tonic = {version="0.2",  features = ["tls"]}
-prost = "0.6"
-tokio = { version = "1.8", features = ["macros", "fs"] }
-serde = {version="1.0.110", features = ["derive"]}
+tonic = {version="0.8.3",  features = ["tls"]}
+prost = "0.11.8"
+tokio = { version = "1.27", features = ["macros", "fs"] }
+serde = {version="1.0.159", features = ["derive"]}
 
 [build-dependencies]
-tonic-build = "0.2"
+tonic-build = "0.8.3"

--- a/weaver/common/protos-rs/pkg/Cargo.toml
+++ b/weaver/common/protos-rs/pkg/Cargo.toml
@@ -15,10 +15,6 @@ name = "weaverpb"
 path = "src/lib.rs"
 
 [dependencies]
-tonic = {version="0.2",  features = ["tls"]}
-prost = "0.6"
-tokio = { version = "0.2", features = ["macros", "fs"] }
-serde = {version="1.0.110", features = ["derive"]}
-
-[build-dependencies]
-tonic-build = "0.2"
+tonic = {version="0.8.3",  features = ["tls"]}
+prost = "0.11.8"
+serde = {version="1.0.159", features = ["derive"]}

--- a/weaver/common/protos-rs/pkg/src/generated/common.ack.rs
+++ b/weaver/common/protos-rs/pkg/src/generated/common.ack.rs
@@ -1,22 +1,55 @@
 /// This message respresents "ACKs" sent between relay-relay,
 /// relay-driver and relay-network
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ack {
     #[prost(enumeration = "ack::Status", tag = "2")]
     pub status: i32,
     #[prost(string, tag = "3")]
-    pub request_id: std::string::String,
+    pub request_id: ::prost::alloc::string::String,
     /// an error can have an associated string
     /// this is the best way to represent this in protobuf
     #[prost(string, tag = "4")]
-    pub message: std::string::String,
+    pub message: ::prost::alloc::string::String,
 }
+/// Nested message and enum types in `Ack`.
 pub mod ack {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-    #[repr(i32)]
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
     pub enum Status {
         Ok = 0,
         Error = 1,
+    }
+    impl Status {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Status::Ok => "OK",
+                Status::Error => "ERROR",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "OK" => Some(Self::Ok),
+                "ERROR" => Some(Self::Error),
+                _ => None,
+            }
+        }
     }
 }

--- a/weaver/common/protos-rs/pkg/src/generated/common.events.rs
+++ b/weaver/common/protos-rs/pkg/src/generated/common.events.rs
@@ -1,46 +1,63 @@
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventMatcher {
     #[prost(enumeration = "EventType", tag = "1")]
     pub event_type: i32,
     #[prost(string, tag = "2")]
-    pub event_class_id: std::string::String,
+    pub event_class_id: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub transaction_ledger_id: std::string::String,
+    pub transaction_ledger_id: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
-    pub transaction_contract_id: std::string::String,
+    pub transaction_contract_id: ::prost::alloc::string::String,
     #[prost(string, tag = "5")]
-    pub transaction_func: std::string::String,
+    pub transaction_func: ::prost::alloc::string::String,
 }
 /// Below message is used to communicate between dest-relay and src-relay;
 /// and src-relay and src-driver.
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventSubscription {
     #[prost(message, optional, tag = "1")]
-    pub event_matcher: ::std::option::Option<EventMatcher>,
+    pub event_matcher: ::core::option::Option<EventMatcher>,
     #[prost(message, optional, tag = "2")]
-    pub query: ::std::option::Option<super::query::Query>,
+    pub query: ::core::option::Option<super::query::Query>,
     #[prost(enumeration = "EventSubOperation", tag = "3")]
     pub operation: i32,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventSubscriptionState {
     #[prost(string, tag = "1")]
-    pub request_id: std::string::String,
+    pub request_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub publishing_request_id: std::string::String,
+    pub publishing_request_id: ::prost::alloc::string::String,
     #[prost(enumeration = "event_subscription_state::Status", tag = "3")]
     pub status: i32,
     #[prost(string, tag = "4")]
-    pub message: std::string::String,
+    pub message: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "5")]
-    pub event_matcher: ::std::option::Option<EventMatcher>,
+    pub event_matcher: ::core::option::Option<EventMatcher>,
     #[prost(message, repeated, tag = "6")]
-    pub event_publication_specs: ::std::vec::Vec<EventPublication>,
+    pub event_publication_specs: ::prost::alloc::vec::Vec<EventPublication>,
 }
+/// Nested message and enum types in `EventSubscriptionState`.
 pub mod event_subscription_state {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-    #[repr(i32)]
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
     pub enum Status {
         /// pending ACK from remote relay
         SubscribePendingAck = 0,
@@ -53,67 +70,154 @@ pub mod event_subscription_state {
         Error = 6,
         DuplicateQuerySubscribed = 7,
     }
+    impl Status {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Status::SubscribePendingAck => "SUBSCRIBE_PENDING_ACK",
+                Status::SubscribePending => "SUBSCRIBE_PENDING",
+                Status::Subscribed => "SUBSCRIBED",
+                Status::UnsubscribePendingAck => "UNSUBSCRIBE_PENDING_ACK",
+                Status::UnsubscribePending => "UNSUBSCRIBE_PENDING",
+                Status::Unsubscribed => "UNSUBSCRIBED",
+                Status::Error => "ERROR",
+                Status::DuplicateQuerySubscribed => "DUPLICATE_QUERY_SUBSCRIBED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "SUBSCRIBE_PENDING_ACK" => Some(Self::SubscribePendingAck),
+                "SUBSCRIBE_PENDING" => Some(Self::SubscribePending),
+                "SUBSCRIBED" => Some(Self::Subscribed),
+                "UNSUBSCRIBE_PENDING_ACK" => Some(Self::UnsubscribePendingAck),
+                "UNSUBSCRIBE_PENDING" => Some(Self::UnsubscribePending),
+                "UNSUBSCRIBED" => Some(Self::Unsubscribed),
+                "ERROR" => Some(Self::Error),
+                "DUPLICATE_QUERY_SUBSCRIBED" => Some(Self::DuplicateQuerySubscribed),
+                _ => None,
+            }
+        }
+    }
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractTransaction {
     #[prost(string, tag = "1")]
-    pub driver_id: std::string::String,
+    pub driver_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub ledger_id: std::string::String,
+    pub ledger_id: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub contract_id: std::string::String,
+    pub contract_id: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
-    pub func: std::string::String,
-    #[prost(bytes, repeated, tag = "5")]
-    pub args: ::std::vec::Vec<std::vec::Vec<u8>>,
+    pub func: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", repeated, tag = "5")]
+    pub args: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
     #[prost(uint64, tag = "6")]
     pub replace_arg_index: u64,
     #[prost(string, repeated, tag = "7")]
-    pub members: ::std::vec::Vec<std::string::String>,
+    pub members: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventPublication {
     #[prost(oneof = "event_publication::PublicationTarget", tags = "1, 2")]
-    pub publication_target: ::std::option::Option<event_publication::PublicationTarget>,
+    pub publication_target: ::core::option::Option<event_publication::PublicationTarget>,
 }
+/// Nested message and enum types in `EventPublication`.
 pub mod event_publication {
-    #[derive(Clone, PartialEq, ::prost::Oneof, serde::Serialize, serde::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PublicationTarget {
         #[prost(message, tag = "1")]
         Ctx(super::ContractTransaction),
         #[prost(string, tag = "2")]
-        AppUrl(std::string::String),
+        AppUrl(::prost::alloc::string::String),
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventStates {
     #[prost(message, repeated, tag = "1")]
-    pub states: ::std::vec::Vec<EventState>,
+    pub states: ::prost::alloc::vec::Vec<EventState>,
 }
 /// the payload that is used for the communication between the requesting relay
 /// and its network
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventState {
     #[prost(message, optional, tag = "1")]
-    pub state: ::std::option::Option<super::state::RequestState>,
+    pub state: ::core::option::Option<super::state::RequestState>,
     #[prost(string, tag = "2")]
-    pub event_id: std::string::String,
+    pub event_id: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub message: std::string::String,
+    pub message: ::prost::alloc::string::String,
 }
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum EventType {
     LedgerState = 0,
     AssetLock = 1,
     AssetClaim = 2,
 }
+impl EventType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            EventType::LedgerState => "LEDGER_STATE",
+            EventType::AssetLock => "ASSET_LOCK",
+            EventType::AssetClaim => "ASSET_CLAIM",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "LEDGER_STATE" => Some(Self::LedgerState),
+            "ASSET_LOCK" => Some(Self::AssetLock),
+            "ASSET_CLAIM" => Some(Self::AssetClaim),
+            _ => None,
+        }
+    }
+}
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum EventSubOperation {
     Subscribe = 0,
     Unsubscribe = 1,
     Update = 2,
+}
+impl EventSubOperation {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            EventSubOperation::Subscribe => "SUBSCRIBE",
+            EventSubOperation::Unsubscribe => "UNSUBSCRIBE",
+            EventSubOperation::Update => "UPDATE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SUBSCRIBE" => Some(Self::Subscribe),
+            "UNSUBSCRIBE" => Some(Self::Unsubscribe),
+            "UPDATE" => Some(Self::Update),
+            _ => None,
+        }
+    }
 }

--- a/weaver/common/protos-rs/pkg/src/generated/common.query.rs
+++ b/weaver/common/protos-rs/pkg/src/generated/common.query.rs
@@ -1,24 +1,26 @@
 /// the payload to define the data that is being requested
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Query {
     #[prost(string, repeated, tag = "1")]
-    pub policy: ::std::vec::Vec<std::string::String>,
+    pub policy: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(string, tag = "2")]
-    pub address: std::string::String,
+    pub address: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub requesting_relay: std::string::String,
+    pub requesting_relay: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
-    pub requesting_network: std::string::String,
+    pub requesting_network: ::prost::alloc::string::String,
     #[prost(string, tag = "5")]
-    pub certificate: std::string::String,
+    pub certificate: ::prost::alloc::string::String,
     #[prost(string, tag = "6")]
-    pub requestor_signature: std::string::String,
+    pub requestor_signature: ::prost::alloc::string::String,
     #[prost(string, tag = "7")]
-    pub nonce: std::string::String,
+    pub nonce: ::prost::alloc::string::String,
     #[prost(string, tag = "8")]
-    pub request_id: std::string::String,
+    pub request_id: ::prost::alloc::string::String,
     #[prost(string, tag = "9")]
-    pub requesting_org: std::string::String,
+    pub requesting_org: ::prost::alloc::string::String,
     #[prost(bool, tag = "10")]
     pub confidential: bool,
 }

--- a/weaver/common/protos-rs/pkg/src/generated/common.state.rs
+++ b/weaver/common/protos-rs/pkg/src/generated/common.state.rs
@@ -1,5 +1,7 @@
 /// Metadata for a View
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Meta {
     /// Underlying distributed ledger protocol.
     #[prost(enumeration = "meta::Protocol", tag = "1")]
@@ -8,67 +10,122 @@ pub struct Meta {
     /// If the observer and network are synchronizing on a global clock
     /// there won't be a need to distinguish between static and dynamic views.
     #[prost(string, tag = "2")]
-    pub timestamp: std::string::String,
+    pub timestamp: ::prost::alloc::string::String,
     /// Notorization, SPV, ZKP, etc. Possibly enum
     #[prost(string, tag = "3")]
-    pub proof_type: std::string::String,
+    pub proof_type: ::prost::alloc::string::String,
     /// The data field's serialization format (e.g. JSON, XML, Protobuf)
     #[prost(string, tag = "4")]
-    pub serialization_format: std::string::String,
+    pub serialization_format: ::prost::alloc::string::String,
 }
+/// Nested message and enum types in `Meta`.
 pub mod meta {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-    #[repr(i32)]
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
     pub enum Protocol {
         Bitcoin = 0,
         Ethereum = 1,
         Fabric = 3,
         Corda = 4,
     }
+    impl Protocol {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Protocol::Bitcoin => "BITCOIN",
+                Protocol::Ethereum => "ETHEREUM",
+                Protocol::Fabric => "FABRIC",
+                Protocol::Corda => "CORDA",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "BITCOIN" => Some(Self::Bitcoin),
+                "ETHEREUM" => Some(Self::Ethereum),
+                "FABRIC" => Some(Self::Fabric),
+                "CORDA" => Some(Self::Corda),
+                _ => None,
+            }
+        }
+    }
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct View {
     #[prost(message, optional, tag = "1")]
-    pub meta: ::std::option::Option<Meta>,
+    pub meta: ::core::option::Option<Meta>,
     /// Represents the data playload of this view.
     /// The representation of Fabric, Corda etc will be captured elsewhere.
     /// For some protocols, like Bitcoin, the structure of an SPV proof is well known.
-    #[prost(bytes, tag = "2")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 /// View represents the response from a remote network
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ViewPayload {
     #[prost(string, tag = "1")]
-    pub request_id: std::string::String,
+    pub request_id: ::prost::alloc::string::String,
     #[prost(oneof = "view_payload::State", tags = "2, 3")]
-    pub state: ::std::option::Option<view_payload::State>,
+    pub state: ::core::option::Option<view_payload::State>,
 }
+/// Nested message and enum types in `ViewPayload`.
 pub mod view_payload {
-    #[derive(Clone, PartialEq, ::prost::Oneof, serde::Serialize, serde::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum State {
         #[prost(message, tag = "2")]
         View(super::View),
         #[prost(string, tag = "3")]
-        Error(std::string::String),
+        Error(::prost::alloc::string::String),
     }
 }
 /// the payload that is used for the communication between the requesting relay
 /// and its network
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestState {
     #[prost(string, tag = "1")]
-    pub request_id: std::string::String,
+    pub request_id: ::prost::alloc::string::String,
     #[prost(enumeration = "request_state::Status", tag = "2")]
     pub status: i32,
     #[prost(oneof = "request_state::State", tags = "3, 4")]
-    pub state: ::std::option::Option<request_state::State>,
+    pub state: ::core::option::Option<request_state::State>,
 }
+/// Nested message and enum types in `RequestState`.
 pub mod request_state {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-    #[repr(i32)]
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
     pub enum Status {
         /// pending ACK from remote relay
         PendingAck = 0,
@@ -87,11 +144,45 @@ pub mod request_state {
         /// Once network fetches this request state, mark it delete for cleanup later on
         Deleted = 7,
     }
-    #[derive(Clone, PartialEq, ::prost::Oneof, serde::Serialize, serde::Deserialize)]
+    impl Status {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Status::PendingAck => "PENDING_ACK",
+                Status::Pending => "PENDING",
+                Status::Error => "ERROR",
+                Status::Completed => "COMPLETED",
+                Status::EventReceived => "EVENT_RECEIVED",
+                Status::EventWritten => "EVENT_WRITTEN",
+                Status::EventWriteError => "EVENT_WRITE_ERROR",
+                Status::Deleted => "DELETED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "PENDING_ACK" => Some(Self::PendingAck),
+                "PENDING" => Some(Self::Pending),
+                "ERROR" => Some(Self::Error),
+                "COMPLETED" => Some(Self::Completed),
+                "EVENT_RECEIVED" => Some(Self::EventReceived),
+                "EVENT_WRITTEN" => Some(Self::EventWritten),
+                "EVENT_WRITE_ERROR" => Some(Self::EventWriteError),
+                "DELETED" => Some(Self::Deleted),
+                _ => None,
+            }
+        }
+    }
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum State {
         #[prost(message, tag = "3")]
         View(super::View),
         #[prost(string, tag = "4")]
-        Error(std::string::String),
+        Error(::prost::alloc::string::String),
     }
 }

--- a/weaver/common/protos-rs/pkg/src/generated/driver.driver.rs
+++ b/weaver/common/protos-rs/pkg/src/generated/driver.driver.rs
@@ -1,20 +1,24 @@
 /// Data for a View processing by dest-driver
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WriteExternalStateMessage {
     #[prost(message, optional, tag = "1")]
-    pub view_payload: ::std::option::Option<super::super::common::state::ViewPayload>,
+    pub view_payload: ::core::option::Option<super::super::common::state::ViewPayload>,
     #[prost(message, optional, tag = "2")]
-    pub ctx: ::std::option::Option<super::super::common::events::ContractTransaction>,
+    pub ctx: ::core::option::Option<super::super::common::events::ContractTransaction>,
 }
-#[doc = r" Generated client implementations."]
+/// Generated client implementations.
 pub mod driver_communication_client {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
     pub struct DriverCommunicationClient<T> {
         inner: tonic::client::Grpc<T>,
     }
     impl DriverCommunicationClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
@@ -27,87 +31,148 @@ pub mod driver_communication_client {
     impl<T> DriverCommunicationClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + HttpBody + Send + 'static,
         T::Error: Into<StdError>,
-        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        #[doc = " Data Sharing "]
-        #[doc = " the remote relay sends a RequestDriverState request to its driver with a"]
-        #[doc = " query defining the data it wants to receive"]
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> DriverCommunicationClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            DriverCommunicationClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Data Sharing
+        /// the remote relay sends a RequestDriverState request to its driver with a
+        /// query defining the data it wants to receive
         pub async fn request_driver_state(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::common::query::Query>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/driver.driver.DriverCommunication/RequestDriverState",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " Events Subscription"]
-        #[doc = " the src-relay uses this endpoint to forward the event subscription request from dest-relay to driver"]
+        /// Events Subscription
+        /// the src-relay uses this endpoint to forward the event subscription request from dest-relay to driver
         pub async fn subscribe_event(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::common::events::EventSubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::common::events::EventSubscription,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/driver.driver.DriverCommunication/SubscribeEvent",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " Recommended to have TLS mode on for this unsafe endpoint"]
-        #[doc = " Relay uses this to get Query.requestor_signature and "]
-        #[doc = " Query.certificate required for event subscription"]
+        /// Recommended to have TLS mode on for this unsafe endpoint
+        /// Relay uses this to get Query.requestor_signature and
+        /// Query.certificate required for event subscription
         pub async fn request_signed_event_subscription_query(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::common::events::EventSubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::query::Query>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::common::events::EventSubscription,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::query::Query>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/driver.driver.DriverCommunication/RequestSignedEventSubscriptionQuery",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " Events Publication"]
-        #[doc = " the dest-relay calls the dest-driver on this end point to write the remote network state to the local ledger"]
+        /// Events Publication
+        /// the dest-relay calls the dest-driver on this end point to write the remote network state to the local ledger
         pub async fn write_external_state(
             &mut self,
             request: impl tonic::IntoRequest<super::WriteExternalStateMessage>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/driver.driver.DriverCommunication/WriteExternalState",
@@ -115,81 +180,111 @@ pub mod driver_communication_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
-    impl<T: Clone> Clone for DriverCommunicationClient<T> {
-        fn clone(&self) -> Self {
-            Self {
-                inner: self.inner.clone(),
-            }
-        }
-    }
-    impl<T> std::fmt::Debug for DriverCommunicationClient<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "DriverCommunicationClient {{ ... }}")
-        }
-    }
 }
-#[doc = r" Generated server implementations."]
+/// Generated server implementations.
 pub mod driver_communication_server {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    #[doc = "Generated trait containing gRPC methods that should be implemented for use with DriverCommunicationServer."]
+    /// Generated trait containing gRPC methods that should be implemented for use with DriverCommunicationServer.
     #[async_trait]
     pub trait DriverCommunication: Send + Sync + 'static {
-        #[doc = " Data Sharing "]
-        #[doc = " the remote relay sends a RequestDriverState request to its driver with a"]
-        #[doc = " query defining the data it wants to receive"]
+        /// Data Sharing
+        /// the remote relay sends a RequestDriverState request to its driver with a
+        /// query defining the data it wants to receive
         async fn request_driver_state(
             &self,
             request: tonic::Request<super::super::super::common::query::Query>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " Events Subscription"]
-        #[doc = " the src-relay uses this endpoint to forward the event subscription request from dest-relay to driver"]
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// Events Subscription
+        /// the src-relay uses this endpoint to forward the event subscription request from dest-relay to driver
         async fn subscribe_event(
             &self,
-            request: tonic::Request<super::super::super::common::events::EventSubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " Recommended to have TLS mode on for this unsafe endpoint"]
-        #[doc = " Relay uses this to get Query.requestor_signature and "]
-        #[doc = " Query.certificate required for event subscription"]
+            request: tonic::Request<
+                super::super::super::common::events::EventSubscription,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// Recommended to have TLS mode on for this unsafe endpoint
+        /// Relay uses this to get Query.requestor_signature and
+        /// Query.certificate required for event subscription
         async fn request_signed_event_subscription_query(
             &self,
-            request: tonic::Request<super::super::super::common::events::EventSubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::query::Query>, tonic::Status>;
-        #[doc = " Events Publication"]
-        #[doc = " the dest-relay calls the dest-driver on this end point to write the remote network state to the local ledger"]
+            request: tonic::Request<
+                super::super::super::common::events::EventSubscription,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::query::Query>,
+            tonic::Status,
+        >;
+        /// Events Publication
+        /// the dest-relay calls the dest-driver on this end point to write the remote network state to the local ledger
         async fn write_external_state(
             &self,
             request: tonic::Request<super::WriteExternalStateMessage>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
-    #[doc(hidden)]
     pub struct DriverCommunicationServer<T: DriverCommunication> {
         inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
-    struct _Inner<T>(Arc<T>, Option<tonic::Interceptor>);
+    struct _Inner<T>(Arc<T>);
     impl<T: DriverCommunication> DriverCommunicationServer<T> {
         pub fn new(inner: T) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, None);
-            Self { inner }
+            Self::from_arc(Arc::new(inner))
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, Some(interceptor.into()));
-            Self { inner }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
-    impl<T, B> Service<http::Request<B>> for DriverCommunicationServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for DriverCommunicationServer<T>
     where
         T: DriverCommunication,
-        B: HttpBody + Send + Sync + 'static,
+        B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
         type Response = http::Response<tonic::body::BoxBody>;
-        type Error = Never;
+        type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -198,32 +293,41 @@ pub mod driver_communication_server {
                 "/driver.driver.DriverCommunication/RequestDriverState" => {
                     #[allow(non_camel_case_types)]
                     struct RequestDriverStateSvc<T: DriverCommunication>(pub Arc<T>);
-                    impl<T: DriverCommunication>
-                        tonic::server::UnaryService<super::super::super::common::query::Query>
-                        for RequestDriverStateSvc<T>
-                    {
+                    impl<
+                        T: DriverCommunication,
+                    > tonic::server::UnaryService<
+                        super::super::super::common::query::Query,
+                    > for RequestDriverStateSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::super::super::common::query::Query>,
+                            request: tonic::Request<
+                                super::super::super::common::query::Query,
+                            >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.request_driver_state(request).await };
+                            let fut = async move {
+                                (*inner).request_driver_state(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = RequestDriverStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -232,52 +336,16 @@ pub mod driver_communication_server {
                 "/driver.driver.DriverCommunication/SubscribeEvent" => {
                     #[allow(non_camel_case_types)]
                     struct SubscribeEventSvc<T: DriverCommunication>(pub Arc<T>);
-                    impl<T: DriverCommunication>
-                        tonic::server::UnaryService<
-                            super::super::super::common::events::EventSubscription,
-                        > for SubscribeEventSvc<T>
-                    {
+                    impl<
+                        T: DriverCommunication,
+                    > tonic::server::UnaryService<
+                        super::super::super::common::events::EventSubscription,
+                    > for SubscribeEventSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<
-                                super::super::super::common::events::EventSubscription,
-                            >,
-                        ) -> Self::Future {
-                            let inner = self.0.clone();
-                            let fut = async move { inner.subscribe_event(request).await };
-                            Box::pin(fut)
-                        }
-                    }
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let interceptor = inner.1.clone();
-                        let inner = inner.0;
-                        let method = SubscribeEventSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/driver.driver.DriverCommunication/RequestSignedEventSubscriptionQuery" => {
-                    #[allow(non_camel_case_types)]
-                    struct RequestSignedEventSubscriptionQuerySvc<T: DriverCommunication>(
-                        pub Arc<T>,
-                    );
-                    impl<T: DriverCommunication>
-                        tonic::server::UnaryService<
-                            super::super::super::common::events::EventSubscription,
-                        > for RequestSignedEventSubscriptionQuerySvc<T>
-                    {
-                        type Response = super::super::super::common::query::Query;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
@@ -286,22 +354,72 @@ pub mod driver_communication_server {
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move {
-                                inner.request_signed_event_subscription_query(request).await
+                                (*inner).subscribe_event(request).await
                             };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
+                        let inner = inner.0;
+                        let method = SubscribeEventSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/driver.driver.DriverCommunication/RequestSignedEventSubscriptionQuery" => {
+                    #[allow(non_camel_case_types)]
+                    struct RequestSignedEventSubscriptionQuerySvc<
+                        T: DriverCommunication,
+                    >(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: DriverCommunication,
+                    > tonic::server::UnaryService<
+                        super::super::super::common::events::EventSubscription,
+                    > for RequestSignedEventSubscriptionQuerySvc<T> {
+                        type Response = super::super::super::common::query::Query;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::super::common::events::EventSubscription,
+                            >,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner)
+                                    .request_signed_event_subscription_query(request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
                         let inner = inner.0;
                         let method = RequestSignedEventSubscriptionQuerySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -310,56 +428,71 @@ pub mod driver_communication_server {
                 "/driver.driver.DriverCommunication/WriteExternalState" => {
                     #[allow(non_camel_case_types)]
                     struct WriteExternalStateSvc<T: DriverCommunication>(pub Arc<T>);
-                    impl<T: DriverCommunication>
-                        tonic::server::UnaryService<super::WriteExternalStateMessage>
-                        for WriteExternalStateSvc<T>
-                    {
+                    impl<
+                        T: DriverCommunication,
+                    > tonic::server::UnaryService<super::WriteExternalStateMessage>
+                    for WriteExternalStateSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::WriteExternalStateMessage>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.write_external_state(request).await };
+                            let fut = async move {
+                                (*inner).write_external_state(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = WriteExternalStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .body(tonic::body::BoxBody::empty())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
     impl<T: DriverCommunication> Clone for DriverCommunicationServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
-            Self { inner }
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
         }
     }
     impl<T: DriverCommunication> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone(), self.1.clone())
+            Self(self.0.clone())
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
@@ -367,7 +500,8 @@ pub mod driver_communication_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: DriverCommunication> tonic::transport::NamedService for DriverCommunicationServer<T> {
+    impl<T: DriverCommunication> tonic::server::NamedService
+    for DriverCommunicationServer<T> {
         const NAME: &'static str = "driver.driver.DriverCommunication";
     }
 }

--- a/weaver/common/protos-rs/pkg/src/generated/networks.networks.rs
+++ b/weaver/common/protos-rs/pkg/src/generated/networks.networks.rs
@@ -1,68 +1,88 @@
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DbName {
     #[prost(string, tag = "1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RelayDatabase {
     #[prost(map = "string, string", tag = "1")]
-    pub pairs: ::std::collections::HashMap<std::string::String, std::string::String>,
+    pub pairs: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetStateMessage {
     #[prost(string, tag = "1")]
-    pub request_id: std::string::String,
+    pub request_id: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetworkQuery {
     #[prost(string, repeated, tag = "1")]
-    pub policy: ::std::vec::Vec<std::string::String>,
+    pub policy: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(string, tag = "2")]
-    pub address: std::string::String,
+    pub address: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub requesting_relay: std::string::String,
+    pub requesting_relay: ::prost::alloc::string::String,
     #[prost(string, tag = "4")]
-    pub requesting_network: std::string::String,
+    pub requesting_network: ::prost::alloc::string::String,
     #[prost(string, tag = "5")]
-    pub certificate: std::string::String,
+    pub certificate: ::prost::alloc::string::String,
     #[prost(string, tag = "6")]
-    pub requestor_signature: std::string::String,
+    pub requestor_signature: ::prost::alloc::string::String,
     #[prost(string, tag = "7")]
-    pub nonce: std::string::String,
+    pub nonce: ::prost::alloc::string::String,
     #[prost(string, tag = "8")]
-    pub requesting_org: std::string::String,
+    pub requesting_org: ::prost::alloc::string::String,
     #[prost(bool, tag = "9")]
     pub confidential: bool,
 }
 /// Below message is used for network/client to dest-relay communication
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetworkEventSubscription {
     #[prost(message, optional, tag = "1")]
-    pub event_matcher: ::std::option::Option<super::super::common::events::EventMatcher>,
+    pub event_matcher: ::core::option::Option<
+        super::super::common::events::EventMatcher,
+    >,
     #[prost(message, optional, tag = "2")]
-    pub query: ::std::option::Option<NetworkQuery>,
+    pub query: ::core::option::Option<NetworkQuery>,
     #[prost(message, optional, tag = "3")]
-    pub event_publication_spec:
-        ::std::option::Option<super::super::common::events::EventPublication>,
+    pub event_publication_spec: ::core::option::Option<
+        super::super::common::events::EventPublication,
+    >,
 }
-#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetworkEventUnsubscription {
     #[prost(message, optional, tag = "1")]
-    pub request: ::std::option::Option<NetworkEventSubscription>,
+    pub request: ::core::option::Option<NetworkEventSubscription>,
     #[prost(string, tag = "2")]
-    pub request_id: std::string::String,
+    pub request_id: ::prost::alloc::string::String,
 }
-#[doc = r" Generated client implementations."]
+/// Generated client implementations.
 pub mod network_client {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    #[doc = " This service is the interface for how the network communicates with"]
-    #[doc = " its relay."]
+    use tonic::codegen::http::Uri;
+    /// This service is the interface for how the network communicates with
+    /// its relay.
+    #[derive(Debug, Clone)]
     pub struct NetworkClient<T> {
         inner: tonic::client::Grpc<T>,
     }
     impl NetworkClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
@@ -75,85 +95,144 @@ pub mod network_client {
     impl<T> NetworkClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + HttpBody + Send + 'static,
         T::Error: Into<StdError>,
-        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        #[doc = " Data Sharing endpoints"]
-        #[doc = " endpoint for a network to request remote relay state via local relay"]
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> NetworkClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            NetworkClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Data Sharing endpoints
+        /// endpoint for a network to request remote relay state via local relay
         pub async fn request_state(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkQuery>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/networks.networks.Network/RequestState");
+            let path = http::uri::PathAndQuery::from_static(
+                "/networks.networks.Network/RequestState",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " This rpc endpoint is for polling the local relay for request state."]
+        /// This rpc endpoint is for polling the local relay for request state.
         pub async fn get_state(
             &mut self,
             request: impl tonic::IntoRequest<super::GetStateMessage>,
-        ) -> Result<tonic::Response<super::super::super::common::state::RequestState>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::state::RequestState>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/networks.networks.Network/GetState");
+            let path = http::uri::PathAndQuery::from_static(
+                "/networks.networks.Network/GetState",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " NOTE: This rpc is just for debugging."]
+        /// NOTE: This rpc is just for debugging.
         pub async fn request_database(
             &mut self,
             request: impl tonic::IntoRequest<super::DbName>,
         ) -> Result<tonic::Response<super::RelayDatabase>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/networks.networks.Network/RequestDatabase");
+            let path = http::uri::PathAndQuery::from_static(
+                "/networks.networks.Network/RequestDatabase",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " Event endpoints"]
-        #[doc = " endpoint for a client to subscribe to event via local relay initiating subscription flow."]
+        /// Event endpoints
+        /// endpoint for a client to subscribe to event via local relay initiating subscription flow.
         pub async fn subscribe_event(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkEventSubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/networks.networks.Network/SubscribeEvent");
+            let path = http::uri::PathAndQuery::from_static(
+                "/networks.networks.Network/SubscribeEvent",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " This rpc endpoint is for polling the local relay for subscription state."]
+        /// This rpc endpoint is for polling the local relay for subscription state.
         pub async fn get_event_subscription_state(
             &mut self,
             request: impl tonic::IntoRequest<super::GetStateMessage>,
@@ -161,96 +240,109 @@ pub mod network_client {
             tonic::Response<super::super::super::common::events::EventSubscriptionState>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/networks.networks.Network/GetEventSubscriptionState",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " endpoint for a client to subscribe to event via local relay initiating subscription flow."]
+        /// endpoint for a client to subscribe to event via local relay initiating subscription flow.
         pub async fn unsubscribe_event(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkEventUnsubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/networks.networks.Network/UnsubscribeEvent");
+            let path = http::uri::PathAndQuery::from_static(
+                "/networks.networks.Network/UnsubscribeEvent",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " endpoint for a client to fetch received events. "]
-        #[doc = " Note: events are marked as deleted from relay database as soon as client fetches them."]
+        /// endpoint for a client to fetch received events.
+        /// Note: events are marked as deleted from relay database as soon as client fetches them.
         pub async fn get_event_states(
             &mut self,
             request: impl tonic::IntoRequest<super::GetStateMessage>,
-        ) -> Result<tonic::Response<super::super::super::common::events::EventStates>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::events::EventStates>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/networks.networks.Network/GetEventStates");
+            let path = http::uri::PathAndQuery::from_static(
+                "/networks.networks.Network/GetEventStates",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
-    impl<T: Clone> Clone for NetworkClient<T> {
-        fn clone(&self) -> Self {
-            Self {
-                inner: self.inner.clone(),
-            }
-        }
-    }
-    impl<T> std::fmt::Debug for NetworkClient<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "NetworkClient {{ ... }}")
-        }
-    }
 }
-#[doc = r" Generated server implementations."]
+/// Generated server implementations.
 pub mod network_server {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    #[doc = "Generated trait containing gRPC methods that should be implemented for use with NetworkServer."]
+    /// Generated trait containing gRPC methods that should be implemented for use with NetworkServer.
     #[async_trait]
     pub trait Network: Send + Sync + 'static {
-        #[doc = " Data Sharing endpoints"]
-        #[doc = " endpoint for a network to request remote relay state via local relay"]
+        /// Data Sharing endpoints
+        /// endpoint for a network to request remote relay state via local relay
         async fn request_state(
             &self,
             request: tonic::Request<super::NetworkQuery>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " This rpc endpoint is for polling the local relay for request state."]
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// This rpc endpoint is for polling the local relay for request state.
         async fn get_state(
             &self,
             request: tonic::Request<super::GetStateMessage>,
-        ) -> Result<tonic::Response<super::super::super::common::state::RequestState>, tonic::Status>;
-        #[doc = " NOTE: This rpc is just for debugging."]
+        ) -> Result<
+            tonic::Response<super::super::super::common::state::RequestState>,
+            tonic::Status,
+        >;
+        /// NOTE: This rpc is just for debugging.
         async fn request_database(
             &self,
             request: tonic::Request<super::DbName>,
         ) -> Result<tonic::Response<super::RelayDatabase>, tonic::Status>;
-        #[doc = " Event endpoints"]
-        #[doc = " endpoint for a client to subscribe to event via local relay initiating subscription flow."]
+        /// Event endpoints
+        /// endpoint for a client to subscribe to event via local relay initiating subscription flow.
         async fn subscribe_event(
             &self,
             request: tonic::Request<super::NetworkEventSubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " This rpc endpoint is for polling the local relay for subscription state."]
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// This rpc endpoint is for polling the local relay for subscription state.
         async fn get_event_subscription_state(
             &self,
             request: tonic::Request<super::GetStateMessage>,
@@ -258,48 +350,80 @@ pub mod network_server {
             tonic::Response<super::super::super::common::events::EventSubscriptionState>,
             tonic::Status,
         >;
-        #[doc = " endpoint for a client to subscribe to event via local relay initiating subscription flow."]
+        /// endpoint for a client to subscribe to event via local relay initiating subscription flow.
         async fn unsubscribe_event(
             &self,
             request: tonic::Request<super::NetworkEventUnsubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " endpoint for a client to fetch received events. "]
-        #[doc = " Note: events are marked as deleted from relay database as soon as client fetches them."]
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// endpoint for a client to fetch received events.
+        /// Note: events are marked as deleted from relay database as soon as client fetches them.
         async fn get_event_states(
             &self,
             request: tonic::Request<super::GetStateMessage>,
-        ) -> Result<tonic::Response<super::super::super::common::events::EventStates>, tonic::Status>;
+        ) -> Result<
+            tonic::Response<super::super::super::common::events::EventStates>,
+            tonic::Status,
+        >;
     }
-    #[doc = " This service is the interface for how the network communicates with"]
-    #[doc = " its relay."]
+    /// This service is the interface for how the network communicates with
+    /// its relay.
     #[derive(Debug)]
-    #[doc(hidden)]
     pub struct NetworkServer<T: Network> {
         inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
-    struct _Inner<T>(Arc<T>, Option<tonic::Interceptor>);
+    struct _Inner<T>(Arc<T>);
     impl<T: Network> NetworkServer<T> {
         pub fn new(inner: T) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, None);
-            Self { inner }
+            Self::from_arc(Arc::new(inner))
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, Some(interceptor.into()));
-            Self { inner }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
-    impl<T, B> Service<http::Request<B>> for NetworkServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for NetworkServer<T>
     where
         T: Network,
-        B: HttpBody + Send + Sync + 'static,
+        B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
         type Response = http::Response<tonic::body::BoxBody>;
-        type Error = Never;
+        type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -308,29 +432,36 @@ pub mod network_server {
                 "/networks.networks.Network/RequestState" => {
                     #[allow(non_camel_case_types)]
                     struct RequestStateSvc<T: Network>(pub Arc<T>);
-                    impl<T: Network> tonic::server::UnaryService<super::NetworkQuery> for RequestStateSvc<T> {
+                    impl<T: Network> tonic::server::UnaryService<super::NetworkQuery>
+                    for RequestStateSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NetworkQuery>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.request_state(request).await };
+                            let fut = async move {
+                                (*inner).request_state(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = RequestStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -339,29 +470,34 @@ pub mod network_server {
                 "/networks.networks.Network/GetState" => {
                     #[allow(non_camel_case_types)]
                     struct GetStateSvc<T: Network>(pub Arc<T>);
-                    impl<T: Network> tonic::server::UnaryService<super::GetStateMessage> for GetStateSvc<T> {
+                    impl<T: Network> tonic::server::UnaryService<super::GetStateMessage>
+                    for GetStateSvc<T> {
                         type Response = super::super::super::common::state::RequestState;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetStateMessage>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.get_state(request).await };
+                            let fut = async move { (*inner).get_state(request).await };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = GetStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -370,26 +506,36 @@ pub mod network_server {
                 "/networks.networks.Network/RequestDatabase" => {
                     #[allow(non_camel_case_types)]
                     struct RequestDatabaseSvc<T: Network>(pub Arc<T>);
-                    impl<T: Network> tonic::server::UnaryService<super::DbName> for RequestDatabaseSvc<T> {
+                    impl<T: Network> tonic::server::UnaryService<super::DbName>
+                    for RequestDatabaseSvc<T> {
                         type Response = super::RelayDatabase;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::DbName>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DbName>,
+                        ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.request_database(request).await };
+                            let fut = async move {
+                                (*inner).request_database(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = RequestDatabaseSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -398,31 +544,38 @@ pub mod network_server {
                 "/networks.networks.Network/SubscribeEvent" => {
                     #[allow(non_camel_case_types)]
                     struct SubscribeEventSvc<T: Network>(pub Arc<T>);
-                    impl<T: Network> tonic::server::UnaryService<super::NetworkEventSubscription>
-                        for SubscribeEventSvc<T>
-                    {
+                    impl<
+                        T: Network,
+                    > tonic::server::UnaryService<super::NetworkEventSubscription>
+                    for SubscribeEventSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NetworkEventSubscription>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.subscribe_event(request).await };
+                            let fut = async move {
+                                (*inner).subscribe_event(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = SubscribeEventSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -432,31 +585,35 @@ pub mod network_server {
                     #[allow(non_camel_case_types)]
                     struct GetEventSubscriptionStateSvc<T: Network>(pub Arc<T>);
                     impl<T: Network> tonic::server::UnaryService<super::GetStateMessage>
-                        for GetEventSubscriptionStateSvc<T>
-                    {
+                    for GetEventSubscriptionStateSvc<T> {
                         type Response = super::super::super::common::events::EventSubscriptionState;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetStateMessage>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut =
-                                async move { inner.get_event_subscription_state(request).await };
+                            let fut = async move {
+                                (*inner).get_event_subscription_state(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = GetEventSubscriptionStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -465,31 +622,38 @@ pub mod network_server {
                 "/networks.networks.Network/UnsubscribeEvent" => {
                     #[allow(non_camel_case_types)]
                     struct UnsubscribeEventSvc<T: Network>(pub Arc<T>);
-                    impl<T: Network> tonic::server::UnaryService<super::NetworkEventUnsubscription>
-                        for UnsubscribeEventSvc<T>
-                    {
+                    impl<
+                        T: Network,
+                    > tonic::server::UnaryService<super::NetworkEventUnsubscription>
+                    for UnsubscribeEventSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::NetworkEventUnsubscription>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.unsubscribe_event(request).await };
+                            let fut = async move {
+                                (*inner).unsubscribe_event(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = UnsubscribeEventSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -498,53 +662,69 @@ pub mod network_server {
                 "/networks.networks.Network/GetEventStates" => {
                     #[allow(non_camel_case_types)]
                     struct GetEventStatesSvc<T: Network>(pub Arc<T>);
-                    impl<T: Network> tonic::server::UnaryService<super::GetStateMessage> for GetEventStatesSvc<T> {
+                    impl<T: Network> tonic::server::UnaryService<super::GetStateMessage>
+                    for GetEventStatesSvc<T> {
                         type Response = super::super::super::common::events::EventStates;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetStateMessage>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.get_event_states(request).await };
+                            let fut = async move {
+                                (*inner).get_event_states(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = GetEventStatesSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .body(tonic::body::BoxBody::empty())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
     impl<T: Network> Clone for NetworkServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
-            Self { inner }
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
         }
     }
     impl<T: Network> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone(), self.1.clone())
+            Self(self.0.clone())
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
@@ -552,7 +732,7 @@ pub mod network_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: Network> tonic::transport::NamedService for NetworkServer<T> {
+    impl<T: Network> tonic::server::NamedService for NetworkServer<T> {
         const NAME: &'static str = "networks.networks.Network";
     }
 }

--- a/weaver/common/protos-rs/pkg/src/generated/relay.datatransfer.rs
+++ b/weaver/common/protos-rs/pkg/src/generated/relay.datatransfer.rs
@@ -1,13 +1,15 @@
-#[doc = r" Generated client implementations."]
+/// Generated client implementations.
 pub mod data_transfer_client {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    #[doc = " definitions of all messages used in the datatransfer protocol"]
+    use tonic::codegen::http::Uri;
+    /// definitions of all messages used in the datatransfer protocol
+    #[derive(Debug, Clone)]
     pub struct DataTransferClient<T> {
         inner: tonic::client::Grpc<T>,
     }
     impl DataTransferClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
@@ -20,64 +22,121 @@ pub mod data_transfer_client {
     impl<T> DataTransferClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + HttpBody + Send + 'static,
         T::Error: Into<StdError>,
-        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        #[doc = " the requesting relay sends a RequestState request to the remote relay with a"]
-        #[doc = " query defining the data it wants to receive"]
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> DataTransferClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            DataTransferClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// the requesting relay sends a RequestState request to the remote relay with a
+        /// query defining the data it wants to receive
         pub async fn request_state(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::common::query::Query>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/relay.datatransfer.DataTransfer/RequestState",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " the remote relay asynchronously sends back the requested data with"]
-        #[doc = " SendState"]
+        /// the remote relay asynchronously sends back the requested data with
+        /// SendState
         pub async fn send_state(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::common::state::ViewPayload>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::common::state::ViewPayload,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/relay.datatransfer.DataTransfer/SendState");
+            let path = http::uri::PathAndQuery::from_static(
+                "/relay.datatransfer.DataTransfer/SendState",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " Handling state sent from the driver."]
+        /// Handling state sent from the driver.
         pub async fn send_driver_state(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::common::state::ViewPayload>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::common::state::ViewPayload,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/relay.datatransfer.DataTransfer/SendDriverState",
@@ -85,73 +144,96 @@ pub mod data_transfer_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
-    impl<T: Clone> Clone for DataTransferClient<T> {
-        fn clone(&self) -> Self {
-            Self {
-                inner: self.inner.clone(),
-            }
-        }
-    }
-    impl<T> std::fmt::Debug for DataTransferClient<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "DataTransferClient {{ ... }}")
-        }
-    }
 }
-#[doc = r" Generated server implementations."]
+/// Generated server implementations.
 pub mod data_transfer_server {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    #[doc = "Generated trait containing gRPC methods that should be implemented for use with DataTransferServer."]
+    /// Generated trait containing gRPC methods that should be implemented for use with DataTransferServer.
     #[async_trait]
     pub trait DataTransfer: Send + Sync + 'static {
-        #[doc = " the requesting relay sends a RequestState request to the remote relay with a"]
-        #[doc = " query defining the data it wants to receive"]
+        /// the requesting relay sends a RequestState request to the remote relay with a
+        /// query defining the data it wants to receive
         async fn request_state(
             &self,
             request: tonic::Request<super::super::super::common::query::Query>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " the remote relay asynchronously sends back the requested data with"]
-        #[doc = " SendState"]
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// the remote relay asynchronously sends back the requested data with
+        /// SendState
         async fn send_state(
             &self,
             request: tonic::Request<super::super::super::common::state::ViewPayload>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " Handling state sent from the driver."]
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// Handling state sent from the driver.
         async fn send_driver_state(
             &self,
             request: tonic::Request<super::super::super::common::state::ViewPayload>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
     }
-    #[doc = " definitions of all messages used in the datatransfer protocol"]
+    /// definitions of all messages used in the datatransfer protocol
     #[derive(Debug)]
-    #[doc(hidden)]
     pub struct DataTransferServer<T: DataTransfer> {
         inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
-    struct _Inner<T>(Arc<T>, Option<tonic::Interceptor>);
+    struct _Inner<T>(Arc<T>);
     impl<T: DataTransfer> DataTransferServer<T> {
         pub fn new(inner: T) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, None);
-            Self { inner }
+            Self::from_arc(Arc::new(inner))
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, Some(interceptor.into()));
-            Self { inner }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
-    impl<T, B> Service<http::Request<B>> for DataTransferServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for DataTransferServer<T>
     where
         T: DataTransfer,
-        B: HttpBody + Send + Sync + 'static,
+        B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
         type Response = http::Response<tonic::body::BoxBody>;
-        type Error = Never;
+        type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -160,32 +242,41 @@ pub mod data_transfer_server {
                 "/relay.datatransfer.DataTransfer/RequestState" => {
                     #[allow(non_camel_case_types)]
                     struct RequestStateSvc<T: DataTransfer>(pub Arc<T>);
-                    impl<T: DataTransfer>
-                        tonic::server::UnaryService<super::super::super::common::query::Query>
-                        for RequestStateSvc<T>
-                    {
+                    impl<
+                        T: DataTransfer,
+                    > tonic::server::UnaryService<
+                        super::super::super::common::query::Query,
+                    > for RequestStateSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::super::super::common::query::Query>,
+                            request: tonic::Request<
+                                super::super::super::common::query::Query,
+                            >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.request_state(request).await };
+                            let fut = async move {
+                                (*inner).request_state(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = RequestStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -194,12 +285,16 @@ pub mod data_transfer_server {
                 "/relay.datatransfer.DataTransfer/SendState" => {
                     #[allow(non_camel_case_types)]
                     struct SendStateSvc<T: DataTransfer>(pub Arc<T>);
-                    impl<T: DataTransfer>
-                        tonic::server::UnaryService<super::super::super::common::state::ViewPayload>
-                        for SendStateSvc<T>
-                    {
+                    impl<
+                        T: DataTransfer,
+                    > tonic::server::UnaryService<
+                        super::super::super::common::state::ViewPayload,
+                    > for SendStateSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
@@ -207,21 +302,22 @@ pub mod data_transfer_server {
                             >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.send_state(request).await };
+                            let fut = async move { (*inner).send_state(request).await };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = SendStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -230,12 +326,16 @@ pub mod data_transfer_server {
                 "/relay.datatransfer.DataTransfer/SendDriverState" => {
                     #[allow(non_camel_case_types)]
                     struct SendDriverStateSvc<T: DataTransfer>(pub Arc<T>);
-                    impl<T: DataTransfer>
-                        tonic::server::UnaryService<super::super::super::common::state::ViewPayload>
-                        for SendDriverStateSvc<T>
-                    {
+                    impl<
+                        T: DataTransfer,
+                    > tonic::server::UnaryService<
+                        super::super::super::common::state::ViewPayload,
+                    > for SendDriverStateSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
@@ -243,45 +343,57 @@ pub mod data_transfer_server {
                             >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.send_driver_state(request).await };
+                            let fut = async move {
+                                (*inner).send_driver_state(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = SendDriverStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .body(tonic::body::BoxBody::empty())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
     impl<T: DataTransfer> Clone for DataTransferServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
-            Self { inner }
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
         }
     }
     impl<T: DataTransfer> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone(), self.1.clone())
+            Self(self.0.clone())
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
@@ -289,7 +401,7 @@ pub mod data_transfer_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: DataTransfer> tonic::transport::NamedService for DataTransferServer<T> {
+    impl<T: DataTransfer> tonic::server::NamedService for DataTransferServer<T> {
         const NAME: &'static str = "relay.datatransfer.DataTransfer";
     }
 }

--- a/weaver/common/protos-rs/pkg/src/generated/relay.events.rs
+++ b/weaver/common/protos-rs/pkg/src/generated/relay.events.rs
@@ -1,12 +1,14 @@
-#[doc = r" Generated client implementations."]
+/// Generated client implementations.
 pub mod event_subscribe_client {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
     pub struct EventSubscribeClient<T> {
         inner: tonic::client::Grpc<T>,
     }
     impl EventSubscribeClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
@@ -19,64 +21,119 @@ pub mod event_subscribe_client {
     impl<T> EventSubscribeClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + HttpBody + Send + 'static,
         T::Error: Into<StdError>,
-        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        #[doc = " the dest-relay forwards the request from client as EventSubscription to the src-relay"]
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> EventSubscribeClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            EventSubscribeClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// the dest-relay forwards the request from client as EventSubscription to the src-relay
         pub async fn subscribe_event(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::common::events::EventSubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::common::events::EventSubscription,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/relay.events.EventSubscribe/SubscribeEvent");
+            let path = http::uri::PathAndQuery::from_static(
+                "/relay.events.EventSubscribe/SubscribeEvent",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " Src-relay based upon query (EventSubscription) forwards the same response (Ack) "]
-        #[doc = " from driver to the dest-relay by calling a new endpoint in dest-relay"]
+        /// Src-relay based upon query (EventSubscription) forwards the same response (Ack)
+        /// from driver to the dest-relay by calling a new endpoint in dest-relay
         pub async fn send_subscription_status(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::common::ack::Ack>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/relay.events.EventSubscribe/SendSubscriptionStatus",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " Src-driver status of event subscription (Ack) "]
-        #[doc = " to the src-relay by calling a new endpoint in src-relay"]
+        /// Src-driver status of event subscription (Ack)
+        /// to the src-relay by calling a new endpoint in src-relay
         pub async fn send_driver_subscription_status(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::common::ack::Ack>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/relay.events.EventSubscribe/SendDriverSubscriptionStatus",
@@ -84,28 +141,18 @@ pub mod event_subscribe_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
-    impl<T: Clone> Clone for EventSubscribeClient<T> {
-        fn clone(&self) -> Self {
-            Self {
-                inner: self.inner.clone(),
-            }
-        }
-    }
-    impl<T> std::fmt::Debug for EventSubscribeClient<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "EventSubscribeClient {{ ... }}")
-        }
-    }
 }
-#[doc = r" Generated client implementations."]
+/// Generated client implementations.
 pub mod event_publish_client {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
     pub struct EventPublishClient<T> {
         inner: tonic::client::Grpc<T>,
     }
     impl EventPublishClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
@@ -118,116 +165,194 @@ pub mod event_publish_client {
     impl<T> EventPublishClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + HttpBody + Send + 'static,
         T::Error: Into<StdError>,
-        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = tonic::client::Grpc::with_interceptor(inner, interceptor);
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        #[doc = " src-driver forwards the state as part of event subscription to src-relay"]
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> EventPublishClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            EventPublishClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// src-driver forwards the state as part of event subscription to src-relay
         pub async fn send_driver_state(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::common::state::ViewPayload>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::common::state::ViewPayload,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/relay.events.EventPublish/SendDriverState");
+            let path = http::uri::PathAndQuery::from_static(
+                "/relay.events.EventPublish/SendDriverState",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        #[doc = " src-relay will forward the state as part of event subscription to dest-relay"]
+        /// src-relay will forward the state as part of event subscription to dest-relay
         pub async fn send_state(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::common::state::ViewPayload>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::common::state::ViewPayload,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/relay.events.EventPublish/SendState");
+            let path = http::uri::PathAndQuery::from_static(
+                "/relay.events.EventPublish/SendState",
+            );
             self.inner.unary(request.into_request(), path, codec).await
-        }
-    }
-    impl<T: Clone> Clone for EventPublishClient<T> {
-        fn clone(&self) -> Self {
-            Self {
-                inner: self.inner.clone(),
-            }
-        }
-    }
-    impl<T> std::fmt::Debug for EventPublishClient<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "EventPublishClient {{ ... }}")
         }
     }
 }
-#[doc = r" Generated server implementations."]
+/// Generated server implementations.
 pub mod event_subscribe_server {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    #[doc = "Generated trait containing gRPC methods that should be implemented for use with EventSubscribeServer."]
+    /// Generated trait containing gRPC methods that should be implemented for use with EventSubscribeServer.
     #[async_trait]
     pub trait EventSubscribe: Send + Sync + 'static {
-        #[doc = " the dest-relay forwards the request from client as EventSubscription to the src-relay"]
+        /// the dest-relay forwards the request from client as EventSubscription to the src-relay
         async fn subscribe_event(
             &self,
-            request: tonic::Request<super::super::super::common::events::EventSubscription>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " Src-relay based upon query (EventSubscription) forwards the same response (Ack) "]
-        #[doc = " from driver to the dest-relay by calling a new endpoint in dest-relay"]
+            request: tonic::Request<
+                super::super::super::common::events::EventSubscription,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// Src-relay based upon query (EventSubscription) forwards the same response (Ack)
+        /// from driver to the dest-relay by calling a new endpoint in dest-relay
         async fn send_subscription_status(
             &self,
             request: tonic::Request<super::super::super::common::ack::Ack>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " Src-driver status of event subscription (Ack) "]
-        #[doc = " to the src-relay by calling a new endpoint in src-relay"]
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// Src-driver status of event subscription (Ack)
+        /// to the src-relay by calling a new endpoint in src-relay
         async fn send_driver_subscription_status(
             &self,
             request: tonic::Request<super::super::super::common::ack::Ack>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
-    #[doc(hidden)]
     pub struct EventSubscribeServer<T: EventSubscribe> {
         inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
-    struct _Inner<T>(Arc<T>, Option<tonic::Interceptor>);
+    struct _Inner<T>(Arc<T>);
     impl<T: EventSubscribe> EventSubscribeServer<T> {
         pub fn new(inner: T) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, None);
-            Self { inner }
+            Self::from_arc(Arc::new(inner))
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, Some(interceptor.into()));
-            Self { inner }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
-    impl<T, B> Service<http::Request<B>> for EventSubscribeServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for EventSubscribeServer<T>
     where
         T: EventSubscribe,
-        B: HttpBody + Send + Sync + 'static,
+        B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
         type Response = http::Response<tonic::body::BoxBody>;
-        type Error = Never;
+        type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -236,13 +361,16 @@ pub mod event_subscribe_server {
                 "/relay.events.EventSubscribe/SubscribeEvent" => {
                     #[allow(non_camel_case_types)]
                     struct SubscribeEventSvc<T: EventSubscribe>(pub Arc<T>);
-                    impl<T: EventSubscribe>
-                        tonic::server::UnaryService<
-                            super::super::super::common::events::EventSubscription,
-                        > for SubscribeEventSvc<T>
-                    {
+                    impl<
+                        T: EventSubscribe,
+                    > tonic::server::UnaryService<
+                        super::super::super::common::events::EventSubscription,
+                    > for SubscribeEventSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
@@ -250,21 +378,24 @@ pub mod event_subscribe_server {
                             >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.subscribe_event(request).await };
+                            let fut = async move {
+                                (*inner).subscribe_event(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = SubscribeEventSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -273,32 +404,40 @@ pub mod event_subscribe_server {
                 "/relay.events.EventSubscribe/SendSubscriptionStatus" => {
                     #[allow(non_camel_case_types)]
                     struct SendSubscriptionStatusSvc<T: EventSubscribe>(pub Arc<T>);
-                    impl<T: EventSubscribe>
-                        tonic::server::UnaryService<super::super::super::common::ack::Ack>
-                        for SendSubscriptionStatusSvc<T>
-                    {
+                    impl<
+                        T: EventSubscribe,
+                    > tonic::server::UnaryService<super::super::super::common::ack::Ack>
+                    for SendSubscriptionStatusSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::super::super::common::ack::Ack>,
+                            request: tonic::Request<
+                                super::super::super::common::ack::Ack,
+                            >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.send_subscription_status(request).await };
+                            let fut = async move {
+                                (*inner).send_subscription_status(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = SendSubscriptionStatusSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -306,58 +445,76 @@ pub mod event_subscribe_server {
                 }
                 "/relay.events.EventSubscribe/SendDriverSubscriptionStatus" => {
                     #[allow(non_camel_case_types)]
-                    struct SendDriverSubscriptionStatusSvc<T: EventSubscribe>(pub Arc<T>);
-                    impl<T: EventSubscribe>
-                        tonic::server::UnaryService<super::super::super::common::ack::Ack>
-                        for SendDriverSubscriptionStatusSvc<T>
-                    {
+                    struct SendDriverSubscriptionStatusSvc<T: EventSubscribe>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: EventSubscribe,
+                    > tonic::server::UnaryService<super::super::super::common::ack::Ack>
+                    for SendDriverSubscriptionStatusSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::super::super::common::ack::Ack>,
+                            request: tonic::Request<
+                                super::super::super::common::ack::Ack,
+                            >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut =
-                                async move { inner.send_driver_subscription_status(request).await };
+                            let fut = async move {
+                                (*inner).send_driver_subscription_status(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = SendDriverSubscriptionStatusSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .body(tonic::body::BoxBody::empty())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
     impl<T: EventSubscribe> Clone for EventSubscribeServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
-            Self { inner }
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
         }
     }
     impl<T: EventSubscribe> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone(), self.1.clone())
+            Self(self.0.clone())
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
@@ -365,56 +522,88 @@ pub mod event_subscribe_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: EventSubscribe> tonic::transport::NamedService for EventSubscribeServer<T> {
+    impl<T: EventSubscribe> tonic::server::NamedService for EventSubscribeServer<T> {
         const NAME: &'static str = "relay.events.EventSubscribe";
     }
 }
-#[doc = r" Generated server implementations."]
+/// Generated server implementations.
 pub mod event_publish_server {
-    #![allow(unused_variables, dead_code, missing_docs)]
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    #[doc = "Generated trait containing gRPC methods that should be implemented for use with EventPublishServer."]
+    /// Generated trait containing gRPC methods that should be implemented for use with EventPublishServer.
     #[async_trait]
     pub trait EventPublish: Send + Sync + 'static {
-        #[doc = " src-driver forwards the state as part of event subscription to src-relay"]
+        /// src-driver forwards the state as part of event subscription to src-relay
         async fn send_driver_state(
             &self,
             request: tonic::Request<super::super::super::common::state::ViewPayload>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
-        #[doc = " src-relay will forward the state as part of event subscription to dest-relay"]
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
+        /// src-relay will forward the state as part of event subscription to dest-relay
         async fn send_state(
             &self,
             request: tonic::Request<super::super::super::common::state::ViewPayload>,
-        ) -> Result<tonic::Response<super::super::super::common::ack::Ack>, tonic::Status>;
+        ) -> Result<
+            tonic::Response<super::super::super::common::ack::Ack>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
-    #[doc(hidden)]
     pub struct EventPublishServer<T: EventPublish> {
         inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
-    struct _Inner<T>(Arc<T>, Option<tonic::Interceptor>);
+    struct _Inner<T>(Arc<T>);
     impl<T: EventPublish> EventPublishServer<T> {
         pub fn new(inner: T) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, None);
-            Self { inner }
+            Self::from_arc(Arc::new(inner))
         }
-        pub fn with_interceptor(inner: T, interceptor: impl Into<tonic::Interceptor>) -> Self {
-            let inner = Arc::new(inner);
-            let inner = _Inner(inner, Some(interceptor.into()));
-            Self { inner }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
-    impl<T, B> Service<http::Request<B>> for EventPublishServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for EventPublishServer<T>
     where
         T: EventPublish,
-        B: HttpBody + Send + Sync + 'static,
+        B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
         type Response = http::Response<tonic::body::BoxBody>;
-        type Error = Never;
+        type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -423,12 +612,16 @@ pub mod event_publish_server {
                 "/relay.events.EventPublish/SendDriverState" => {
                     #[allow(non_camel_case_types)]
                     struct SendDriverStateSvc<T: EventPublish>(pub Arc<T>);
-                    impl<T: EventPublish>
-                        tonic::server::UnaryService<super::super::super::common::state::ViewPayload>
-                        for SendDriverStateSvc<T>
-                    {
+                    impl<
+                        T: EventPublish,
+                    > tonic::server::UnaryService<
+                        super::super::super::common::state::ViewPayload,
+                    > for SendDriverStateSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
@@ -436,21 +629,24 @@ pub mod event_publish_server {
                             >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.send_driver_state(request).await };
+                            let fut = async move {
+                                (*inner).send_driver_state(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = SendDriverStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -459,12 +655,16 @@ pub mod event_publish_server {
                 "/relay.events.EventPublish/SendState" => {
                     #[allow(non_camel_case_types)]
                     struct SendStateSvc<T: EventPublish>(pub Arc<T>);
-                    impl<T: EventPublish>
-                        tonic::server::UnaryService<super::super::super::common::state::ViewPayload>
-                        for SendStateSvc<T>
-                    {
+                    impl<
+                        T: EventPublish,
+                    > tonic::server::UnaryService<
+                        super::super::super::common::state::ViewPayload,
+                    > for SendStateSvc<T> {
                         type Response = super::super::super::common::ack::Ack;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
@@ -472,45 +672,55 @@ pub mod event_publish_server {
                             >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.send_state(request).await };
+                            let fut = async move { (*inner).send_state(request).await };
                             Box::pin(fut)
                         }
                     }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let interceptor = inner.1.clone();
                         let inner = inner.0;
                         let method = SendStateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = if let Some(interceptor) = interceptor {
-                            tonic::server::Grpc::with_interceptor(codec, interceptor)
-                        } else {
-                            tonic::server::Grpc::new(codec)
-                        };
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .body(tonic::body::BoxBody::empty())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
     impl<T: EventPublish> Clone for EventPublishServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
-            Self { inner }
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
         }
     }
     impl<T: EventPublish> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone(), self.1.clone())
+            Self(self.0.clone())
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
@@ -518,7 +728,7 @@ pub mod event_publish_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: EventPublish> tonic::transport::NamedService for EventPublishServer<T> {
+    impl<T: EventPublish> tonic::server::NamedService for EventPublishServer<T> {
         const NAME: &'static str = "relay.events.EventPublish";
     }
 }

--- a/weaver/core/drivers/fabric-driver/server/utils.ts
+++ b/weaver/core/drivers/fabric-driver/server/utils.ts
@@ -140,11 +140,16 @@ function getRelayClientForEventPublish() {
     return client;
 }
 
+async function delay(ms: number) {
+    await new Promise(f => setTimeout(f, ms));
+}
+
 export {
     checkIfArraysAreEqual,
     handlePromise,
     relayCallback,
     getRelayClientForQueryResponse,
     getRelayClientForEventSubscription,
-    getRelayClientForEventPublish
+    getRelayClientForEventPublish,
+    delay
 }

--- a/weaver/core/relay/Cargo.lock
+++ b/weaver/core/relay/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arrayvec"
@@ -25,34 +25,35 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-stream"
-version = "0.2.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.2.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -62,16 +63,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.11.0"
+name = "axum"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes 1.4.0",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde 1.0.159",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+dependencies = [
+ "async-trait",
+ "bytes 1.4.0",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bincode"
@@ -79,7 +131,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.139",
+ "serde 1.0.159",
 ]
 
 [[package]]
@@ -108,21 +160,15 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -131,24 +177,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "config"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.139",
+ "serde 1.0.159",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -177,55 +214,72 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.2"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
+ "cfg-if",
  "crossbeam-utils",
- "lazy_static",
- "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
+ "cfg-if",
 ]
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -259,11 +313,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -274,30 +327,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -310,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -320,15 +357,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -337,38 +374,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -377,7 +414,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.9",
+ "pin-project-lite",
  "pin-utils",
  "slab",
 ]
@@ -393,33 +430,22 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.4.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -427,10 +453,9 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.25",
+ "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -449,45 +474,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.2.8"
+name = "hermit-abi"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
- "bytes 1.2.0",
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes 1.4.0",
  "fnv",
- "itoa 1.0.2",
+ "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.4.0",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.13.10"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.4.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -496,44 +537,55 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
- "pin-project 1.0.11",
+ "itoa",
+ "pin-project-lite",
  "socket2",
- "tokio 0.2.25",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.4.3"
+name = "hyper-timeout"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "bytes 0.5.6",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.4.0",
  "hyper",
  "native-tls",
- "tokio 0.2.25",
- "tokio-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -545,23 +597,25 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
+name = "io-lifetimes"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "itertools"
@@ -573,34 +627,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.8"
+name = "itertools"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
-
-[[package]]
-name = "js-sys"
-version = "0.3.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
- "wasm-bindgen",
+ "either",
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
+name = "itoa"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -617,26 +664,16 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ryu",
  "static_assertions",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
-dependencies = [
- "serde 0.8.23",
- "serde_test",
-]
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linked-hash-map"
@@ -645,22 +682,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
-name = "listenfd"
-version = "0.3.5"
+name = "linux-raw-sys"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e514e2cb8a9624701346ea3e694c1766d76778e343e537d873c1c366e79a7"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "listenfd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0500463acd96259d219abb05dc57e5a076ef04b2db9a2112846929b5f174c96"
 dependencies = [
  "libc",
  "uuid",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -670,20 +714,14 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
+name = "matchit"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -693,58 +731,29 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "wasi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -755,9 +764,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -769,17 +778,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -812,19 +810,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.13.0"
+name = "num_cpus"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -840,7 +848,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -851,9 +859,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",
@@ -864,33 +872,34 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
+ "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if",
+ "instant",
  "libc",
- "redox_syscall 0.1.57",
+ "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
@@ -904,49 +913,23 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.30"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
- "pin-project-internal 0.4.30",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
-dependencies = [
- "pin-project-internal 1.0.11",
+ "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.30"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -962,21 +945,21 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -988,7 +971,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
  "bytes 0.5.6",
- "prost-derive",
+ "prost-derive 0.6.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+dependencies = [
+ "bytes 1.4.0",
+ "prost-derive 0.11.8",
 ]
 
 [[package]]
@@ -999,11 +992,11 @@ checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
  "bytes 0.5.6",
  "heck",
- "itertools",
+ "itertools 0.8.2",
  "log",
  "multimap",
  "petgraph",
- "prost",
+ "prost 0.6.1",
  "prost-types",
  "tempfile",
  "which",
@@ -1016,10 +1009,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.8.2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1029,37 +1035,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
  "bytes 0.5.6",
- "prost",
+ "prost 0.6.1",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
- "rand_pcg",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1067,51 +1070,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core",
+ "getrandom",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1120,25 +1099,24 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "relay"
 version = "1.5.4"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.20.0",
  "bincode",
  "config",
  "futures",
  "listenfd",
- "prost",
  "reqwest",
- "serde 1.0.139",
+ "serde 1.0.159",
  "serde_json",
  "sled",
- "tokio 1.18.5",
+ "tokio",
  "tonic",
  "tonic-build",
  "uuid",
@@ -1146,43 +1124,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "reqwest"
-version = "0.10.10"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
- "base64 0.13.0",
- "bytes 0.5.6",
+ "base64 0.21.0",
+ "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
+ "once_cell",
  "percent-encoding",
- "pin-project-lite 0.2.9",
- "serde 1.0.139",
+ "pin-project-lite",
+ "serde 1.0.159",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.25",
- "tokio-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1202,7 +1172,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1212,12 +1182,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
-name = "rustls"
-version = "0.17.0"
+name = "rustix"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
- "base64 0.11.0",
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
  "log",
  "ring",
  "sct",
@@ -1225,19 +1208,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.10"
+name = "rustls-pemfile"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1248,9 +1245,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -1258,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1271,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1287,9 +1284,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
@@ -1301,7 +1298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
 dependencies = [
  "lazy_static",
- "linked-hash-map 0.3.0",
  "num-traits 0.1.43",
  "regex",
  "serde 0.8.23",
@@ -1309,33 +1305,24 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
- "itoa 1.0.2",
+ "itoa",
  "ryu",
- "serde 1.0.139",
-]
-
-[[package]]
-name = "serde_test"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
-dependencies = [
- "serde 0.8.23",
+ "serde 1.0.159",
 ]
 
 [[package]]
@@ -1345,25 +1332,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.2",
+ "itoa",
  "ryu",
- "serde 1.0.139",
+ "serde 1.0.159",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "sled"
-version = "0.31.0"
+version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb6824dde66ad33bf20c6e8476f5b82b871bc8bc3c129a10ea2f7dae5060fa3"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
 dependencies = [
  "crc32fast",
  "crossbeam-epoch",
@@ -1377,19 +1364,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1406,9 +1392,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1416,17 +1402,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.3.0"
+name = "syn"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
 dependencies = [
- "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "tempfile"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+dependencies = [
+ "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall 0.2.13",
- "remove_dir_all",
- "winapi 0.3.9",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1440,131 +1442,132 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "memchr",
+ "autocfg",
+ "bytes 1.4.0",
+ "libc",
  "mio",
- "pin-project-lite 0.1.12",
- "slab",
- "tokio-macros 0.2.6",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.18.5"
+name = "tokio-io-timeout"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050c618355082ae5a89ec63bbf897225d5ffe84c7c4e036874e4d185a5044e"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
- "pin-project-lite 0.2.9",
- "tokio-macros 1.8.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.13.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "futures-core",
  "rustls",
- "tokio 0.2.25",
+ "tokio",
  "webpki",
 ]
 
 [[package]]
-name = "tokio-tls"
-version = "0.3.1"
+name = "tokio-stream"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
- "native-tls",
- "tokio 0.2.25",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.4.0",
  "futures-core",
  "futures-sink",
- "log",
- "pin-project-lite 0.1.12",
- "tokio 0.2.25",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.139",
+ "serde 1.0.159",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.2.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afef9ce97ea39593992cf3fa00ff33b1ad5eb07665b31355df63a690e38c736"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64 0.11.0",
- "bytes 0.5.6",
+ "axum",
+ "base64 0.13.1",
+ "bytes 1.4.0",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
+ "hyper-timeout",
  "percent-encoding",
- "pin-project 0.4.30",
- "prost",
- "prost-derive",
- "tokio 0.2.25",
+ "pin-project",
+ "prost 0.11.8",
+ "prost-derive 0.11.8",
+ "rustls-pemfile",
+ "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "tokio-util",
  "tower",
- "tower-balance",
- "tower-load",
- "tower-make",
+ "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -1579,156 +1582,34 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "tower"
-version = "0.3.1"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3169017c090b7a28fce80abaad0ab4f5566423677c9331bb320af7e49cfe62"
-dependencies = [
- "futures-core",
- "tower-buffer",
- "tower-discover",
- "tower-layer",
- "tower-limit",
- "tower-load-shed",
- "tower-retry",
- "tower-service",
- "tower-timeout",
- "tower-util",
-]
-
-[[package]]
-name = "tower-balance"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a792277613b7052448851efcf98a2c433e6f1d01460832dc60bef676bc275d4c"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 0.4.30",
+ "pin-project",
+ "pin-project-lite",
  "rand",
  "slab",
- "tokio 0.2.25",
- "tower-discover",
- "tower-layer",
- "tower-load",
- "tower-make",
- "tower-ready-cache",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-buffer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.30",
- "tokio 0.2.25",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-discover"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.30",
- "tower-service",
 ]
 
 [[package]]
 name = "tower-layer"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
-
-[[package]]
-name = "tower-limit"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
-dependencies = [
- "futures-core",
- "pin-project 0.4.30",
- "tokio 0.2.25",
- "tower-layer",
- "tower-load",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
-dependencies = [
- "futures-core",
- "log",
- "pin-project 0.4.30",
- "tokio 0.2.25",
- "tower-discover",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load-shed"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
-dependencies = [
- "futures-core",
- "pin-project 0.4.30",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-make"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
-dependencies = [
- "tokio 0.2.25",
- "tower-service",
-]
-
-[[package]]
-name = "tower-ready-cache"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eabb6620e5481267e2ec832c780b31cad0c15dcb14ed825df5076b26b591e1f"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap",
- "log",
- "tokio 0.2.25",
- "tower-service",
-]
-
-[[package]]
-name = "tower-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
-dependencies = [
- "futures-core",
- "pin-project 0.4.30",
- "tokio 0.2.25",
- "tower-layer",
- "tower-service",
-]
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -1737,58 +1618,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
-name = "tower-timeout"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
-dependencies = [
- "pin-project 0.4.30",
- "tokio 0.2.25",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project 0.4.30",
- "tower-service",
-]
-
-[[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
- "log",
- "pin-project-lite 0.2.9",
+ "cfg-if",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
@@ -1799,51 +1655,42 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.11",
+ "pin-project",
  "tracing",
 ]
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "untrusted"
@@ -1853,23 +1700,22 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
 ]
 
 [[package]]
@@ -1896,50 +1742,42 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
- "cfg-if 1.0.0",
- "serde 1.0.139",
- "serde_json",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1947,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1957,41 +1795,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "weaver_protos_rs"
 version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f76c48122acb4bb3615dfeb3487549630c22bd61b02417f914f52a25f08b68b"
 dependencies = [
- "prost",
- "serde 1.0.139",
- "tokio 0.2.25",
+ "prost 0.11.8",
+ "serde 1.0.159",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1999,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
@@ -2018,12 +1852,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2031,12 +1859,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2052,64 +1874,92 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "winreg"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "winapi 0.3.9",
+ "windows-targets",
 ]
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
+name = "windows-targets"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2118,5 +1968,5 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
- "linked-hash-map 0.5.6",
+ "linked-hash-map",
 ]

--- a/weaver/core/relay/Cargo.toml
+++ b/weaver/core/relay/Cargo.toml
@@ -22,21 +22,20 @@ path = "driver/driver.rs"
 
 
 [dependencies]
-tonic = {version="0.2",  features = ["tls"]}
-prost = "0.6"
-tokio = { version = "1.18", features = ["macros", "fs"] }
-sled = "0.31.0"
-uuid = { version = "0.8", features = ["v4"] }
-bincode = "1.2.1"
-serde = {version="1.0.110", features = ["derive"]}
-config = "0.10.1"
-listenfd = "0.3"
-futures = { version = "0.3.5" }
-base64 = "0.13.0"
-reqwest = { version = "0.10.10", features = ["json"] }
-serde_json = "1.0.1"
-# weaver_protos_rs = { path = "./protos-rs" }
-weaver_protos_rs = "1.5.4"
+tonic = { version="0.8.3",  features = ["tls"] }
+tokio = { version = "1.27", features = ["macros", "fs", "rt", "rt-multi-thread", "sync"] }
+sled = "0.34.7"
+uuid = { version = "1.3.0", features = ["v4"] }
+bincode = "1.3.3"
+serde = {version="1.0.159", features = ["derive"]}
+config = "0.11.0"
+listenfd = "1.0.1"
+futures = { version = "0.3.27" }
+base64 = "0.20.0"
+reqwest = { version = "0.11.16", features = ["json"] }
+serde_json = "1.0.95"
+weaver_protos_rs = { path = "./protos-rs" }
+# weaver_protos_rs = "1.5.4"
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/weaver/core/relay/config/Dummy_Relay_tls.toml
+++ b/weaver/core/relay/config/Dummy_Relay_tls.toml
@@ -1,0 +1,53 @@
+name = "Dummy_Relay"
+port="9085"
+hostname="localhost"
+db_path="db/Dummy_Relay_tls/requests"
+# This will be replaced by the task queue.
+remote_db_path="db/Dummy_Relay_tls/remote_request"
+
+# FOR TLS
+cert_path="credentials/fabric_cert.pem"
+key_path="credentials/fabric_key"
+tls=true
+
+# Networks map is used to identity the network behind the relay
+# by its network name so the request can be routed to the right driver
+[networks]
+[networks.Dummy_Network]
+network="Dummy"
+
+# Location of the remote relays
+[relays]
+[relays.Corda_Relay]
+hostname="localhost"
+port="9081"
+tls=true
+tlsca_cert_path="credentials/fabric_ca_cert.pem"
+[relays.Dummy_Relay]
+hostname="localhost"
+port="9085"
+tls=true
+tlsca_cert_path="credentials/fabric_ca_cert.pem"
+[relays.Fabric_Relay2]
+hostname="localhost"
+port="9083"
+tls=true
+tlsca_cert_path="credentials/fabric_ca_cert.pem"
+
+# host and port of the driver identified by networks map
+[drivers]
+[drivers.Fabric]
+hostname="localhost"
+port="9090"
+tls=true
+tlsca_cert_path="credentials/fabric_ca_cert.pem"
+[drivers.Corda]
+hostname="localhost"
+port="9099"
+tls=true
+tlsca_cert_path="credentials/fabric_ca_cert.pem"
+[drivers.Dummy]
+hostname="localhost"
+port="9092"
+tls=true
+tlsca_cert_path="credentials/fabric_ca_cert.pem"

--- a/weaver/core/relay/scripts/update-protos.sh
+++ b/weaver/core/relay/scripts/update-protos.sh
@@ -12,14 +12,16 @@ uncomment() {
     sed -i'.scriptbak' -e "$1"' s/^# weaver_protos_rs/weaver_protos_rs/' "$2"
 }
 
+lineNum="$(grep -n "weaver_protos_rs" Cargo.toml | head -n 1 | cut -d: -f1)"
+
 if [ "$1" = "local" ]; then
     rm -rf protos-rs
     cp -r $WEAVER_ROOT/common/protos-rs/pkg protos-rs
-    comment 39 Cargo.toml
-    uncomment 38 Cargo.toml
+    comment $((lineNum+1)) Cargo.toml
+    uncomment $lineNum Cargo.toml
 else
-    uncomment 39 Cargo.toml
-    comment 38 Cargo.toml
+    uncomment $((lineNum+1)) Cargo.toml
+    comment $lineNum Cargo.toml
 fi
 
 rm -f Cargo.toml.scriptbak

--- a/weaver/core/relay/src/client.rs
+++ b/weaver/core/relay/src/client.rs
@@ -46,7 +46,7 @@ async fn datasharing() -> Result<(), Box<dyn std::error::Error>> {
     match ack::Status::from_i32(response.get_ref().status) {
         Some(ack_status) => match ack_status {
             ack::Status::Ok => {
-                poll_for_state(request_id.to_string(), network_client).await;
+                poll_for_state(request_id.to_string(), network_client, 0).await;
                 println!("Data Sharing: Success!");
             }
             ack::Status::Error => {
@@ -65,6 +65,7 @@ async fn datasharing() -> Result<(), Box<dyn std::error::Error>> {
 fn poll_for_state(
     request_id: String,
     mut network_client: NetworkClient<tonic::transport::Channel>,
+    iter: u32,
 ) -> BoxFuture<'static, ()> {
     async move {
         sleep(time::Duration::from_millis(2000));
@@ -77,8 +78,9 @@ fn poll_for_state(
                 println!("Get state response: {:?}", response);
                 match request_state::Status::from_i32(response.get_ref().status) {
                     Some(request_status) => {
-                        if request_status == request_state::Status::Pending {
-                            poll_for_state(request_id, network_client).await;
+                        if request_status == request_state::Status::Pending ||
+                           request_status == request_state::Status::PendingAck {
+                            poll_for_state(request_id, network_client, iter+1).await;
                         } else if request_status == request_state::Status::Error {
                             println!("Error");
                             std::process::exit(1);
@@ -154,7 +156,7 @@ async fn event_suscribe(driver: bool) -> Result<(), Box<dyn std::error::Error>> 
     match ack::Status::from_i32(response.get_ref().status) {
         Some(ack_status) => match ack_status {
             ack::Status::Ok => {
-                poll_for_event_subscription(request_id.clone().to_string(), network_client).await;
+                poll_for_event_subscription(request_id.clone().to_string(), network_client, 0).await;
             }
             ack::Status::Error => {
                 println!("An error occurred in subscribe_event call");
@@ -239,7 +241,7 @@ async fn event_unsuscribe(request_id: String, driver: bool) -> Result<(), Box<dy
     match ack::Status::from_i32(response.get_ref().status) {
         Some(ack_status) => match ack_status {
             ack::Status::Ok => {
-                poll_for_event_subscription(request_id.to_string(), network_client).await;
+                poll_for_event_subscription(request_id.to_string(), network_client, 0).await;
             }
             ack::Status::Error => {
                 println!("An error occurred in unsubscribe_event call");
@@ -257,6 +259,7 @@ async fn event_unsuscribe(request_id: String, driver: bool) -> Result<(), Box<dy
 fn poll_for_event_subscription(
     request_id: String,
     mut network_client: NetworkClient<tonic::transport::Channel>,
+    iter: u32,
 ) -> BoxFuture<'static, ()> {
     async move {
         sleep(time::Duration::from_millis(2000));
@@ -274,7 +277,7 @@ fn poll_for_event_subscription(
                             request_status == event_subscription_state::Status::UnsubscribePending ||
                             request_status == event_subscription_state::Status::SubscribePendingAck ||
                             request_status == event_subscription_state::Status::SubscribePendingAck {
-                            poll_for_event_subscription(request_id, network_client).await;
+                            poll_for_event_subscription(request_id, network_client, iter+1).await;
                         } else if request_status == event_subscription_state::Status::Subscribed {
                             println!("Event Subscription: Success!");
                         } else if request_status == event_subscription_state::Status::Unsubscribed {

--- a/weaver/core/relay/src/client_tls.rs
+++ b/weaver/core/relay/src/client_tls.rs
@@ -1,26 +1,50 @@
 mod relay_proto;
-use weaverpb::networks::networks::{network_client::NetworkClient, NetworkQuery};
+use weaverpb::common::ack::ack;
+use weaverpb::common::state::{request_state, view_payload, ViewPayload, View, Meta, meta};
+use weaverpb::common::events::{event_subscription_state, EventMatcher, EventPublication, event_publication, ContractTransaction};
+use weaverpb::relay::events::{event_publish_client::EventPublishClient};
+use weaverpb::networks::networks::{network_client::NetworkClient, GetStateMessage, NetworkQuery, NetworkEventSubscription, NetworkEventUnsubscription};
 use relay_proto::get_url;
-use std::env;
 
+use std::env;
+use futures::future::{BoxFuture, FutureExt};
+use std::thread::sleep;
+use std::time;
+use serde_json;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args: Vec<String> = env::args().collect();
+    println!("\nTLS Data Sharing Test");
+    datasharing().await?;
+    println!("\nTLS Event: Driver Subscription Test");
+    event_suscribe(true).await?;
+    println!("\nTLS Event: Client Subscription Test");
+    event_suscribe(false).await?;
+    Ok(())
+}
+
+
+async fn get_tls_channel(url: String) -> Result<Channel, Box<dyn std::error::Error>> {
     let pem = tokio::fs::read("credentials/fabric_ca_cert.pem").await?;
     let ca = Certificate::from_pem(pem);
 
     let tls = ClientTlsConfig::new()
         .ca_certificate(ca)
         .domain_name("example.com");
-    let net_addr = format!("http://{}", get_url(&args));
+    let net_addr = format!("http://{}", url);
 
-    let channel = Channel::from_shared(net_addr)?
-        .tls_config(tls)
+    let channel = Channel::from_shared(net_addr.to_string())?
+        .tls_config(tls)?
         .connect()
         .await?;
+        
+    Ok(channel)
+}
 
+async fn datasharing() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let channel = get_tls_channel(get_url(&args)).await?;
     let mut network_client = NetworkClient::new(channel);
     let request = tonic::Request::new(NetworkQuery {
         policy: vec!["test".to_string()],
@@ -35,6 +59,392 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
     let response = network_client.request_state(request).await?;
     println!("RESPONSE={:?}", response);
+    let request_id = &response.get_ref().request_id;
+    match ack::Status::from_i32(response.get_ref().status) {
+        Some(ack_status) => match ack_status {
+            ack::Status::Ok => {
+                poll_for_state(request_id.to_string(), network_client,0).await;
+                println!("Data Sharing: Success!");
+            }
+            ack::Status::Error => {
+                println!("An error occurred in request_state call");
+                std::process::exit(1);
+            }
+        },
+        None => {
+            println!("The returned Ack has no status");
+            std::process::exit(1);
+        }
+    }
+    Ok(())
+}
 
+fn poll_for_state(
+    request_id: String,
+    mut network_client: NetworkClient<tonic::transport::Channel>,
+    iter: u32,
+) -> BoxFuture<'static, ()> {
+    async move {
+        if iter.clone() == 10 {
+            println!("Poll state timeout.");
+            std::process::exit(1);
+        }
+        sleep(time::Duration::from_millis(2000));
+        let request = tonic::Request::new(GetStateMessage {
+            request_id: request_id.to_string(),
+        });
+        let result = network_client.get_state(request).await;
+        match result {
+            Ok(response) => {
+                println!("Get state response: {:?}", response);
+                match request_state::Status::from_i32(response.get_ref().status) {
+                    Some(request_status) => {
+                        if request_status == request_state::Status::Pending ||
+                           request_status == request_state::Status::PendingAck {
+                            poll_for_state(request_id, network_client, iter+1).await;
+                        } else if request_status == request_state::Status::Error {
+                            println!("Error");
+                            std::process::exit(1);
+                        }
+                    }
+                    None => {
+                        println!("No status returned from get state request");
+                        std::process::exit(1);
+                    }
+                };
+            }
+            Err(_error) => {
+                println!("Error getting state response");
+                std::process::exit(1);
+            }
+        }
+    }
+    .boxed()
+}
+async fn event_suscribe(driver: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let channel = get_tls_channel(get_url(&args)).await?;
+    let mut network_client = NetworkClient::new(channel);
+    let network_query = NetworkQuery {
+        policy: vec!["test".to_string()],
+        address: args[2].to_string(),
+        requesting_relay: "".to_string(),
+        requesting_network: "".to_string(),
+        requesting_org: "".to_string(),
+        certificate: "test".to_string(),
+        requestor_signature: "test".to_string(),
+        nonce: "test".to_string(),
+        confidential: false,
+    };
+    let event_matcher = EventMatcher {
+        event_type: 0,
+        event_class_id: "test".to_string(),
+        transaction_ledger_id: "test".to_string(),
+        transaction_contract_id: "test".to_string(),
+        transaction_func: "test".to_string(),
+    };
+    let tmp;
+    if driver {
+        let ctx = ContractTransaction {
+            driver_id: "Dummy_Network".to_string(),
+            ledger_id: "abc".to_string(),
+            contract_id: "abc".to_string(),
+            func: "abc".to_string(),
+            args: vec![],
+            replace_arg_index: 0,
+            members: vec![],
+        };
+        tmp = event_publication::PublicationTarget::Ctx(ctx);
+    } else {
+        tmp = event_publication::PublicationTarget::AppUrl("abc".to_string());
+    }
+    let event_publication_spec = EventPublication { 
+        publication_target: std::option::Option::Some(tmp),
+    };
+    let request = tonic::Request::new(NetworkEventSubscription {
+        event_matcher: std::option::Option::Some(event_matcher),
+        query: std::option::Option::Some(network_query),
+        event_publication_spec: std::option::Option::Some(event_publication_spec),
+    });
+    let response = network_client.subscribe_event(request).await?;
+    println!("RESPONSE={:?}", response);
+    let request_id = &response.get_ref().request_id;
+    match ack::Status::from_i32(response.get_ref().status) {
+        Some(ack_status) => match ack_status {
+            ack::Status::Ok => {
+                poll_for_event_subscription(request_id.clone().to_string(), network_client, 0).await;
+            }
+            ack::Status::Error => {
+                println!("An error occurred in subscribe_event call");
+                std::process::exit(1);
+            }
+        },
+        None => {
+            println!("The returned Ack has no status");
+            std::process::exit(1);
+        }
+    }
+    println!("\n");
+    let result = event_publish_test(request_id.to_string(), driver).await;
+    match result {
+        Ok(()) => {
+            println!("Publish test: Successful");
+        },
+        Err(error) => {
+            println!("Error during Publish Test: {:?}", error);
+            std::process::exit(1);
+        }
+    }
+    println!("\n");
+    return event_unsuscribe(request_id.to_string(), driver).await;
+}
+
+async fn event_unsuscribe(request_id: String, driver: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let channel = get_tls_channel(get_url(&args)).await?;
+    let mut network_client = NetworkClient::new(channel);
+    let network_query = NetworkQuery {
+        policy: vec!["test".to_string()],
+        address: args[2].to_string(),
+        requesting_relay: "".to_string(),
+        requesting_network: "".to_string(),
+        requesting_org: "".to_string(),
+        certificate: "test".to_string(),
+        requestor_signature: "test".to_string(),
+        nonce: "test".to_string(),
+        confidential: false,
+    };
+    let event_matcher = EventMatcher {
+        event_type: 0,
+        event_class_id: "test".to_string(),
+        transaction_ledger_id: "test".to_string(),
+        transaction_contract_id: "test".to_string(),
+        transaction_func: "test".to_string(),
+    };
+    let tmp;
+    if driver {
+        let ctx = ContractTransaction {
+            driver_id: "Dummy_Network".to_string(),
+            ledger_id: "abc".to_string(),
+            contract_id: "abc".to_string(),
+            func: "abc".to_string(),
+            args: vec![],
+            replace_arg_index: 0,
+            members: vec![],
+        };
+        tmp = event_publication::PublicationTarget::Ctx(ctx);
+    } else {
+        tmp = event_publication::PublicationTarget::AppUrl("abc".to_string());
+    }
+    let event_publication_spec = EventPublication { 
+        publication_target: std::option::Option::Some(tmp),
+    };
+    let net_event_sub = NetworkEventSubscription {
+        event_matcher: std::option::Option::Some(event_matcher),
+        query: std::option::Option::Some(network_query),
+        event_publication_spec: std::option::Option::Some(event_publication_spec),
+    };
+    let request = tonic::Request::new(NetworkEventUnsubscription {
+        request: std::option::Option::Some(net_event_sub),
+        request_id: request_id,
+    });
+    let response = network_client.unsubscribe_event(request).await?;
+    println!("RESPONSE={:?}", response);
+    let request_id = &response.get_ref().request_id;
+    match ack::Status::from_i32(response.get_ref().status) {
+        Some(ack_status) => match ack_status {
+            ack::Status::Ok => {
+                poll_for_event_subscription(request_id.to_string(), network_client, 0).await;
+            }
+            ack::Status::Error => {
+                println!("An error occurred in unsubscribe_event call");
+                std::process::exit(1);
+            }
+        },
+        None => {
+            println!("The returned Ack has no status");
+            std::process::exit(1);
+        }
+    }
+    Ok(())
+}
+
+fn poll_for_event_subscription(
+    request_id: String,
+    mut network_client: NetworkClient<tonic::transport::Channel>,
+    iter: u32,
+) -> BoxFuture<'static, ()> {
+    async move {
+        if iter.clone() == 10 {
+            println!("Poll state timeout.");
+            std::process::exit(1);
+        }
+        sleep(time::Duration::from_millis(2000));
+        let request = tonic::Request::new(GetStateMessage {
+            request_id: request_id.to_string(),
+        });
+        let result = network_client.get_event_subscription_state(request).await;
+        match result {
+            Ok(response) => {
+                println!("Get Event Subscription State response: {:?}", response);
+                match event_subscription_state::Status::from_i32(response.get_ref().status) {
+                    Some(request_status) => {
+                        println!("Received status: {:?}", response);
+                        if request_status == event_subscription_state::Status::SubscribePending ||
+                            request_status == event_subscription_state::Status::UnsubscribePending ||
+                            request_status == event_subscription_state::Status::SubscribePendingAck ||
+                            request_status == event_subscription_state::Status::SubscribePendingAck {
+                            poll_for_event_subscription(request_id, network_client, iter+1).await;
+                        } else if request_status == event_subscription_state::Status::Subscribed {
+                            println!("Event Subscription: Success!");
+                        } else if request_status == event_subscription_state::Status::Unsubscribed {
+                            println!("Event Unsubscription: Success!");
+                        } else {
+                            println!("Error: {:?}", response.get_ref().message.to_string());
+                            std::process::exit(1);
+                        }
+                    }
+                    None => {
+                        println!("No status returned from get state request");
+                        std::process::exit(1);
+                    }
+                };
+            }
+            Err(_error) => { 
+                println!("Error getting state response");
+                std::process::exit(1);
+            }
+        }
+    }
+    .boxed()
+}
+
+async fn event_publish_test(request_id: String, driver: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let channel = get_tls_channel(get_url(&args)).await?;
+    let mut client = EventPublishClient::new(channel.clone());
+    // localhost:9081/Corda_Network/test
+    // {locationsegment}/{Network_id}/{query}
+    // localhost:9081/Corda_Network/mychannel:simplestate:read:TestState
+    let meta = Meta {
+        proof_type: "abc".to_string(),
+        protocol: meta::Protocol::Fabric as i32,
+        serialization_format: "abc".to_string(),
+        timestamp: "abc".to_string(),
+    };
+    let data: Vec<u8> = vec![104, 101, 108, 108, 111];
+    let view = View {
+        meta: Some(meta),
+        data: data,
+    };
+    let view_payload = ViewPayload {
+        request_id: request_id.to_string(),
+        state: Some(view_payload::State::View(view)),
+    };
+    let view_payload_err = ViewPayload {
+        request_id: request_id.to_string(),
+        state: Some(view_payload::State::Error("mock error".to_string())),
+    };
+    
+    let response = client.send_driver_state(view_payload.clone()).await?;
+    if ack::Status::from_i32(response.get_ref().status).expect("No Valid Status") != ack::Status::Ok {
+        println!("An error occurred in send driver state call {:?}", response.get_ref().message);
+        std::process::exit(1);
+    }
+    
+    sleep(time::Duration::from_millis(2000));
+    
+    let response_err = client.send_driver_state(view_payload_err.clone()).await?;
+    if ack::Status::from_i32(response_err.get_ref().status).expect("No Valid Status") != ack::Status::Ok {
+        println!("An error occurred in send driver state call {:?}", response.get_ref().message);
+        std::process::exit(1);
+    }
+    
+    sleep(time::Duration::from_millis(2000));
+    
+    let mut network_client = NetworkClient::new(channel);
+    let request = tonic::Request::new(GetStateMessage {
+        request_id: request_id.to_string(),
+    });
+    
+    // Check if states status are correct.
+    let event_states_res = network_client.get_event_states(request).await;
+    match event_states_res {
+        Ok(response) => {
+            let mut event_states = response.into_inner().states;
+            println!("Received States: {:?}", event_states);
+            let event_state = event_states.pop().expect("No State");
+            let event_state_status = event_state.clone().state.expect("No RequestState").status;
+            if driver {
+                if request_state::Status::from_i32(event_state_status).expect("No Valid Status") != request_state::Status::EventWritten {
+                    println!("Error: event not got written to ledger: {:?}", event_state.message.to_string());
+                    std::process::exit(1);
+                }
+            } else {
+                if request_state::Status::from_i32(event_state_status).expect("No Valid Status") != request_state::Status::EventReceived {
+                    println!("Error: event status not correct: expected 4, received {:?}", event_state_status);
+                    std::process::exit(1);
+                }
+            }
+            let event_state_json = serde_json::to_string(&event_state.clone().state.expect("No RequestState").state);
+            let view_payload_json = serde_json::to_string(&view_payload.clone().state);
+            if  event_state_json.expect("stringify error") != view_payload_json.expect("stringify error") {
+                println!("Error: event state different than what is send: \nExpected: {:?}, \nReceived: {:?}", event_state.state, view_payload.state);
+                std::process::exit(1);
+            }
+            let event_state_err = event_states.pop().expect("No State");
+            let event_state_err_status = event_state_err.clone().state.expect("No RequestState").status;
+            if driver {
+                if request_state::Status::from_i32(event_state_err_status.clone()).expect("No Valid Status") != request_state::Status::EventWriteError {
+                    println!("Error: event status not correct: expected 6, received {:?}", event_state_err_status);
+                    std::process::exit(1);
+                }
+            } else {
+                if request_state::Status::from_i32(event_state_err_status.clone()).expect("No Valid Status") != request_state::Status::Error {
+                    println!("Error: event status not correct: expected 2, received {:?}", event_state_err_status);
+                    std::process::exit(1);
+                }
+            }
+            let event_state_err_json = serde_json::to_string(&event_state_err.clone().state.expect("No RequestState").state);
+            let view_payload_err_json = serde_json::to_string(&view_payload_err.clone().state);
+            if event_state_err_json.expect("stringify error") != view_payload_err_json.expect("stringify error") {
+                println!("Error: event state different than what is send: \nExpected: {:?}, \nReceived: {:?}", event_state_err.state, view_payload_err.state);
+                std::process::exit(1);
+            }
+        },
+        Err(error) => {
+            println!("An error occurred while getting event states: {:?}.", error);
+            std::process::exit(1);
+        }
+    }
+    
+    let request_2 = tonic::Request::new(GetStateMessage {
+        request_id: request_id.to_string(),
+    });
+    // Check if states are deleted after first fetch.
+    let event_states_res = network_client.get_event_states(request_2).await;
+    match event_states_res {
+        Ok(response) => {
+            let mut event_states = response.into_inner().states;
+            println!("Received States 2nd: {:?}", event_states);
+            let event_state = event_states.pop().expect("No State");
+            let event_state_status = event_state.state.expect("No RequestState").status;
+            if request_state::Status::from_i32(event_state_status.clone()).expect("No Valid Status") != request_state::Status::Deleted {
+                println!("Error: event status not correct: expected 7, received {:?}", event_state_status);
+                std::process::exit(1);
+            }
+            let event_state_err = event_states.pop().expect("No State");
+            let event_state_err_status = event_state_err.state.expect("No RequestState").status;
+            if request_state::Status::from_i32(event_state_err_status.clone()).expect("No Valid Status") != request_state::Status::Deleted {
+                println!("Error: event status not correct: expected 7, received {:?}", event_state_err_status);
+                std::process::exit(1);
+            }
+        },
+        Err(error) => {
+            println!("An error occurred while getting event states: {:?}.", error);
+            std::process::exit(1);
+        }
+    }
+    
     Ok(())
 }

--- a/weaver/core/relay/src/main.rs
+++ b/weaver/core/relay/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let identity = Identity::from_pem(cert, key);
         // Spins up two gRPC services in a tonic server. One for relay to relay and one for network to relay communication.
         let server = Server::builder()
-            .tls_config(ServerTlsConfig::new().identity(identity))
+            .tls_config(ServerTlsConfig::new().identity(identity))?
             .add_service(DataTransferServer::new(relay))
             .add_service(EventSubscribeServer::new(event_subscribe))
             .add_service(EventPublishServer::new(event_publish))

--- a/weaver/core/relay/src/services/data_transfer_service.rs
+++ b/weaver/core/relay/src/services/data_transfer_service.rs
@@ -322,8 +322,8 @@ fn spawn_send_state(state: ViewPayload, requestor_host: String, requester_port: 
                 .ca_certificate(ca)
                 .domain_name(requestor_host);
 
-            let channel = Channel::from_shared(client_addr).unwrap()
-                .tls_config(tls)
+            let channel = Channel::from_shared(client_addr.to_string()).unwrap()
+                .tls_config(tls).expect(&format!("Error in TLS configuration for client: {}", client_addr.to_string()))
                 .connect()
                 .await
                 .unwrap();

--- a/weaver/core/relay/src/services/event_publish_service.rs
+++ b/weaver/core/relay/src/services/event_publish_service.rs
@@ -164,8 +164,8 @@ fn spawn_send_state(state: ViewPayload, requestor_host: String, requester_port: 
                 .ca_certificate(ca)
                 .domain_name(requestor_host);
 
-            let channel = Channel::from_shared(client_addr).unwrap()
-                .tls_config(tls)
+            let channel = Channel::from_shared(client_addr.to_string()).unwrap()
+                .tls_config(tls).expect(&format!("Error in TLS configuration for client: {}", client_addr.to_string()))
                 .connect()
                 .await
                 .unwrap();

--- a/weaver/core/relay/src/services/event_subscribe_service.rs
+++ b/weaver/core/relay/src/services/event_subscribe_service.rs
@@ -290,7 +290,7 @@ fn spawn_send_subscription_status(
                 .domain_name(requestor_host);
 
             let channel = Channel::from_shared(client_addr.clone()).unwrap()
-                .tls_config(tls)
+                .tls_config(tls).expect(&format!("Error in TLS configuration for client: {}", client_addr.to_string()))
                 .connect()
                 .await
                 .unwrap();

--- a/weaver/core/relay/src/services/helpers.rs
+++ b/weaver/core/relay/src/services/helpers.rs
@@ -233,7 +233,7 @@ pub async fn get_driver_client(
             .domain_name(hostname);
 
         let channel = Channel::from_shared(driver_address).unwrap()
-            .tls_config(tls)
+            .tls_config(tls)?
             .connect()
             .await
             .unwrap();

--- a/weaver/core/relay/src/services/network_service.rs
+++ b/weaver/core/relay/src/services/network_service.rs
@@ -635,7 +635,7 @@ async fn data_transfer_call(
             .domain_name(relay_host);
 
         let channel = Channel::from_shared(client_addr)?
-            .tls_config(tls)
+            .tls_config(tls)?
             .connect()
             .await?;
 
@@ -745,7 +745,7 @@ async fn suscribe_event_call(
             .domain_name(relay_host);
     
         let channel = Channel::from_shared(client_addr)?
-            .tls_config(tls)
+            .tls_config(tls)?
             .connect()
             .await?;
     

--- a/weaver/sdks/corda/src/main/kotlin/org/hyperledger/cacti/weaver/corda/sdk/InteroperableHelper.kt
+++ b/weaver/sdks/corda/src/main/kotlin/org/hyperledger/cacti/weaver/corda/sdk/InteroperableHelper.kt
@@ -325,7 +325,7 @@ class InteroperableHelper {
          * @return Returns the request state when it has status "COMPLETED" or "ERROR".
          */
         suspend fun pollForState(requestId: String, client: RelayClient, retryCount: Int = 0): Either<Error, State.RequestState> = coroutineScope {
-            val num = 10
+            val num = 30
             if (retryCount > num) {
                 Left(Error("Error: Timeout, remote network took longer than $num seconds to respond"))
             } else {

--- a/weaver/sdks/fabric/interoperation-node-sdk/src/Relay.ts
+++ b/weaver/sdks/fabric/interoperation-node-sdk/src/Relay.ts
@@ -172,6 +172,7 @@ class Relay {
             if (dateObj.getTime() < Date.now()) {
                 throw new Error("Timeout: State is still pending.");
             } else {
+                await helpers.delay(1000);
                 return await this.recursiveState(requestID, dateObj);
             }
         } else {
@@ -305,6 +306,7 @@ class Relay {
             if (dateObj.getTime() < Date.now()) {
                 throw new Error("Timeout: State is still pending.");
             } else {
+                await helpers.delay(1000);
                 return await this.recursiveEventSubscriptionState(requestID, dateObj);
             }
         } else {

--- a/weaver/sdks/fabric/interoperation-node-sdk/src/helpers.ts
+++ b/weaver/sdks/fabric/interoperation-node-sdk/src/helpers.ts
@@ -47,4 +47,8 @@ function parseAddress(address: string): { locationSegment: string; viewSegment: 
     };
 }
 
-export { handlePromise, promisifyAll, parseAddress };
+async function delay(ms: number) {
+    await new Promise(f => setTimeout(f, ms));
+}
+
+export { handlePromise, promisifyAll, parseAddress, delay };


### PR DESCRIPTION
    Additionally:
    - upgrade other dependencies for relay
    - added tls based unit test in relay

Closes #2349 

Replaces #2351 which I closed by accident