### PR TITLE
docs(readme): fix broken VS-code badge in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+ [![Open in Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&labelColor=2c2c32&color=007acc&logoColor=007acc)](https://open.vscode.dev/hyperledger/cactus)
+ ![license](https://img.shields.io/github/license/hyperledger/cactus) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4089/badge)](https://bestpractices.coreinfrastructure.org/projects/4089)
+ ![GitHub issues](https://img.shields.io/github/issues/hyperledger/cactus)
+
 ![Cacti Logo Color](./images/HL_Cacti_Logo_Color.png#gh-light-mode-only)
 ![Cacti Logo Color](./images/HL_Cacti_Logo_Colorreverse.svg#gh-dark-mode-only)
 


### PR DESCRIPTION
1. Replaced the Open in VSCode badge to be backed by the shields.io
service which actually works.
2. Removed the codecov badge for now because it does not work
at the moment due to us having broken up the test execution into
smaller CI jobs that are separate from each other.

Fixes #2169

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>