### PR TITLE
fix(tessera): updated tessera version error in quorum-all-in-one #2411

### DIFF
--- a/tools/docker/quorum-all-in-one/Dockerfile
+++ b/tools/docker/quorum-all-in-one/Dockerfile
@@ -4,11 +4,15 @@ ARG TESSERA_VERSION=22.1.7
 FROM quorumengineering/quorum:$QUORUM_VERSION AS quorum
 FROM quorumengineering/tessera:$TESSERA_VERSION AS tessera
 
-COPY --from=quorum /usr/local/bin/geth /usr/local/bin/
 COPY --from=quorum /usr/local/bin/bootnode /usr/local/bin/
+
+#LIBSODIUM
+RUN apt-get update && apt-get install -y libsodium23
 
 # BASH
 RUN apt update && apt-get -y install bash
+RUN apt update && apt-get -y install software-properties-common
+RUN apt update && apt-get -y install tar
 
 # SUPERVISORD
 RUN apt update && apt-get -y install supervisor

--- a/tools/docker/quorum-all-in-one/start-quorum.sh
+++ b/tools/docker/quorum-all-in-one/start-quorum.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+curl -o geth-v22.7.4.tar.gz https://artifacts.consensys.net/public/go-quorum/raw/versions/v22.7.4/geth_v22.7.4_linux_amd64.tar.gz
+tar xvfz geth-v22.7.4.tar.gz
+mv geth /usr/local/bin
+
+export PATH=$PATH:/usr/local/bin
+
 UDS_WAIT=10
 for i in $(seq 1 100)
 do
@@ -32,12 +38,12 @@ geth \
   --nodiscover \
   --verbosity 2 \
   --networkid ${NETWORK_ID} \
-  --rpc \
-  --rpccorsdomain "*" \
-  --rpcvhosts "*" \
-  --rpcaddr 0.0.0.0 \
-  --rpcport 8545 \
-  --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,${QUORUM_CONSENSUS:-raft} \
+  --http \
+  --http.corsdomain "*" \
+  --http.vhosts "*" \
+  --http.addr 0.0.0.0 \
+  --http.port 8545 \
+  --http.api admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,${QUORUM_CONSENSUS:-raft} \
   --port 21000 \
   --allow-insecure-unlock \
   --unlock 0 \

--- a/tools/docker/quorum-all-in-one/start-tessera.sh
+++ b/tools/docker/quorum-all-in-one/start-tessera.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
+curl -o tessera-22.1.7.tar https://s01.oss.sonatype.org/service/local/repositories/releases/content/net/consensys/quorum/tessera/tessera-dist/22.1.7/tessera-dist-22.1.7.tar
+
 DDIR=/qdata/tm
 rm -rf ${DDIR}
 mkdir -p ${DDIR}
 cp /tm.pub ${DDIR}/tm.pub
 cp /tm.key ${DDIR}/tm.key
 
-#extract the tessera version from the jar
-TESSERA_VERSION=$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
-echo "Tessera version (extracted from manifest file): ${TESSERA_VERSION}"
+tar xvf tessera-22.1.7.tar
+export PATH=$PATH:tessera-22.1.7/bin
+
 # sorting versions to target correct configuration
 TESSERA_CONFIG_TYPE="-09"
 
@@ -65,4 +67,4 @@ cat <<EOF > ${DDIR}/tessera-config-09.json
 EOF
 
 cat ${DDIR}/tessera-config-09.json
-java -Xms128M -Xmx128M -Dverbosity=WARN -jar /tessera/tessera-app.jar -configfile ${DDIR}/tessera-config-09.json
+tessera -configfile ${DDIR}/tessera-config-09.json


### PR DESCRIPTION
fixes: #2411

related to: #2240 and #2274

Tessera version was updated and some flags were deprecated. It has been
fixed in this commit. Also, the quorum and tessera compatibility with
quorum-all-in-one. The container and image has been built and ran
successfully.