### PR TITLE
style: changes made for fixing #1357

### DIFF
--- a/packages/cactus-common/src/main/typescript/signer-key-pairs.ts
+++ b/packages/cactus-common/src/main/typescript/signer-key-pairs.ts
@@ -2,8 +2,8 @@ import crypto from "crypto";
 import secp256k1 from "secp256k1";
 
 export interface ISignerKeyPairs {
-  privateKey: any;
-  publicKey: any;
+  privateKey: Uint8Array;
+  publicKey: Uint8Array;
 }
 
 export class Secp256k1Keys {
@@ -12,7 +12,7 @@ export class Secp256k1Keys {
    * @return Generated key pair
    */
   static generateKeyPairsBuffer(): ISignerKeyPairs {
-    let privKey: any;
+    let privKey: Uint8Array;
     // generate secp256K1 private key
     do {
       privKey = crypto.randomBytes(32);

--- a/packages/cactus-common/src/main/typescript/strings.ts
+++ b/packages/cactus-common/src/main/typescript/strings.ts
@@ -9,7 +9,7 @@ export class Strings {
     return source.replace(new RegExp(searchValue, "gm"), replaceValue);
   }
 
-  public static isString(val: any): val is string {
+  public static isString(val: unknown): val is string {
     return typeof val === "string" || val instanceof String;
   }
 

--- a/packages/cactus-common/src/test/typescript/unit/key-converter.test.ts
+++ b/packages/cactus-common/src/test/typescript/unit/key-converter.test.ts
@@ -307,7 +307,11 @@ test.skip("Test invalid from key format", async (t: Test) => {
   }, "KeyConverter#publicKeyAs Invalid KeyFormat");
 
   t.throws(() => {
-    keyConverter.publicKeyAs(keyPair.publicKey, KeyFormat.Raw, "abc" as any);
+    keyConverter.publicKeyAs(
+      keyPair.publicKey,
+      KeyFormat.Raw,
+      "abc" as KeyFormat,
+    );
   }, "KeyConverter#publicKeyAs Invalid KeyFormat");
 
   t.throws(() => {
@@ -319,7 +323,11 @@ test.skip("Test invalid from key format", async (t: Test) => {
   }, "KeyConverter#privateKeyAs Invalid KeyFormat");
 
   t.throws(() => {
-    keyConverter.privateKeyAs(keyPair.privateKey, KeyFormat.Raw, "abc" as any);
+    keyConverter.privateKeyAs(
+      keyPair.privateKey,
+      KeyFormat.Raw,
+      "abc" as KeyFormat,
+    );
   }, "KeyConverter#privateKeyAs Invalid KeyFormat");
 
   t.end();


### PR DESCRIPTION
submitting fixes for issue #1357 minus the linter warning ID 79 and 80 as they have been already solved in batch 9 #1478.
I have added types of variables and objects wherever necessary in place of 'any' and for packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts I have declared a interface for prototyping the stdOutDataHandler function.

fixes #1357
Signed-off-by: Arnab Nandi arnabnandi2002@gmail.com