### PR TITLE
ci(test-tooling): fix CI job failing due to with wasm-pack

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/rustc-container/rustc-container.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/rustc-container/rustc-container.ts
@@ -89,7 +89,7 @@ export class RustcContainer {
     this.hostSourceDir = Optional.ofNullable(opts.hostSourceDir);
     this.imageName =
       opts.imageName || "ghcr.io/hyperledger/cactus-rust-compiler";
-    this.imageTag = opts.imageTag || "2022-01-12-15d4793c---fix-1646";
+    this.imageTag = opts.imageTag || "2023-06-26-8e59648";
     this.imageFqn = `${this.imageName}:${this.imageTag}`;
     this.envVars = opts.envVars || new Map();
     this.emitContainerLogs = Bools.isBooleanStrict(opts.emitContainerLogs)


### PR DESCRIPTION
Updated the cactus-rust-compiler version to properly build the image and get the required files.

Fixes https://github.com/hyperledger/cacti/issues/2407

Signed-off-by: adrianbatuto <adrian.batuto@accenture.com>