### PR TITLE
chore(deps): clean up typescript compiler dependency declarations

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/src/utility-emissions-channel/typescript/package.json
+++ b/examples/cactus-example-carbon-accounting-backend/src/utility-emissions-channel/typescript/package.json
@@ -22,8 +22,7 @@
     "mocha": "^8.3.2",
     "sinon": "^10.0.0",
     "ts-node": "^9.1.1",
-    "tslint": "^6.1.3",
-    "typescript": "^4.2.3"
+    "tslint": "^6.1.3"
   },
   "dependencies": {
     "crypto-js": "^4.0.0",

--- a/examples/cactus-example-electricity-trade/tools/periodicExecuter/package.json
+++ b/examples/cactus-example-electricity-trade/tools/periodicExecuter/package.json
@@ -12,6 +12,6 @@
     "ts-node": "9.1.1"
   },
   "devDependencies": {
-    "typescript": "3.9.10"
+    "typescript": "4.9.5"
   }
 }

--- a/examples/cactus-example-electricity-trade/tools/transferNumericAsset/package.json
+++ b/examples/cactus-example-electricity-trade/tools/transferNumericAsset/package.json
@@ -18,6 +18,6 @@
     "socket.io": "4.5.4"
   },
   "devDependencies": {
-    "typescript": "3.9.10"
+    "typescript": "4.9.5"
   }
 }

--- a/examples/cactus-example-tcs-huawei/tools/periodicExecuter/package.json
+++ b/examples/cactus-example-tcs-huawei/tools/periodicExecuter/package.json
@@ -12,6 +12,6 @@
     "ts-node": "9.1.1"
   },
   "devDependencies": {
-    "typescript": "3.9.10"
+    "typescript": "4.9.5"
   }
 }

--- a/examples/cactus-example-tcs-huawei/tools/transferNumericAsset/package.json
+++ b/examples/cactus-example-tcs-huawei/tools/transferNumericAsset/package.json
@@ -18,6 +18,6 @@
     "socket.io": "4.5.4"
   },
   "devDependencies": {
-    "typescript": "3.9.10"
+    "typescript": "4.9.5"
   }
 }

--- a/examples/test-run-transaction/package.json
+++ b/examples/test-run-transaction/package.json
@@ -42,6 +42,6 @@
     "eslint-plugin-prettier": "4.0.0",
     "prettier": "2.5.1",
     "tslint": "6.0.0",
-    "typescript": "4.3.5"
+    "typescript": "4.9.5"
   }
 }

--- a/examples/test-run-transaction/supply-chain-app-stub/package.json
+++ b/examples/test-run-transaction/supply-chain-app-stub/package.json
@@ -11,7 +11,7 @@
     "mongodb": "3.7.3",
     "mongoose": "5.13.14",
     "ts-node": "9.1.1",
-    "typescript": "4.5.5",
+    "typescript": "4.9.5",
     "helmet": "4.6.0"
   },
   "devDependencies": {

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/src/test/typescript/unit-test/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/src/test/typescript/unit-test/package.json
@@ -18,6 +18,6 @@
     "shelljs": "0.8.5"
   },
   "devDependencies": {
-    "typescript": "3.9.10"
+    "typescript": "4.9.5"
   }
 }

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/basic-asset-transfer/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/basic-asset-transfer/chaincode-typescript/package.json
@@ -37,7 +37,7 @@
         "sinon-chai": "3.7.0",
         "ts-node": "7.0.1",
         "tslint": "5.20.1",
-        "typescript": "3.9.10"
+        "typescript": "4.9.5"
     },
     "nyc": {
         "extension": [

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/lock-asset/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/lock-asset/chaincode-typescript/package.json
@@ -37,7 +37,7 @@
         "sinon-chai": "3.7.0",
         "ts-node": "7.0.1",
         "tslint": "5.20.1",
-        "typescript": "3.9.10"
+        "typescript": "4.9.5"
     },
     "nyc": {
         "extension": [

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/package.json
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/package.json
@@ -18,6 +18,6 @@
     "socket.io-client": "4.5.4"
   },
   "devDependencies": {
-    "typescript": "3.9.10"
+    "typescript": "4.9.5"
   }
 }

--- a/packages/cactus-plugin-odap-hermes/package.json
+++ b/packages/cactus-plugin-odap-hermes/package.json
@@ -74,7 +74,7 @@
     "crypto-js": "4.0.0",
     "fabric-network": "2.2.10",
     "ipfs-http-client": "51.0.1",
-    "typescript": "4.3.2"
+    "typescript": "4.9.5"
   },
   "engines": {
     "node": ">=10",

--- a/packages/cactus-plugin-odap-hermes/src/test/typescript/fabric-contracts/lock-asset/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-odap-hermes/src/test/typescript/fabric-contracts/lock-asset/chaincode-typescript/package.json
@@ -37,7 +37,7 @@
         "sinon-chai": "3.7.0",
         "ts-node": "7.0.1",
         "tslint": "5.20.1",
-        "typescript": "3.9.10"
+        "typescript": "4.9.5"
     },
     "nyc": {
         "extension": [

--- a/weaver/core/drivers/fabric-driver/package-local.json
+++ b/weaver/core/drivers/fabric-driver/package-local.json
@@ -37,7 +37,7 @@
         "patch-package": "^6.2.2",
         "@types/node": "^14.0.14",
         "typedoc": "^0.23.15",
-        "typescript": "^4.8.4",
+        "typescript": "4.9.5",
         "nodemon": "^2.0.4"
     }
 }

--- a/weaver/core/drivers/fabric-driver/package.json
+++ b/weaver/core/drivers/fabric-driver/package.json
@@ -38,6 +38,6 @@
         "nodemon": "^2.0.4",
         "patch-package": "^6.2.2",
         "typedoc": "^0.23.15",
-        "typescript": "^4.8.4"
+        "typescript": "4.9.5"
     }
 }

--- a/weaver/core/identity-management/iin-agent/package-local.json
+++ b/weaver/core/identity-management/iin-agent/package-local.json
@@ -37,7 +37,7 @@
         "@types/node": "^14.0.14",
         "ts-node": "^10.9.0",
         "typedoc": "^0.23.15",
-        "typescript": "^4.8.4",
+        "typescript": "4.9.5",
         "nodemon": "^2.0.4",
         "chai": "^4.1.2",
         "chai-as-promised": "^7.1.1",

--- a/weaver/core/identity-management/iin-agent/package.json
+++ b/weaver/core/identity-management/iin-agent/package.json
@@ -46,6 +46,6 @@
         "sinon-chai": "^3.3.0",
         "ts-node": "^10.9.0",
         "typedoc": "^0.23.15",
-        "typescript": "^4.8.4"
+        "typescript": "4.9.5"
     }
 }

--- a/weaver/samples/besu/besu-cli/package-local.json
+++ b/weaver/samples/besu/besu-cli/package-local.json
@@ -47,7 +47,7 @@
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.17.0",
     "tslint-config-standard": "^8.0.1",
-    "typescript": "^4.9.5"
+    "typescript": "4.9.5"
   },
   "jest": {
     "preset": "ts-jest",

--- a/weaver/samples/besu/besu-cli/package.json
+++ b/weaver/samples/besu/besu-cli/package.json
@@ -46,7 +46,7 @@
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.17.0",
     "tslint-config-standard": "^8.0.1",
-    "typescript": "^4.9.5"
+    "typescript": "4.9.5"
   },
   "jest": {
     "preset": "ts-jest",

--- a/weaver/samples/besu/simpleasset/package.json
+++ b/weaver/samples/besu/simpleasset/package.json
@@ -39,6 +39,6 @@
   },
   "devDependencies": {
     "truffle": "^5.4.15",
-    "typescript": "^4.9.3"
+    "typescript": "4.9.5"
   }
 }

--- a/weaver/samples/fabric/fabric-cli/package-local.json
+++ b/weaver/samples/fabric/fabric-cli/package-local.json
@@ -68,7 +68,7 @@
     "protobufjs": "^6.9.0",
     "ts-jest": "^24.1.0",
     "ts-node": "^10.8.0",
-    "typescript": "^4.7.2"
+    "typescript": "4.9.5"
   },
   "jest": {
     "preset": "ts-jest",

--- a/weaver/samples/fabric/fabric-cli/package.json
+++ b/weaver/samples/fabric/fabric-cli/package.json
@@ -68,7 +68,7 @@
     "protobufjs": "^6.9.0",
     "ts-jest": "^24.1.0",
     "ts-node": "^10.8.0",
-    "typescript": "^4.7.2"
+    "typescript": "4.9.5"
   },
   "jest": {
     "preset": "ts-jest",

--- a/weaver/sdks/besu/node/package-local.json
+++ b/weaver/sdks/besu/node/package-local.json
@@ -39,7 +39,7 @@
     "sinon-chai": "^3.3.0",
     "ts-node": "^10.9.0",
     "typedoc": "^0.23.15",
-    "typescript": "^4.8.4"
+    "typescript": "4.9.5"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/hyperledger-labs"

--- a/weaver/sdks/besu/node/package.json
+++ b/weaver/sdks/besu/node/package.json
@@ -39,7 +39,7 @@
     "sinon-chai": "^3.3.0",
     "ts-node": "^10.9.0",
     "typedoc": "^0.23.15",
-    "typescript": "^4.8.4"
+    "typescript": "4.9.5"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/hyperledger"

--- a/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
+++ b/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
@@ -62,7 +62,7 @@
     "sinon-chai": "^3.3.0",
     "ts-node": "^10.9.0",
     "typedoc": "^0.23.15",
-    "typescript": "^4.8.4"
+    "typescript": "4.9.5"
   },
   "license": "Apache-2.0",
   "licenses": [

--- a/weaver/sdks/fabric/interoperation-node-sdk/package.json
+++ b/weaver/sdks/fabric/interoperation-node-sdk/package.json
@@ -62,7 +62,7 @@
     "sinon-chai": "^3.3.0",
     "ts-node": "^10.9.0",
     "typedoc": "^0.23.15",
-    "typescript": "^4.8.4"
+    "typescript": "4.9.5"
   },
   "license": "Apache-2.0",
   "licenses": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5365,7 +5365,7 @@ __metadata:
     tslint: ^5.12.0
     tslint-config-prettier: ^1.17.0
     tslint-config-standard: ^8.0.1
-    typescript: ^4.9.5
+    typescript: 4.9.5
     winston: ^3.3.3
   bin:
     besu-cli: bin/besu-cli
@@ -5384,7 +5384,7 @@ __metadata:
     ganache-cli: ^6.12.2
     solc: ^0.8.8
     truffle: ^5.4.15
-    typescript: ^4.9.3
+    typescript: 4.9.5
   languageName: unknown
   linkType: soft
 
@@ -5422,7 +5422,7 @@ __metadata:
     nodemon: ^2.0.4
     patch-package: ^6.2.2
     typedoc: ^0.23.15
-    typescript: ^4.8.4
+    typescript: 4.9.5
     winston: ^3.3.3
   languageName: unknown
   linkType: soft
@@ -5462,7 +5462,7 @@ __metadata:
     protobufjs: ^6.9.0
     ts-jest: ^24.1.0
     ts-node: ^10.8.0
-    typescript: ^4.7.2
+    typescript: 4.9.5
     uuid: ^8.3.1
     winston: ^3.3.3
     y18n: ^4.0.1
@@ -5500,7 +5500,7 @@ __metadata:
     sinon-chai: ^3.3.0
     ts-node: ^10.9.0
     typedoc: ^0.23.15
-    typescript: ^4.8.4
+    typescript: 4.9.5
   languageName: unknown
   linkType: soft
 
@@ -5542,7 +5542,7 @@ __metadata:
     sinon-chai: ^3.3.0
     ts-node: ^10.9.0
     typedoc: ^0.23.15
-    typescript: ^4.8.4
+    typescript: 4.9.5
     web3: 1.10.0
   languageName: unknown
   linkType: soft
@@ -5583,7 +5583,7 @@ __metadata:
     sshpk: ^1.16.1
     ts-node: ^10.9.0
     typedoc: ^0.23.15
-    typescript: ^4.8.4
+    typescript: 4.9.5
     uuid: ^8.3.1
   languageName: unknown
   linkType: soft
@@ -6744,7 +6744,7 @@ __metadata:
     secp256k1: 4.0.2
     socket.io: 4.5.4
     sqlite3: 5.1.5
-    typescript: 4.3.2
+    typescript: 4.9.5
     typescript-optional: 2.0.1
     web3: 1.6.1
     web3-utils: 1.6.1
@@ -41420,17 +41420,7 @@ gluegun@latest:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.3.2":
-  version: 4.3.2
-  resolution: "typescript@npm:4.3.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: c2a86fa03ce03b255adc13ccd70a55173ca6539ae12114feca59f34a4e9bb69f14fb7cd5adc6c2416e568cff05c870b89d1366768ec55fce04fbdffb429a1cee
-  languageName: node
-  linkType: hard
-
-"typescript@npm:4.9.5, typescript@npm:^4.7.2, typescript@npm:^4.8.4, typescript@npm:^4.9.3, typescript@npm:^4.9.5":
+"typescript@npm:4.9.5":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
   bin:
@@ -41460,17 +41450,7 @@ gluegun@latest:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.3.2#~builtin<compat/typescript>":
-  version: 4.3.2
-  resolution: "typescript@patch:typescript@npm%3A4.3.2#~builtin<compat/typescript>::version=4.3.2&hash=dba6d9"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 67da730521568e0de52b13926ad714288a1a6f265b3563c0e646731e6676454bad78bea9e29eafeeb922987e09df9c52d22fabbcddd225dc88783d3610df5209
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@4.9.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
+"typescript@patch:typescript@4.9.5#~builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:


### PR DESCRIPTION
Pinned all of the versions to 4.9.5 in all of the packages.

Fixes #2532

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>