### PR TITLE
build(tools): bump DinD base images - fix cgroup v2 sed: write error

### DIFF
--- a/tools/docker/besu-multi-party-all-in-one/Dockerfile
+++ b/tools/docker/besu-multi-party-all-in-one/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.3-dind
+FROM docker:24.0.2-dind
 
 ARG BESU_VERSION=21.1.2
 ARG QUORUM_VERSION=21.4.1

--- a/tools/docker/corda-all-in-one/Dockerfile
+++ b/tools/docker/corda-all-in-one/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.2-dind
+FROM docker:24.0.2-dind
 
 ARG SAMPLES_KOTLIN_SHA=30fd841dd035934bae75ab8910da3b6e3d5d6ee7
 ARG SAMPLES_KOTLIN_CORDAPP_SUB_DIR_PATH="./Advanced/obligation-cordapp/"

--- a/tools/docker/corda-all-in-one/corda-v4_8-flowdb/Dockerfile
+++ b/tools/docker/corda-all-in-one/corda-v4_8-flowdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.2-dind
+FROM docker:24.0.2-dind
 
 ARG SAMPLES_KOTLIN_SHA=30fd841dd035934bae75ab8910da3b6e3d5d6ee7
 ARG SAMPLES_KOTLIN_FLOWDB_SUB_DIR_PATH="./Basic/flow-database-access/"

--- a/tools/docker/corda-all-in-one/corda-v4_8/Dockerfile
+++ b/tools/docker/corda-all-in-one/corda-v4_8/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.2-dind
+FROM docker:24.0.2-dind
 
 # cordaVersion=4.8.5
 # cordaCoreVersion=4.8.5

--- a/tools/docker/iroha2-all-in-one/Dockerfile
+++ b/tools/docker/iroha2-all-in-one/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.21-dind
+FROM docker:24.0.2-dind
 
 ENV APP_ROOT="/app"
 ENV FREEZE_TMP_DIR="/opt/docker-freeze"

--- a/tools/docker/quorum-multi-party-all-in-one/Dockerfile
+++ b/tools/docker/quorum-multi-party-all-in-one/Dockerfile
@@ -17,7 +17,7 @@ RUN quorum-dev-quickstart --clientType goquorum --outputPath ./ --monitoring def
 # docker-compose base
 ################################
 
-FROM docker:20.10.21-dind
+FROM docker:24.0.2-dind
 
 ENV ROOT_DIR=/opt/quorum-dev-quickstart
 

--- a/tools/docker/sawtooth-all-in-one/Dockerfile
+++ b/tools/docker/sawtooth-all-in-one/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.17-dind
+FROM docker:24.0.2-dind
 
 # Install docker-compose and it's dependencies
 RUN apk update \

--- a/tools/docker/supabase-all-in-one/Dockerfile
+++ b/tools/docker/supabase-all-in-one/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.21-dind
+FROM docker:24.0.2-dind
 
 ARG SUPABSE_TAG="v0.22.10"
 


### PR DESCRIPTION
Bump the versions across the board so that all our
test container images are fixed.

Once this is merged, we can start upgrading the
images that the test cases are using (for now
they remain pinned to the previous, buggy images)

Fixes #2518

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>