### PR TITLE
fix(iroha2-connector): fix flaky tests to solve #2370 and #2373

### DIFF
--- a/packages/cactus-plugin-ledger-connector-iroha2/src/test/typescript/integration/iroha2-generate-and-send-signed-transaction.test.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/test/typescript/integration/iroha2-generate-and-send-signed-transaction.test.ts
@@ -25,7 +25,6 @@ import {
 import {
   generateTestIrohaCredentials,
   IrohaV2TestEnv,
-  waitForCommit,
 } from "../test-helpers/iroha2-env-setup";
 import { addRandomSuffix } from "../test-helpers/utils";
 
@@ -160,17 +159,15 @@ describe("Generate and send signed transaction tests", () => {
     // 3. Send
     const transactionResponse = await env.apiClient.transactV1({
       signedTransaction,
+      waitForCommit: true,
       baseConfig: env.defaultBaseConfig,
     });
     expect(transactionResponse).toBeTruthy();
     expect(transactionResponse.status).toEqual(200);
     expect(transactionResponse.data.rejectReason).toBeUndefined();
     expect(transactionResponse.data.status).toEqual(
-      TransactionStatusV1.Submitted,
+      TransactionStatusV1.Committed,
     );
-
-    // Sleep
-    await waitForCommit();
 
     // Check if domain was created
     await assertDomainExistence(domainName);

--- a/packages/cactus-plugin-ledger-connector-iroha2/src/test/typescript/integration/iroha2-setup-and-basic-operations.test.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha2/src/test/typescript/integration/iroha2-setup-and-basic-operations.test.ts
@@ -32,7 +32,6 @@ import { setCrypto } from "@iroha2/client";
 import {
   IrohaV2TestEnv,
   generateTestIrohaCredentials,
-  waitForCommit,
 } from "../test-helpers/iroha2-env-setup";
 import { addRandomSuffix } from "../test-helpers/utils";
 
@@ -110,46 +109,6 @@ describe("Setup and basic endpoint tests", () => {
       await defaultConfigConnector.createClient(requestConfig)
     ).toriiOptions;
     expect(overwrittenConfig).toEqual(requestConfig.torii);
-  });
-
-  test("Simple transaction without waiting and query endpoints works", async () => {
-    const domainName = addRandomSuffix("singleTxTest");
-
-    // Create new domain
-    const transactionResponse = await env.apiClient.transactV1({
-      transaction: {
-        instruction: {
-          name: IrohaInstruction.RegisterDomain,
-          params: [domainName],
-        },
-      },
-      baseConfig: env.defaultBaseConfig,
-    });
-    expect(transactionResponse).toBeTruthy();
-    expect(transactionResponse.status).toEqual(200);
-    expect(transactionResponse.data.status).toBeTruthy();
-    expect(transactionResponse.data.status).toEqual(
-      TransactionStatusV1.Submitted,
-    );
-    expect(transactionResponse.data.hash).toBeTruthy();
-    expect(transactionResponse.data.hash.length).toEqual(64);
-
-    // Sleep
-    await waitForCommit();
-
-    // Query it
-    const queryResponse = await env.apiClient.queryV1({
-      query: {
-        query: IrohaQuery.FindDomainById,
-        params: [domainName],
-      },
-      baseConfig: env.defaultBaseConfig,
-    });
-    expect(queryResponse).toBeTruthy();
-    expect(queryResponse.data).toBeTruthy();
-    expect(queryResponse.data.response).toBeTruthy();
-    expect(queryResponse.data.response.id).toBeTruthy();
-    expect(queryResponse.data.response.id.name).toEqual(domainName);
   });
 
   test("Waiting for transaction commit returns it's status", async () => {


### PR DESCRIPTION
- Use waitForCommit for all transactions used in test suites to prevent spurious CI test failures.

Closes: #2370
Closes: #2373