### PR TITLE
build(codegen): fix OpenAPI TypeError: error.response.data.on is not a function

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_RUNNER_DISABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
+      YARN_TOOLS_VALIDATE_BUNDLE_NAMES_DISABLED: true
+      YARN_CUSTOM_CHECKS_DISABLED: true
     runs-on: ubuntu-20.04
     steps:
       - name: Use Node.js v16.14.2
@@ -37,6 +39,127 @@ jobs:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+  # lint clean codegen
+  yarn_lint:
+    continue-on-error: false
+    env:
+      DEV_BUILD_DISABLED: false
+      FULL_BUILD_DISABLED: true
+      JEST_TEST_RUNNER_DISABLED: false
+      TAPE_TEST_RUNNER_DISABLED: false
+      YARN_TOOLS_VALIDATE_BUNDLE_NAMES_DISABLED: true
+      YARN_CUSTOM_CHECKS_DISABLED: true
+    needs: build-dev
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Use Node.js v16.14.2
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: v16.14.2
+      - uses: actions/checkout@v3.5.2
+      - id: yarn-cache-dir-path
+        name: Get yarn cache directory path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - id: yarn-cache
+        name: Restore Yarn Cache
+        uses: actions/cache@v3.0.4
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install
+      - run: yarn lint
+  yarn_codegen:
+    continue-on-error: false
+    env:
+      DEV_BUILD_DISABLED: false
+      FULL_BUILD_DISABLED: true
+      JEST_TEST_RUNNER_DISABLED: false
+      TAPE_TEST_RUNNER_DISABLED: false
+      YARN_TOOLS_VALIDATE_BUNDLE_NAMES_DISABLED: true
+      YARN_CUSTOM_CHECKS_DISABLED: true
+    needs: build-dev
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Use Node.js v16.14.2
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: v16.14.2
+      - uses: actions/checkout@v3.5.2
+      - id: yarn-cache-dir-path
+        name: Get yarn cache directory path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - id: yarn-cache
+        name: Restore Yarn Cache
+        uses: actions/cache@v3.0.4
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install
+      - run: yarn codegen
+  yarn_custom_checks:
+    continue-on-error: false
+    env:
+      DEV_BUILD_DISABLED: false
+      FULL_BUILD_DISABLED: true
+      JEST_TEST_RUNNER_DISABLED: false
+      TAPE_TEST_RUNNER_DISABLED: false
+      YARN_TOOLS_VALIDATE_BUNDLE_NAMES_DISABLED: true
+      YARN_CUSTOM_CHECKS_DISABLED: true
+    needs: build-dev
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Use Node.js v16.14.2
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: v16.14.2
+      - uses: actions/checkout@v3.5.2
+      - id: yarn-cache-dir-path
+        name: Get yarn cache directory path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - id: yarn-cache
+        name: Restore Yarn Cache
+        uses: actions/cache@v3.0.4
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install
+      - run: yarn custom-checks
+  yarn_tools_validate_bundle_names:
+    continue-on-error: false
+    env:
+      DEV_BUILD_DISABLED: false
+      FULL_BUILD_DISABLED: true
+      JEST_TEST_RUNNER_DISABLED: false
+      TAPE_TEST_RUNNER_DISABLED: false
+      YARN_TOOLS_VALIDATE_BUNDLE_NAMES_DISABLED: true
+      YARN_CUSTOM_CHECKS_DISABLED: true
+    needs: build-dev
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Use Node.js v16.14.2
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: v16.14.2
+      - uses: actions/checkout@v3.5.2
+      - id: yarn-cache-dir-path
+        name: Get yarn cache directory path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - id: yarn-cache
+        name: Restore Yarn Cache
+        uses: actions/cache@v3.0.4
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install
+      - run: yarn tools:validate-bundle-names
   cactus-api-client:
     continue-on-error: false
     env:

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "lint": "eslint '*/*/src/**/*.{js,ts}' --quiet --fix && cspell \"*/*/src/**/*.{js,ts}\"",
     "tsc": "tsc --build --verbose",
     "codegen": "lerna run codegen",
-    "precodegen": "npm-run-all --sequential --continue-on-error --print-label --print-name codegen:warmup-*",
-    "postcodegen": "rm --force --verbose ./openapitools.json",
-    "codegen:warmup-v5.2.1": "yarn openapi-generator-cli version-manager set 5.2.1",
-    "codegen:warmup-v6.3.0": "yarn openapi-generator-cli version-manager set 6.3.0",
+    "precodegen": "npm-run-all --sequential --continue-on-error --print-label --print-name 'codegen:warmup-*'",
+    "codegen:warmup-mkdir": "make-dir ./node_modules/@openapitools/openapi-generator-cli/versions/",
+    "codegen:warmup-v5.2.1": "nwget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.2.1/openapi-generator-cli-5.2.1.jar -O ./node_modules/@openapitools/openapi-generator-cli/versions/5.2.1.jar",
+    "codegen:warmup-v6.3.0": "nwget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar -O ./node_modules/@openapitools/openapi-generator-cli/versions/6.3.0.jar",
     "watch-other": "lerna run --parallel watch",
     "watch-tsc": "tsc --build --watch",
     "watch": "run-p -r watch-*",
@@ -54,7 +54,7 @@
     "build:prod": "npm-run-all build:prod:frontend",
     "build:prod:frontend": "lerna run build:prod:frontend",
     "build:dev": "npm-run-all build:dev:backend webpack:dev:web build:dev:frontend",
-    "build:dev:backend": "npm-run-all lint clean codegen tsc build:dev:backend:postbuild",
+    "build:dev:backend": "npm-run-all tsc build:dev:backend:postbuild",
     "build:dev:frontend": "lerna run build:dev:frontend --scope=\"@hyperledger/cactus-example-supply-chain-frontend\" && lerna run build:dev:frontend --scope=\"@hyperledger/cactus-example-carbon-accounting-frontend\"",
     "build:dev:common": "lerna exec --stream --scope '*/*common' -- 'del-cli dist/** && tsc --project ./tsconfig.json && webpack --env=dev --target=node --config ../../webpack.config.js'",
     "build:dev:backend:postbuild": "lerna run build:dev:backend:postbuild",
@@ -159,7 +159,8 @@
     "typescript": "4.7.4",
     "webpack": "5.76.0",
     "webpack-bundle-analyzer": "4.4.2",
-    "webpack-cli": "4.7.2"
+    "webpack-cli": "4.7.2",
+    "wget-improved": "3.4.0"
   },
   "resolutions": {
     "ansi-html": ">0.0.8",

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -119,8 +119,17 @@ function mainTask()
     yarn configure
   fi
 
-  yarn tools:validate-bundle-names
-  yarn custom-checks
+  if [ "${YARN_TOOLS_VALIDATE_BUNDLE_NAMES_DISABLED:-false}" = "true" ]; then
+    echo "$(date +%FT%T%z) [CI] yarn tools:validate-bundle-names disabled. Skipping..."
+  else
+    yarn tools:validate-bundle-names
+  fi
+
+  if [ "${YARN_CUSTOM_CHECKS_DISABLED:-false}" = "true" ]; then
+    echo "$(date +%FT%T%z) [CI] yarn custom-checks disabled. Skipping..."
+  else
+    yarn custom-checks
+  fi
 
   if [ "${JEST_TEST_RUNNER_DISABLED:-false}" = "true" ]; then
     echo "$(date +%FT%T%z) [CI] Jest test runner disabled. Skipping..."

--- a/yarn.lock
+++ b/yarn.lock
@@ -21848,7 +21848,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@0.0.8, minimist@1.2.8, minimist@>=1.2.6, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.7:
+minimist@0.0.8, minimist@1.2.6, minimist@1.2.8, minimist@>=1.2.6, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -29694,7 +29694,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tunnel@^0.0.6:
+tunnel@0.0.6, tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
@@ -31951,6 +31951,14 @@ websocket@^1.0.32:
     typedarray-to-buffer "^3.1.5"
     utf-8-validate "^5.0.2"
     yaeti "^0.0.6"
+
+wget-improved@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/wget-improved/-/wget-improved-3.4.0.tgz#da4d2578e46c6ed8532e6d34cbdf8c7344fdd17c"
+  integrity sha512-mHCdqImHntGzaauaQrfhkcHO0sAOp9Fd/9v5PXwrvHK+nggRWG9en5UH72/WitJFv3d3iFwJSAVMrRaCjW6dAA==
+  dependencies:
+    minimist "1.2.6"
+    tunnel "0.0.6"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.5"


### PR DESCRIPTION
1. Stopped using the openapi-generator-cli package to download the .jar files
and instead went with a direct download approach after having reverse
engineered the HTTP URLs that can be used for fetching the jars from
the maven repository.
2. The above appears to be a good fix because the third party service
that was serving HTTP 504 errors was not the download link but the
version validator link (e.g. a service that can tell us whether a
specific version of the OpenAPI generator jar file exists or not). So,
now that we just download exactly the versions of the .jars that we need
there is no request sent to that other service and the problem therefore
seems to have been solved.
3. We no longer need to delete the openapitools.json file in the root
because it no longer gets created to begin with due to the change from 1
4. At this point it is really hard to tell if this is the last of this
issue with the OpenAPI generator jar files, but one can hope.
5. Attempting to speed up the CI by optimizing the build-dev job:
It is no longer doing bundle name validation nor the custom checks by
default and it also skips linting and codegen entirely which are now done
by separate jobs that can run in parallel. This should also reduce the
load we place on the public utility service that is hosting the .jar files
for the OpenAPI generator because this way the 40+ CI jobs that we have
at the moment won't each download a pair of >20 MB .jar files every time.

Fixes #2525

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>