### PR TITLE
fix(keychain-memory-wasm): wee_alloc is Unmaintained GHSA-rc23-xxgq-x27g

### DIFF
--- a/packages/cactus-plugin-keychain-memory-wasm/src/main/rust/cactus-plugin-keychain-memory-wasm/Cargo.toml
+++ b/packages/cactus-plugin-keychain-memory-wasm/src/main/rust/cactus-plugin-keychain-memory-wasm/Cargo.toml
@@ -23,13 +23,6 @@ wasm-bindgen-futures = "0.4.28"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-#
-# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.5", optional = true }
-
 js-sys = "0.3.55"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"

--- a/packages/cactus-plugin-keychain-memory-wasm/src/main/rust/cactus-plugin-keychain-memory-wasm/README.md
+++ b/packages/cactus-plugin-keychain-memory-wasm/src/main/rust/cactus-plugin-keychain-memory-wasm/README.md
@@ -65,5 +65,3 @@ wasm-pack publish
   between WebAssembly and JavaScript.
 * [`console_error_panic_hook`](https://github.com/rustwasm/console_error_panic_hook)
   for logging panic messages to the developer console.
-* [`wee_alloc`](https://github.com/rustwasm/wee_alloc), an allocator optimized
-  for small code size.

--- a/packages/cactus-plugin-keychain-memory-wasm/src/main/rust/cactus-plugin-keychain-memory-wasm/src/lib.rs
+++ b/packages/cactus-plugin-keychain-memory-wasm/src/main/rust/cactus-plugin-keychain-memory-wasm/src/lib.rs
@@ -4,12 +4,6 @@ use std::collections::HashMap;
 use serde::{Serialize, Deserialize};
 use wasm_bindgen::prelude::*;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 // We have to allow snake case because the JS side expects it.
 #[allow(non_snake_case)]
 #[wasm_bindgen]


### PR DESCRIPTION
Removed wee_alloc from being used entirely.
The default Rust allocator will be used instead
which is better maintained and poses less
of a security threat.

Fixes #2352

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>