### PR TITLE
docs(weaver/samples): pin solc to v0.8.8 and turn off IR for Besu asset exchange

### DIFF
--- a/weaver/samples/besu/simpleasset/truffle-config.js
+++ b/weaver/samples/besu/simpleasset/truffle-config.js
@@ -5,20 +5,34 @@ module.exports = {
 			port: 9544, // 7545 - default for Ganache
 			network_id: "1338", // 4447 - default for Ganache
 			//type: "fabric-evm",
-			from: "0x3c7F5262b873F637F8AdA2B09C34624B7F5fbCBF",
+			from: "0x35D99e41ce0Aa49d1B2B62f286b9F4189df7B7ae",
 			gasPrice: 0,
-			gas: "0x1ffffffffffffe"
+			gas: "0x1ffffffffffffe",
+			verbose: true, // helps with debugging contract deployment issues
 		}
 	},
 	compilers: {
 		solc: {
-			version: "^0.8.8",
+			// Unless this is pinned to 0.8.8, some breaking changes that solc
+			// has snuck in [1][2] around 0.8.15 (for IR) are breaking the contract
+			// deployment in a way that opcodes end up in the migration contract's
+			// constructor that Besu does not recognize ("opcode INVALID") in
+			// the Besu logs and then sends back an "internal error" message
+			// via the JSON-RPC response, which is a bug IMO it should state
+			// that the user input was invalid (user input being the contract)
+			//
+			// [1]: https://docs.soliditylang.org/en/v0.8.15/ir-breaking-changes.html#semantic-only-changes
+			// [2]: https://github.com/ethereum/solidity/issues/13311#issuecomment-1199274310
+			version: "0.8.8",
 			settings: {
 				optimizer: {
 				  enabled: true,
 				  runs: 1500
 				},
-				viaIR: true,
+				// If set to true, then the following error occurs:
+				// > Compiling ./contracts/transferInterface.sol
+				// YulException: Variable var_amount_3290 is 9 slot(s) too deep inside the stack.
+				viaIR: false,
 			  }
 			
 		},

--- a/weaver/tests/network-setups/besu/scripts/setupEthSigner.sh
+++ b/weaver/tests/network-setups/besu/scripts/setupEthSigner.sh
@@ -16,7 +16,10 @@ cp ../artifacts/network$1/createKeyFile.js .
 key=`cat $Node/data/key`
 sed -i "s/<AccountPrivateKey>/$key/g" createKeyFile.js
 touch keys/keyFile_${Node}
-npm install web3
+# Without this, the npm install will fail because of conflicting dependency versions
+# that cannot be resolved properly unless "forced" (tested on Ubuntu 22.04)
+# FIXME: Eliminate the need to do an npm install out-of-bounds like this entirely.
+npm install --force web3
 node createKeyFile.js > keys/keyFile_${Node}
 rm createKeyFile.js
 cp ../artifacts/account.toml keys/


### PR DESCRIPTION
1. Without having it pinned to v0.8.8, some breaking changes that solc
has snuck in [1] [2] around v0.8.15 (for IR) are breaking the contract
deployment in a way that opcodes end up in the migration contract's
constructor that Besu does not recognize ("opcode INVALID" in the besu
logs if you set the log level to "ALL") in the Besu logs and then sends
back an "internal error" message via the JSON-RPC response, which is a
bug IMO it should state that the user input was invalid (user input
being the contract)
2. Disabled IR in the truffle (solc) config which is a step backwards
because it's a new feature of the solidity compiler that has certain
benefits to it compared to the legacy compilation mode, but enabling it
breaks the build so it just had to be done. In the future if someone
has time to do a deep dive on why exactly it's failing, then it should
be re-enabled because having the legacy compilation mode being our default
is technical debt that should be paid off rather sooner than later because
we never know how it will come back to cause different issues later on.

When IR is enabled, the following error occurs (even on the pinned v0.8.8 solc):
> Compiling ./contracts/transferInterface.sol
> YulException: Variable var_amount_3290 is 9 slot(s) too deep inside the stack.

[1] https://docs.soliditylang.org/en/v0.8.15/ir-breaking-changes.html#semantic-only-changes
[2] https://github.com/ethereum/solidity/issues/13311#issuecomment-1199274310

Fixes #2423

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>