### PR TITLE
chore(ci): publish weaver go modules

### DIFF
--- a/.github/workflows/test_weaver-pre-release.yaml
+++ b/.github/workflows/test_weaver-pre-release.yaml
@@ -130,26 +130,40 @@ jobs:
         working-directory: weaver/core/relay
         
       # GO
-      # - name: check weaver/common/protos-go/VERSION
-      #   run: cat VERSION | grep $VERSION || exit 1
-      #   working-directory: weaver/common/protos-go
-      # 
-      # - name: check weaver/core/network/fabric-interop-cc/libs/utils/VERSION
-      #   run: cat VERSION | grep $VERSION || exit 1
-      #   working-directory: weaver/core/network/fabric-interop-cc/libs/utils
-      # 
-      # - name: check weaver/core/network/fabric-interop-cc/libs/assetexchange/VERSION
-      #   run: cat VERSION | grep $VERSION || exit 1
-      #   working-directory: weaver/core/network/fabric-interop-cc/libs/assetexchange
-      # 
-      # - name: check weaver/core/network/fabric-interop-cc/interfaces/asset-mgmt/VERSION
-      #   run: cat VERSION | grep $VERSION || exit 1
-      #   working-directory: weaver/core/network/fabric-interop-cc/interfaces/asset-mgmt
-      # 
-      # - name: check weaver/core/network/fabric-interop-cc/contracts/interop/VERSION
-      #   run: cat VERSION | grep $VERSION || exit 1
-      #   working-directory: weaver/core/network/fabric-interop-cc/contracts/interop
-      # 
-      # - name: check weaver/sdks/fabric/go-sdk/VERSION
-      #   run: cat VERSION | grep $VERSION || exit 1
-      #   working-directory: weaver/sdks/fabric/go-sdk
+      - name: check weaver/common/protos-go/VERSION
+        run: cat VERSION | grep $VERSION || exit 1
+        working-directory: weaver/common/protos-go
+      
+      - name: check weaver/core/network/fabric-interop-cc/libs/utils/VERSION
+        run: cat VERSION | grep $VERSION || exit 1
+        working-directory: weaver/core/network/fabric-interop-cc/libs/utils
+      
+      - name: check weaver/core/network/fabric-interop-cc/libs/assetexchange/VERSION
+        run: cat VERSION | grep $VERSION || exit 1
+        working-directory: weaver/core/network/fabric-interop-cc/libs/assetexchange
+      
+      - name: check weaver/core/network/fabric-interop-cc/interfaces/asset-mgmt/VERSION
+        run: cat VERSION | grep $VERSION || exit 1
+        working-directory: weaver/core/network/fabric-interop-cc/interfaces/asset-mgmt
+      
+      - name: check weaver/core/network/fabric-interop-cc/contracts/interop/VERSION
+        run: cat VERSION | grep $VERSION || exit 1
+        working-directory: weaver/core/network/fabric-interop-cc/contracts/interop
+      
+      - name: check weaver/sdks/fabric/go-sdk/VERSION
+        run: cat VERSION | grep $VERSION || exit 1
+        working-directory: weaver/sdks/fabric/go-sdk
+
+  test_weaver_go_pre-release:
+    needs: check_release
+    if: needs.check_release.outputs.status == 'continue'
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3.1.0
+      
+      - name: Update GO Checksum
+        run: sh go-gen-checksum.sh
+      
+      - name: Check if changes are committed
+        run: (git status | grep "nothing to commit, working tree clean") || (echo "go-gen-checksum not called before release commit" && exit 1)

--- a/.github/workflows/weaver_deploy_corda-pkgs.yml
+++ b/.github/workflows/weaver_deploy_corda-pkgs.yml
@@ -52,7 +52,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          sed -i "s#version=.*#version=${VERSION}#g" gradle.properties
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            sed -i "s#version=.*#version=${VERSION}#g" gradle.properties
+          fi
           cat gradle.properties
         working-directory: weaver/common/protos-java-kt
         
@@ -98,7 +101,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          sed -i "s#version=.*#version=${VERSION}#g" gradle.properties
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            sed -i "s#version=.*#version=${VERSION}#g" gradle.properties
+          fi
           cat gradle.properties
         working-directory: weaver/core/network/corda-interop-app
         
@@ -147,7 +153,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          sed -i "s#version=.*#version=${VERSION}#g" gradle.properties
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            sed -i "s#version=.*#version=${VERSION}#g" gradle.properties
+          fi
           cat gradle.properties
         working-directory: weaver/sdks/corda
         
@@ -197,7 +206,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          echo -n $VERSION > VERSION
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
           cat VERSION
         working-directory: weaver/core/drivers/corda-driver
 

--- a/.github/workflows/weaver_deploy_go-pkgs.yml
+++ b/.github/workflows/weaver_deploy_go-pkgs.yml
@@ -6,15 +6,17 @@ name: Deploy Go Modules
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'common/protos-go/VERSION'
-      - 'core/network/fabric-interop-cc/libs/utils/VERSION'
-      - 'core/network/fabric-interop-cc/libs/assetexchange/VERSION'
-      - 'core/network/fabric-interop-cc/interfaces/asset-mgmt/VERSION'
-      - 'core/network/fabric-interop-cc/contracts/interop/VERSION'
-      - 'sdks/fabric/go-sdk/VERSION'
+    # branches:
+    #   - main
+    # paths:
+    #   - 'common/protos-go/VERSION'
+    #   - 'core/network/fabric-interop-cc/libs/utils/VERSION'
+    #   - 'core/network/fabric-interop-cc/libs/assetexchange/VERSION'
+    #   - 'core/network/fabric-interop-cc/interfaces/asset-mgmt/VERSION'
+    #   - 'core/network/fabric-interop-cc/contracts/interop/VERSION'
+    #   - 'sdks/fabric/go-sdk/VERSION'
+    tags:
+      - v*
       
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -34,6 +36,18 @@ jobs:
         run: |
           echo "MODULE_TAG=common/protos-go" >> $GITHUB_ENV
           echo "MODULE_DESC=GO Weaver Protos" >> $GITHUB_ENV
+        
+      - name: Update version
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
+          cat VERSION
+        working-directory: weaver/common/protos-go
         
       - name: Set module version
         run: echo "VERSION=v$(cat VERSION)" >> $GITHUB_ENV
@@ -84,6 +98,18 @@ jobs:
         run: |
           echo "MODULE_TAG=core/network/fabric-interop-cc/libs/utils" >> $GITHUB_ENV
           echo "MODULE_DESC=GO Fabric Utils Library for Interoperation" >> $GITHUB_ENV
+        
+      - name: Update version
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
+          cat VERSION
+        working-directory: weaver/core/network/fabric-interop-cc/libs/utils
         
       - name: Set module version
         run: echo "VERSION=v$(cat VERSION)" >> $GITHUB_ENV
@@ -139,6 +165,18 @@ jobs:
           echo "MODULE_TAG=core/network/fabric-interop-cc/libs/assetexchange" >> $GITHUB_ENV
           echo "MODULE_DESC=GO Fabric Library for Asset Exchange" >> $GITHUB_ENV
         
+      - name: Update version
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
+          cat VERSION
+        working-directory: weaver/core/network/fabric-interop-cc/libs/assetexchange
+        
       - name: Set module version
         run: echo "VERSION=v$(cat VERSION)" >> $GITHUB_ENV
         working-directory: weaver/core/network/fabric-interop-cc/libs/assetexchange
@@ -192,6 +230,18 @@ jobs:
         run: |
           echo "MODULE_TAG=core/network/fabric-interop-cc/interfaces/asset-mgmt" >> $GITHUB_ENV
           echo "MODULE_DESC=GO Fabric Asset Management Interface" >> $GITHUB_ENV
+        
+      - name: Update version
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
+          cat VERSION
+        working-directory: weaver/core/network/fabric-interop-cc/interfaces/asset-mgmt
         
       - name: Set module version
         run: echo "VERSION=v$(cat VERSION)" >> $GITHUB_ENV
@@ -247,6 +297,18 @@ jobs:
           echo "MODULE_TAG=core/network/fabric-interop-cc/contracts/interop" >> $GITHUB_ENV
           echo "MODULE_DESC=GO Fabric Interop Chaincode" >> $GITHUB_ENV
         
+      - name: Update version
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
+          cat VERSION
+        working-directory: weaver/core/network/fabric-interop-cc/contracts/interop
+        
       - name: Set module version
         run: echo "VERSION=v$(cat VERSION)" >> $GITHUB_ENV
         working-directory: weaver/core/network/fabric-interop-cc/contracts/interop
@@ -300,6 +362,18 @@ jobs:
         run: |
             echo "MODULE_TAG=sdks/fabric/go-sdk" >> $GITHUB_ENV
             echo "MODULE_DESC=GO Fabric Weaver SDK" >> $GITHUB_ENV
+          
+      - name: Update version
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
+          cat VERSION
+        working-directory: weaver/sdks/fabric/go-sdk
         
       - name: Set module version
         run: echo "VERSION=v$(cat VERSION)" >> $GITHUB_ENV

--- a/.github/workflows/weaver_deploy_node-pkgs.yml
+++ b/.github/workflows/weaver_deploy_node-pkgs.yml
@@ -54,7 +54,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          sed -i "s#\"version\":.*#\"version\": \"${VERSION}\"#g" package.json
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            sed -i "s#\"version\":.*#\"version\": \"${VERSION}\"#g" package.json
+          fi
           head -4 package.json
         working-directory: weaver/common/protos-js
         
@@ -110,7 +113,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          sed -i "s#\"version\":.*#\"version\": \"${VERSION}\"#g" package.json
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            sed -i "s#\"version\":.*#\"version\": \"${VERSION}\"#g" package.json
+          fi
           head -4 package.json
         working-directory: weaver/sdks/fabric/interoperation-node-sdk
         
@@ -164,7 +170,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          sed -i "s#\"version\":.*#\"version\": \"${VERSION}\"#g" package.json
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            sed -i "s#\"version\":.*#\"version\": \"${VERSION}\"#g" package.json
+          fi
           head -4 package.json
         working-directory: weaver/sdks/besu/node
         
@@ -220,7 +229,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          echo -n $VERSION > VERSION
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
           cat VERSION
         working-directory: weaver/core/drivers/fabric-driver
 
@@ -269,7 +281,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          echo -n $VERSION > VERSION
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
           cat VERSION
         working-directory: weaver/core/identity-management/iin-agent
 

--- a/.github/workflows/weaver_deploy_relay-server.yml
+++ b/.github/workflows/weaver_deploy_relay-server.yml
@@ -41,7 +41,10 @@ jobs:
             VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
             # Strip "v" prefix from tag name
             [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-            sed -i "s#^version\s*=.*#version = ${VERSION}#g" Cargo.toml
+            echo $VERSION
+            if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+              sed -i "s#^version\s*=.*#version = ${VERSION}#g" Cargo.toml
+            fi
             head -4 Cargo.toml
           working-directory: weaver/common/protos-rs/pkg
             
@@ -75,7 +78,10 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          echo -n $VERSION > VERSION
+          echo $VERSION
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z\-]*$ ]]; then
+            echo -n $VERSION > VERSION
+          fi
           cat VERSION
         working-directory: weaver/core/relay
           

--- a/tools/go-gen-checksum.sh
+++ b/tools/go-gen-checksum.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Root of repo
+ROOT_DIR='..'
+
+# Repo full go path
+REPO='github.com/hyperledger/cacti'
+
+# install go-checksum
+go install github.com/vikyd/go-checksum@latest
+
+GOMODULE_PATHS=("weaver/core/network/fabric-interop-cc/libs/utils"
+"weaver/core/network/fabric-interop-cc/libs/assetexchange"
+"weaver/core/network/fabric-interop-cc/interfaces/asset-mgmt"
+"weaver/core/network/fabric-interop-cc/contracts/interop"
+"weaver/sdks/fabric/go-sdk"
+"weaver/samples/fabric/go-cli"
+"weaver/samples/fabric/simpleasset"
+"weaver/samples/fabric/simpleassetandinterop"
+"weaver/samples/fabric/simpleassettransfer"
+"weaver/samples/fabric/simplestatewithacl"
+"weaver/samples/fabric/simplestate")
+
+for GOMODULE in ${GOMODULE_PATHS[@]}; do
+  echo "############# START $GOMODULE ################"
+  cd $ROOT_DIR/$GOMODULE
+  GOMOD_DEPS=$(go mod graph | grep "$REPO/$GOMODULE $REPO" | cut -d ' ' -f 2)
+  cd - > /dev/null
+
+  for GOMOD_DEP in ${GOMOD_DEPS[@]}; do
+    echo "--------- START DEP -----------"
+    GOMOD_PATH=$(echo $GOMOD_DEP | cut -d '@' -f 1 | awk -F "$REPO/" '{print $2}')
+    echo DEP: $GOMOD_DEP
+    echo DEP: $GOMOD_PATH
+    cp $ROOT_DIR/LICENSE $ROOT_DIR/$GOMOD_PATH
+    cd $ROOT_DIR/$GOMOD_PATH
+    GOMOD_NAME="$REPO/$GOMOD_PATH"
+    if [ ! -f VERSION ]; then
+      echo "INFO: VERSION absent"
+      popd
+      echo "------------ END --------------"
+      continue
+    fi
+    GOMOD_VERSION=v$(cat VERSION)
+    GOMOD_SUM=$(go-checksum . $GOMOD_NAME@$GOMOD_VERSION | grep "GoCheckSum" | cut -d ' ' -f 2 | cut -d '"' -f 2)
+    GOMOD_DOTMOD_SUM=$(go-checksum go.mod | grep "GoCheckSum" | cut -d ' ' -f 2 | cut -d '"' -f 2)
+    GOMOD_SUM_ENTRY="$GOMOD_NAME $GOMOD_VERSION $GOMOD_SUM"
+    GOMOD_DOTMOD_SUM_ENTRY="$GOMOD_NAME $GOMOD_VERSION/go.mod $GOMOD_DOTMOD_SUM"
+    echo GOSUM: $GOMOD_SUM_ENTRY
+    echo GOSUM: $GOMOD_DOTMOD_SUM_ENTRY
+    cd - > /dev/null
+    rm $ROOT_DIR/$GOMOD_PATH/LICENSE
+    
+    cd $ROOT_DIR/$GOMODULE
+    UPDATE=false
+    (cat go.mod | grep -q "$GOMOD_NAME $GOMOD_VERSION") || UPDATE=True
+    if $UPDATE; then
+      go mod edit -require $GOMOD_NAME@$GOMOD_VERSION
+    else
+      echo "ERROR: Version $GOMOD_VERSION already there in go.mod, skipping $GOMOD_PATH in $GOMODULE"
+    fi
+    UPDATE=false
+    (cat go.sum | grep -q "$GOMOD_SUM_ENTRY") || UPDATE=True
+    (cat go.sum | grep -q "$GOMOD_DOTMOD_SUM_ENTRY") || UPDATE=True
+    if $UPDATE; then
+      # mv go.sum go.sum.old
+      # grep -v "$GOMOD_NAME $GOMOD_VERSION" go.sum.old > go.sum
+      echo $GOMOD_SUM_ENTRY >> go.sum
+      echo $GOMOD_DOTMOD_SUM_ENTRY >> go.sum
+    else
+      echo "ERROR: Version $GOMOD_VERSION already there in go.sum, skipping $GOMOD_PATH in $GOMODULE"
+    fi
+    cd - > /dev/null
+    echo "------------ END --------------"
+  done
+  echo "############# END $GOMODULE ################\n"
+done

--- a/weaver/core/network/fabric-interop-cc/contracts/interop/VERSION
+++ b/weaver/core/network/fabric-interop-cc/contracts/interop/VERSION
@@ -1,1 +1,1 @@
-1.5.8
+v2.0.0-alpha-prerelease

--- a/weaver/core/network/fabric-interop-cc/interfaces/asset-mgmt/VERSION
+++ b/weaver/core/network/fabric-interop-cc/interfaces/asset-mgmt/VERSION
@@ -1,1 +1,1 @@
-1.5.7
+v2.0.0-alpha-prerelease

--- a/weaver/core/network/fabric-interop-cc/libs/assetexchange/VERSION
+++ b/weaver/core/network/fabric-interop-cc/libs/assetexchange/VERSION
@@ -1,1 +1,1 @@
-1.5.8
+v2.0.0-alpha-prerelease

--- a/weaver/core/network/fabric-interop-cc/libs/utils/VERSION
+++ b/weaver/core/network/fabric-interop-cc/libs/utils/VERSION
@@ -1,1 +1,1 @@
-1.5.6
+v2.0.0-alpha-prerelease


### PR DESCRIPTION
Chore:
- chore(ci): publish weaver go modules
   This way of publishing all go modules in single commit will work as long as in the release commit, only version files are changed and script `go-gen-checksum.sh` in root directory is run, and no other changes are made between that commit and actual releasing (i.e. no other PR is merged affecting these go modules till release PR is merged).

Fixes:
- fix(ci): update version only if tag has version