### PR TITLE
ci(tools/docker): stop compiling Iroha as part of the all-in-one image build

### DIFF
--- a/packages/cactus-plugin-ledger-connector-iroha/src/test/typescript/integration/generate-and-send-signed-transaction.test.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha/src/test/typescript/integration/generate-and-send-signed-transaction.test.ts
@@ -8,9 +8,11 @@
 // Constants
 //////////////////////////////////
 
+import { IROHA_TEST_LEDGER_DEFAULT_OPTIONS } from "@hyperledger/cactus-test-tooling";
+
 // Ledger settings
 const ledgerImageName = "ghcr.io/hyperledger/cactus-iroha-all-in-one";
-const ledgerImageVersion = "2021-08-16--1183";
+const ledgerImageVersion = IROHA_TEST_LEDGER_DEFAULT_OPTIONS.imageVersion;
 const postgresImageName = "postgres";
 const postgresImageVersion = "9.5-alpine";
 

--- a/packages/cactus-plugin-ledger-connector-iroha/src/test/typescript/integration/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha/src/test/typescript/integration/run-transaction-endpoint-v1.test.ts
@@ -37,7 +37,7 @@ import {
 import cryptoHelper from "iroha-helpers/lib/cryptoHelper";
 import { Constants } from "@hyperledger/cactus-core-api";
 
-const testCase = "runs tx on an Iroha v1.2.0 ledger";
+const testCase = "runs tx on an Iroha v1.4.0-patch-3 ledger";
 const logLevel: LogLevelDesc = "INFO";
 
 test.onFailure(async () => {
@@ -87,7 +87,7 @@ test(testCase, async (t: Test) => {
   test.onFinish(async () => {
     await iroha.stop();
   });
-  await iroha.start();
+  await iroha.start(false);
   const irohaPort = await iroha.getRpcToriiPort();
   const rpcToriiPortHost = await iroha.getRpcToriiPortHost();
   const rpcApiWsHost = await iroha.getRpcApiWsHost();

--- a/tools/docker/iroha-all-in-one/Dockerfile
+++ b/tools/docker/iroha-all-in-one/Dockerfile
@@ -1,40 +1,24 @@
-FROM ubuntu:20.04 as builder
-ARG DEBIAN_FRONTEND=noninteractive
+FROM hyperledger/iroha:1.4.0-patch-3
 
-RUN set -e && apt-get update && apt-get install -y --no-install-recommends \
-    file build-essential ninja-build ca-certificates tar curl unzip cmake pkg-config zip software-properties-common
-
-RUN add-apt-repository ppa:git-core/ppa
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends git
-
-RUN git clone https://github.com/hyperledger/iroha.git -b 1.4.0 
-RUN iroha/vcpkg/build_iroha_deps.sh
-RUN /vcpkg-build/vcpkg integrate install
-WORKDIR /iroha/build/
-
-RUN cmake -DCMAKE_TOOLCHAIN_FILE=/vcpkg-build/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TYPE=Release -DPACKAGE_DEB=ON -G "Ninja" ..
-RUN cmake --build . --target package -- -j$(nproc)
-
-FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive  
 RUN set -e && apt-get update && \   
-    apt-get install -y moreutils jq python3 python3-pip && \
+    apt-get install -y moreutils jq wget python3 python3-pip && \
     pip install iroha && \
     apt-get purge -y `apt-get -s purge python3-pip | grep '^ ' | tr -d '*'` && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
-# irohad is the core of Iroha ledger
-COPY --from=builder /iroha/build/bin/irohad /usr/bin/irohad
-# copying iroha-cli optional; only copied for debugging purpose
-COPY --from=builder /iroha/build/bin/iroha-cli /usr/bin/iroha-cli
-# files below are necessary
-COPY --from=builder /iroha/example/ /opt/iroha_data/
-COPY --from=builder /iroha/docker/release/wait-for-it.sh /
+
 COPY genesis.block /opt/iroha_data/genesis.block
 COPY entrypoint.sh healthcheck.py /
-RUN chmod +x /entrypoint.sh /wait-for-it.sh
+RUN chmod +x /entrypoint.sh
 
 WORKDIR /opt/iroha_data
+
+RUN wget https://raw.githubusercontent.com/hyperledger/iroha/v1.4.0-patch-3/example/admin%40test.pub --output-document=admin@test.pub
+RUN wget https://raw.githubusercontent.com/hyperledger/iroha/v1.4.0-patch-3/example/admin%40test.priv --output-document=admin@test.priv
+RUN wget https://raw.githubusercontent.com/hyperledger/iroha/v1.4.0-patch-3/example/node0.pub
+RUN wget https://raw.githubusercontent.com/hyperledger/iroha/v1.4.0-patch-3/example/node0.priv
+
 ENTRYPOINT ["/entrypoint.sh"]
+
 CMD ["irohad"]

--- a/tools/docker/iroha-all-in-one/entrypoint.sh
+++ b/tools/docker/iroha-all-in-one/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# sync the local config file with the environment variables for pg opts
-export pg_opt_value="host=${IROHA_POSTGRES_HOST} port=${IROHA_POSTGRES_PORT} user=${IROHA_POSTGRES_USER} password=${IROHA_POSTGRES_PASSWORD}"
-
 if [ ! $ADMIN_PRIV = *" "* ] && [ -n "$ADMIN_PRIV" ]; then
     sed -i "1s/.*/$ADMIN_PRIV/" admin@test.priv
 fi
@@ -26,10 +23,6 @@ if [ ! $NODE_PUB = *" "* ] && [ -n "$NODE_PUB" ]; then
     genesis.block|sponge genesis.block    
 fi
 
-jq --arg pg_opt "${pg_opt_value}" \
-    '.pg_opt = $pg_opt' \
-    config.docker|sponge config.docker
-
 # if first arg looks like a flag, assume we want to run irohad server
 if [ "${1:0:1}" = '-' ]; then
   set -- irohad "$@"
@@ -46,7 +39,7 @@ if [ "$1" = 'irohad' ]; then
     echo "WARNING: IROHA_POSTGRES_HOST is not defined.
       Do not wait for Postgres to become ready. Iroha may fail to start up"
   fi
-	exec "$@" --genesis_block genesis.block --config config.docker --keypair_name $KEY
+	exec "$@" --genesis_block genesis.block --keypair_name $KEY --verbosity=${IROHA_LOG_LEVEL}
 fi
 
 exec "$@"


### PR DESCRIPTION
1. Upgraded the Iroha AIO image to use v1.4.0-patch-3
2. The new Iroha version now supports configuraton via ENV variables
3. Because of 2) we don't need to apply config file changes in the
entrypoint script of the container anymore, yay.
4. The new image uses the iroha release image as the base and  it
does NOT recompile the entire project which makes the build
orders of magnitude faster, wasting much less CI time/resources.
5. Exposed the healthcheck port for through the IrohaTestLedger class
so the other improvement we'll be able to do after this is to phase out
the hacky python script that does the healthcheck at the moment if
the new built-in healthcheck endpoint does actually work fine.
6. Migrated all the test cases to the new image version.

Fixes #2524

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>