### PR TITLE
style(examples): 2021-09-20 linter warnings batch 17 / 26; part 2

### DIFF
--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/model/converter/bamboo-harvest-converter.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/model/converter/bamboo-harvest-converter.ts
@@ -1,4 +1,5 @@
 import { BambooHarvest } from "../../generated/openapi/typescript-axios";
+import { RuntimeError } from "run-time-error";
 
 /**
  * Responsible for converting model entities such as the `BambooHarvest` to and
@@ -21,17 +22,44 @@ export class BambooHarvestConverter {
    * @param arr The array containing the values of properties describing a
    * `BambooHarvest` model entity.
    */
-  public static ofSolidityStruct(arr: any[]): BambooHarvest {
+  public static ofSolidityStruct(arr: unknown[]): BambooHarvest {
+    const id = arr[BambooHarvestConverter.SOLIDITY_FIELD_ID];
+    if (typeof id !== "string") {
+      const errMsg = `Expected the value of arr[${BambooHarvestConverter.SOLIDITY_FIELD_ID}] to be a string`;
+      throw new RuntimeError(errMsg);
+    }
+    const location = arr[BambooHarvestConverter.SOLIDITY_FIELD_LOCATION];
+    if (typeof location !== "string") {
+      const errMsg = `Expected the value of arr[${BambooHarvestConverter.SOLIDITY_FIELD_LOCATION}] to be a string`;
+      throw new RuntimeError(errMsg);
+    }
+    const startedAt = arr[BambooHarvestConverter.SOLIDITY_FIELD_STARTED_AT];
+    if (typeof startedAt !== "string") {
+      const errMsg = `Expected the value of arr[${BambooHarvestConverter.SOLIDITY_FIELD_STARTED_AT}] to be a string`;
+      throw new RuntimeError(errMsg);
+    }
+    const endedAt = arr[BambooHarvestConverter.SOLIDITY_FIELD_ENDED_AT];
+    if (typeof endedAt !== "string") {
+      const errMsg = `Expected the value of arr[${BambooHarvestConverter.SOLIDITY_FIELD_ENDED_AT}] to be a string`;
+      throw new RuntimeError(errMsg);
+    }
+    const harvester = arr[BambooHarvestConverter.SOLIDITY_FIELD_HARVESTER];
+    if (typeof harvester !== "string") {
+      const errMsg = `Expected the value of arr[${BambooHarvestConverter.SOLIDITY_FIELD_HARVESTER}] to be a string`;
+      throw new RuntimeError(errMsg);
+    }
     return {
-      id: arr[BambooHarvestConverter.SOLIDITY_FIELD_ID],
-      location: arr[BambooHarvestConverter.SOLIDITY_FIELD_LOCATION],
-      startedAt: arr[BambooHarvestConverter.SOLIDITY_FIELD_STARTED_AT],
-      endedAt: arr[BambooHarvestConverter.SOLIDITY_FIELD_ENDED_AT],
-      harvester: arr[BambooHarvestConverter.SOLIDITY_FIELD_HARVESTER],
+      id,
+      location,
+      startedAt,
+      endedAt,
+      harvester,
     };
   }
 
-  public static ofSolidityStructList(arrayOfArrays: any[][]): BambooHarvest[] {
+  public static ofSolidityStructList(
+    arrayOfArrays: unknown[][],
+  ): BambooHarvest[] {
     return arrayOfArrays.map(BambooHarvestConverter.ofSolidityStruct);
   }
 }

--- a/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/model/converter/bookshelf-converter.ts
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/src/main/typescript/model/converter/bookshelf-converter.ts
@@ -1,4 +1,5 @@
 import { Bookshelf } from "../../generated/openapi/typescript-axios/index";
+import { RuntimeError } from "run-time-error";
 
 /**
  * Responsible for converting model entities such as the `Bookshelf` to and
@@ -19,15 +20,31 @@ export class BookshelfConverter {
    * @param arr The array containing the values of properties describing a
    * `Bookshelf` model entity.
    */
-  public static ofSolidityStruct(arr: any[]): Bookshelf {
+  public static ofSolidityStruct(arr: unknown[]): Bookshelf {
+    const id = arr[BookshelfConverter.SOLIDITY_FIELD_ID];
+    if (typeof id !== "string") {
+      const errMsg = `Expected the value of arr[${BookshelfConverter.SOLIDITY_FIELD_ID}] to be a string`;
+      throw new RuntimeError(errMsg);
+    }
+    const shelfCount = arr[BookshelfConverter.SOLIDITY_FIELD_SHELF_COUNT];
+    if (typeof shelfCount !== "number") {
+      const errMsg = `Expected the value of arr[${BookshelfConverter.SOLIDITY_FIELD_SHELF_COUNT}] to be a number`;
+      throw new RuntimeError(errMsg);
+    }
+    const bambooHarvestId =
+      arr[BookshelfConverter.SOLIDITY_FIELD_BAMBOO_HARVEST_ID];
+    if (typeof bambooHarvestId !== "string") {
+      const errMsg = `Expected the value of arr[${BookshelfConverter.SOLIDITY_FIELD_BAMBOO_HARVEST_ID}] to be a string`;
+      throw new RuntimeError(errMsg);
+    }
     return {
-      id: arr[BookshelfConverter.SOLIDITY_FIELD_ID],
-      shelfCount: arr[BookshelfConverter.SOLIDITY_FIELD_SHELF_COUNT],
-      bambooHarvestId: arr[BookshelfConverter.SOLIDITY_FIELD_BAMBOO_HARVEST_ID],
+      id,
+      shelfCount,
+      bambooHarvestId,
     };
   }
 
-  public static ofSolidityStructList(arrayOfArrays: any[][]): Bookshelf[] {
+  public static ofSolidityStructList(arrayOfArrays: unknown[][]): Bookshelf[] {
     return arrayOfArrays.map(BookshelfConverter.ofSolidityStruct);
   }
 }

--- a/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/bamboo-harvest-detail/bamboo-harvest-detail.page.ts
+++ b/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/bamboo-harvest-detail/bamboo-harvest-detail.page.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
+import { RuntimeError } from "run-time-error";
 
 import { Component, Inject, Input, OnInit } from "@angular/core";
 import { FormGroup, FormBuilder, Validators } from "@angular/forms";
@@ -6,9 +7,10 @@ import { ModalController } from "@ionic/angular";
 
 import { ApiClient } from "@hyperledger/cactus-api-client";
 import { BambooHarvest } from "@hyperledger/cactus-example-supply-chain-business-logic-plugin";
+import { Logger, LoggerProvider } from "@hyperledger/cactus-common";
 
 import { QUORUM_DEMO_LEDGER_ID } from "../../../constants";
-import { Logger, LoggerProvider } from "@hyperledger/cactus-common";
+import { isBambooHarvest } from "../is-bamboo-harvest";
 
 @Component({
   selector: "app-bamboo-harvest-detail",
@@ -52,8 +54,12 @@ export class BambooHarvestDetailPage implements OnInit {
     });
   }
 
-  public onClickFormSubmit(value: any): void {
+  public onClickFormSubmit(value: unknown): void {
     this.log.debug("form submitted", value);
+    if (!isBambooHarvest(value)) {
+      const errMsg = `Expected the value to be of type BambooHarvest`;
+      throw new RuntimeError(errMsg);
+    }
     this.bambooHarvest = value;
     this.modalController.dismiss(this.bambooHarvest);
   }

--- a/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/is-bamboo-harvest.ts
+++ b/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/is-bamboo-harvest.ts
@@ -1,0 +1,12 @@
+import { BambooHarvest } from "@hyperledger/cactus-example-supply-chain-business-logic-plugin";
+
+export function isBambooHarvest(x: unknown): x is BambooHarvest {
+  return (
+    !!x &&
+    typeof (x as BambooHarvest).id === "string" &&
+    typeof (x as BambooHarvest).location === "string" &&
+    typeof (x as BambooHarvest).startedAt === "string" &&
+    typeof (x as BambooHarvest).endedAt === "string" &&
+    typeof (x as BambooHarvest).harvester === "string"
+  );
+}


### PR DESCRIPTION
1. Added a user-defined type guard to check for `BambooHarvest` types
on the front-end.
2. Additional runtime type checks during data type conversion so that
if we get invalid input it speaks up against it specifically instead of
using `any` types and generic crashes.

Fixes #2092

Co-authored-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Signed-off-by: adrianbatuto <adrian.batuto@accenture.com>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>