### PR TITLE
fix(plugin-odap-hermes): fix duplicate enum values of OdapMessageType

### DIFF
--- a/packages/cactus-plugin-odap-hermes/src/main/typescript/gateway/plugin-odap-gateway.ts
+++ b/packages/cactus-plugin-odap-hermes/src/main/typescript/gateway/plugin-odap-gateway.ts
@@ -101,7 +101,7 @@ export enum OdapMessageType {
   CommitPreparationRequest = "urn:ietf:odap:msgtype:commit-prepare-msg",
   CommitPreparationResponse = "urn:ietf:odap:msgtype:commit-ack-msg",
   CommitFinalRequest = "urn:ietf:odap:msgtype:commit-final-msg",
-  CommitFinalResponse = "urn:ietf:odap:msgtype:commit-ack-msg",
+  CommitFinalResponse = "urn:ietf:odap:msgtype:commit-final-ack-msg",
   TransferCompleteRequest = "urn:ietf:odap:msgtype:commit-transfer-complete-msg",
 }
 


### PR DESCRIPTION
CommitFinalResponse and CommitPreparationResponse
were accidentally having the same enum value, fixed it by
providing the correct enum value (as per the specs) for
CommitFinalResponse.

Links:
1. https://datatracker.ietf.org/doc/bofreq-hardjono-secure-asset-transfer-protocol/
2. https://www.ietf.org/archive/id/draft-hargreaves-odap-03.txt

Fixes #2553

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>