### PR TITLE
build(docker-compose): upgrade to docker compose V2

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/private-deploy-contract-from-json-cactus.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/private-deploy-contract-from-json-cactus.test.ts
@@ -14,6 +14,9 @@ import { PluginImportType } from "@hyperledger/cactus-core-api";
 import { PluginRegistry } from "@hyperledger/cactus-core";
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 
+const containerImageName =
+  "ghcr.io/hyperledger/cactus-besu-all-in-one-multi-party";
+const containerImageTag = "2023-08-08-pr-2596";
 const testCase = "Executes private transactions on Hyperledger Besu";
 const logLevel: LogLevelDesc = "TRACE";
 
@@ -73,7 +76,12 @@ test(testCase, async (t: Test) => {
   if (preWarmedLedger) {
     keys = keysStatic;
   } else {
-    const ledger = new BesuMpTestLedger({ logLevel });
+    const ledger = new BesuMpTestLedger({
+      logLevel,
+      imageName: containerImageName,
+      imageTag: containerImageTag,
+      emitContainerLogs: false,
+    });
     test.onFinish(() => ledger.stop());
     await ledger.start();
     keys = await ledger.getKeys();

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/private-deploy-contract-from-json-web3-eea.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/private-deploy-contract-from-json-web3-eea.test.ts
@@ -6,6 +6,9 @@ import { BesuMpTestLedger } from "@hyperledger/cactus-test-tooling";
 import { AbiItem } from "web3-utils";
 import { LogLevelDesc } from "@hyperledger/cactus-common";
 
+const containerImageName =
+  "ghcr.io/hyperledger/cactus-besu-all-in-one-multi-party";
+const containerImageTag = "2023-08-08-pr-2596";
 const testCase = "Executes private transactions on Hyperledger Besu";
 const logLevel: LogLevelDesc = "TRACE";
 
@@ -62,7 +65,12 @@ test(testCase, async (t: Test) => {
   if (preWarmedLedger) {
     keys = keysStatic;
   } else {
-    const ledger = new BesuMpTestLedger({ logLevel });
+    const ledger = new BesuMpTestLedger({
+      logLevel,
+      imageName: containerImageName,
+      imageTag: containerImageTag,
+      emitContainerLogs: false,
+    });
     test.onFinish(() => ledger.stop());
     await ledger.start();
     keys = await ledger.getKeys();

--- a/tools/docker/besu-multi-party-all-in-one/Dockerfile
+++ b/tools/docker/besu-multi-party-all-in-one/Dockerfile
@@ -1,32 +1,37 @@
-FROM docker:24.0.2-dind
+################################
+# STAGE 1
+# Setup quorum-dev-quickstart
+################################
 
-ARG BESU_VERSION=21.1.2
-ARG QUORUM_VERSION=21.4.1
-ARG QUORUM_TESSERA_VERSION=21.1.1
-ARG CA_VERSION=1.4.9
+FROM node:18.17.0 AS quorum-dev-quickstart-setup
+
+ENV QUORUM_QUICKSTART_VERSION=0.1.5
+ENV ROOT_DIR=/opt/quorum-dev-quickstart
+
+WORKDIR "${ROOT_DIR}"
+RUN npm install -g "quorum-dev-quickstart@${QUORUM_QUICKSTART_VERSION}"
+RUN quorum-dev-quickstart --clientType besu --outputPath ./ --monitoring default --privacy true --orchestrate false
+
+################################
+# STAGE 2
+# docker compose base
+################################
+
+FROM docker:24.0.5-dind
+
+ENV ROOT_DIR=/opt/quorum-dev-quickstart
 
 WORKDIR /
+
+RUN addgroup -g 1000 quorum \
+  && adduser -u 1000 -G quorum -g docker -s /bin/sh -D quorum \
+  && addgroup docker \
+  && addgroup quorum docker
 
 RUN apk update
 
 # Install dependencies of Docker Compose
-RUN apk add py-pip python3-dev libffi-dev openssl-dev gcc libc-dev make
-
-# Install python/pip - We need this because DinD 18.x has Python 2
-# And we cannot upgrade to DinD 19 because of
-# https://github.com/docker-library/docker/issues/170
-ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade "pip>=21" setuptools
-
-# Without this the docker-compose installation crashes, complaining about
-# a lack of rust compiler...
-# RUN pip install setuptools_rust
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-
-# Install Docker Compose which is a dependency of Fabric Samples
-RUN pip install docker-compose
+RUN apk add docker-cli docker-cli-compose curl
 
 # Need git to clone the sources of the Fabric Samples repository from GitHub
 RUN apk add --no-cache git
@@ -48,54 +53,18 @@ RUN apk add --no-cache libc6-compat
 
 RUN apk add --no-cache --update chromium
 
-ENV CACTUS_CFG_PATH=/etc/hyperledger/cactus
-RUN mkdir -p $CACTUS_CFG_PATH
-# OpenSSH - need to have it so we can shell in and install/instantiate contracts
-RUN apk add --no-cache openssh augeas
-
-# Configure the OpenSSH server we just installed
-RUN augtool 'set /files/etc/ssh/sshd_config/AuthorizedKeysFile ".ssh/authorized_keys /etc/authorized_keys/%u"'
-RUN augtool 'set /files/etc/ssh/sshd_config/PermitRootLogin yes'
-RUN augtool 'set /files/etc/ssh/sshd_config/PasswordAuthentication no'
-RUN augtool 'set /files/etc/ssh/sshd_config/PermitEmptyPasswords no'
-RUN augtool 'set /files/etc/ssh/sshd_config/Port 22'
-RUN augtool 'set /files/etc/ssh/sshd_config/LogLevel DEBUG2'
-RUN augtool 'set /files/etc/ssh/sshd_config/LoginGraceTime 10'
-# Create the server's key - without this sshd will refuse to start
-RUN ssh-keygen -A
-
-# Generate an RSA keypair on the fly to avoid having to hardcode one in the image
-# which technically does not pose a security threat since this is only a development
-# image, but we do it like this anyway.
-RUN mkdir ~/.ssh
-RUN chmod 700 ~/.ssh/
-RUN touch ~/.ssh/authorized_keys
-RUN ["/bin/bash", "-c", "ssh-keygen -t rsa -N '' -f $CACTUS_CFG_PATH/besu-aio-image <<< y"]
-RUN mv $CACTUS_CFG_PATH/besu-aio-image $CACTUS_CFG_PATH/besu-aio-image.key
-RUN cp $CACTUS_CFG_PATH/besu-aio-image.pub ~/.ssh/authorized_keys
-
 RUN apk add --no-cache util-linux
 
-# FIXME - make it so that SSHd does not need this to work
-RUN echo "root:$(uuidgen)" | chpasswd
-
-RUN git clone https://github.com/petermetz/quorum-dev-quickstart.git
-
-WORKDIR /quorum-dev-quickstart
-
-RUN git checkout programmatically-accept-start-args
-
-RUN npm i
-
-RUN npm run build
-
-RUN npm run start -- --elk false --privacy true --clientType besu
+# Copy quorum-dev-quickstart from the base
+COPY --chown=quorum:quorum --from=quorum-dev-quickstart-setup "${ROOT_DIR}" "${ROOT_DIR}"
+WORKDIR "${ROOT_DIR}"
+COPY --chown=quorum:quorum env-config.ini .env
 
 RUN apk add --no-cache supervisor
 RUN apk add --no-cache ncurses
 
 COPY healthcheck.sh /healthcheck.sh
-COPY supervisord.conf /etc/supervisord.conf
+COPY --chown=quorum:quorum supervisord.conf /etc/supervisord.conf
 
 # # Extend the parent image's entrypoint
 # # https://superuser.com/questions/1459466/can-i-add-an-additional-docker-entrypoint-script

--- a/tools/docker/besu-multi-party-all-in-one/README.md
+++ b/tools/docker/besu-multi-party-all-in-one/README.md
@@ -101,3 +101,7 @@ docker run \
   --publish 25000:25000 \
   cbmpaio
 ```
+
+## Updating the Besu version
+- `env-config.ini` is the configuration file of `quorum-dev-quickstart` npm package (it's copied as `.env` in the container).
+- To use another version of besu ledger update specific variables in `env-config.ini` and build the container.

--- a/tools/docker/besu-multi-party-all-in-one/env-config.ini
+++ b/tools/docker/besu-multi-party-all-in-one/env-config.ini
@@ -1,0 +1,22 @@
+# This file defines environment variables defaults for Docker-compose
+# but we also use it for shell scripts as a sourced file
+
+BESU_VERSION=23.4.1
+QUORUM_VERSION=23.4.0
+TESSERA_VERSION=23.4.0
+ETHSIGNER_VERSION=22.1.3
+QUORUM_EXPLORER_VERSION=4f60191
+
+LOCK_FILE=.quorumDevQuickstart.lock
+
+# GoQuorum consensus algorithm
+# istanbul, qbft, raft
+# !!! lower case ONLY here
+GOQUORUM_CONS_ALGO=qbft
+
+# Besu consensus algorithm
+# IBFT, QBFT, CLIQUE
+# PLEASE NOTE: IBFT used here refers to IBFT2.0 and not IBFT1.0 More information can be found https://besu.hyperledger.org/en/latest/HowTo/Configure/Consensus-Protocols/IBFT/
+# We use IBFT here to keep the API names consistent
+# !!! upper case ONLY here
+BESU_CONS_ALGO=QBFT

--- a/tools/docker/besu-multi-party-all-in-one/supervisord.conf
+++ b/tools/docker/besu-multi-party-all-in-one/supervisord.conf
@@ -4,15 +4,6 @@ logfile_maxbytes = 50MB
 logfile_backups=10
 loglevel = debug
 
-[program:sshd]
-command=/usr/sbin/sshd -D
-autostart=true
-autorestart=true
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-
 [program:dockerd]
 command=dockerd-entrypoint.sh
 autostart=true
@@ -23,7 +14,9 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:besu-network]
-command=/quorum-dev-quickstart/run.sh
+command=%(ENV_ROOT_DIR)s/run.sh
+user=quorum
+environment=HOME="/opt/quorum-dev-quickstart",USER="quorum",TERM="linux"
 autostart=true
 autorestart=unexpected
 stderr_logfile=/dev/stderr

--- a/tools/docker/fabric-all-in-one/Dockerfile_v1.4.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v1.4.x
@@ -1,32 +1,16 @@
 # We need to use the older, more stable v18 here because of
 # https://github.com/docker-library/docker/issues/170
-FROM docker:24.0.2-dind
+FROM docker:24.0.5-dind
 
 ARG FABRIC_VERSION=1.4.8
 ARG CA_VERSION=1.4.9
 
 WORKDIR /
 
-RUN apk update
+RUN apk update && apk --no-cache upgrade openssh-client
 
 # Install dependencies of Docker Compose
-RUN apk add py-pip python3-dev libffi-dev openssl-dev gcc libc-dev make
-
-# Install python/pip - We need this because DinD 18.x has Python 2
-# And we cannot upgrade to DinD 19 because of
-# https://github.com/docker-library/docker/issues/170
-ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade "pip>=21" setuptools
-
-# Without this the docker-compose installation crashes, complaining about
-# a lack of rust compiler...
-# RUN pip install setuptools_rust
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-
-# Install Docker Compose which is a dependency of Fabric Samples
-RUN pip install docker-compose
+RUN apk add docker-cli docker-cli-compose
 
 # Need git to clone the sources of the Fabric Samples repository from GitHub
 RUN apk add --no-cache git

--- a/tools/docker/fabric-all-in-one/Dockerfile_v2.x
+++ b/tools/docker/fabric-all-in-one/Dockerfile_v2.x
@@ -1,6 +1,6 @@
 # We need to use the older, more stable v18 here because of
 # https://github.com/docker-library/docker/issues/170
-FROM docker:24.0.2-dind
+FROM docker:24.0.5-dind
 
 ARG FABRIC_VERSION=2.2.0
 ARG CA_VERSION=1.4.9
@@ -9,26 +9,10 @@ ARG COUCH_VERSION=3.1.1
 
 WORKDIR /
 
-RUN apk update
+RUN apk update && apk --no-cache upgrade openssh-client
 
 # Install dependencies of Docker Compose
-RUN apk add py-pip python3-dev libffi-dev openssl-dev gcc libc-dev make
-
-# Install python/pip - We need this because DinD 18.x has Python 2
-# And we cannot upgrade to DinD 19 because of
-# https://github.com/docker-library/docker/issues/170
-ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade "pip>=21" setuptools
-
-# Without this the docker-compose installation crashes, complaining about
-# a lack of rust compiler...
-# RUN pip install setuptools_rust
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-
-# Install Docker Compose which is a dependency of Fabric Samples
-RUN pip install docker-compose
+RUN apk add docker-cli docker-cli-compose
 
 # Need git to clone the sources of the Fabric Samples repository from GitHub
 RUN apk add --no-cache git
@@ -88,11 +72,8 @@ RUN cp $CACTUS_CFG_PATH/fabric-aio-image.pub ~/.ssh/authorized_keys
 # OpenSSH Server (needed for chaincode deployment )
 EXPOSE 22
 
-# supervisord web ui/dashboard
-EXPOSE 9001
-
-# peer1.org2.example.com
-EXPOSE 10051
+# orderer.example.com
+EXPOSE 7050
 
 # peer0.org1.example.com
 EXPOSE 7051
@@ -100,17 +81,17 @@ EXPOSE 7051
 # peer0.org2.example.com
 EXPOSE 9051
 
-# peer1.org1.example.com
-EXPOSE 8051
-
-# orderer.example.com
-EXPOSE 7050
-
-# ca_peerOrg1
+# ca_org1
 EXPOSE 7054
 
-# ca_peerOrg2
+# ca_org2
 EXPOSE 8054
+
+# ca_orderer
+EXPOSE 9054
+
+# supervisord web ui/dashboard
+EXPOSE 9001
 
 # couchdb0, couchdb1, couchdb2, couchdb3
 EXPOSE 5984 6984 7984 8984

--- a/tools/docker/fabric-all-in-one/README.md
+++ b/tools/docker/fabric-all-in-one/README.md
@@ -7,14 +7,27 @@ An all in one fabric docker image with the `fabric-samples` repo fully embedded.
 
 ## Usage
 
-### Building Local Image
+### Local Image Builds
+
+From the project root:
 
 ```sh
+# Fabric 1.4.X
 DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x -t faio14x
-```
-### VSCode
+docker run --detach --privileged --publish-all --name faio14x-testnet faio14x
 
-## Usage
+# Fabric 2.X
+DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v2.x -t faio2x
+docker run --detach --privileged --publish-all --name faio2x-testnet faio2x
+
+# Docker compose (Fabric 2.X)
+docker-compose -f ./tools/docker/fabric-all-in-one/docker-compose-v2.x.yml build
+docker-compose -f ./tools/docker/fabric-all-in-one/docker-compose-v2.x.yml up -d
+
+# Check SSH
+docker cp IMG_NAME:/etc/hyperledger/cactus/fabric-aio-image.key ./fabric-aio-image.key
+ssh root@localhost -p IMG_SSH_PORT -i fabric-aio-image.key
+```
 
 ### Visual Studio Code
 
@@ -46,37 +59,6 @@ Example `.vscode/tasks.json` file for building/running the image:
     }
   ]
 }
-```
-
-### Local Image Builds
-
-From the project root:
-
-```sh
-DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v2.x -t faio2x
-docker run --detach --privileged --publish-all --env FABRIC_VERSION=2.2.0 faio2x
-
-docker ps
-CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                     PORTS                                                                                                                                                                                                                                                                                                                                                                                  NAMES
-db676059b79e        faio2x              "/usr/bin/supervisor…"   9 minutes ago       Up 9 minutes   0.0.0.0:32924->22/tcp, 0.0.0.0:32923->2375/tcp, 0.0.0.0:32922->2376/tcp, 0.0.0.0:32921->5984/tcp, 0.0.0.0:32920->6984/tcp, 0.0.0.0:32919->7050/tcp, 0.0.0.0:32918->7051/tcp, 0.0.0.0:32917->7054/tcp, 0.0.0.0:32916->7984/tcp, 0.0.0.0:32915->8051/tcp, 0.0.0.0:32914->8054/tcp, 0.0.0.0:32913->8984/tcp, 0.0.0.0:32912->9001/tcp, 0.0.0.0:32911->9051/tcp, 0.0.0.0:32910->10051/tcp   sharp_clarke
-
-docker cp db676059b79e:/etc/hyperledger/cactus/fabric-aio-image.key ./fabric-aio-image.key
-
-ssh root@localhost -p 32924 -i fabric-aio-image.key
-```
-
-```sh
-DOCKER_BUILDKIT=1 docker build ./tools/docker/fabric-all-in-one/ -f ./tools/docker/fabric-all-in-one/Dockerfile_v1.4.x  -t faio14x
-docker run --detach --privileged --publish-all --env FABRIC_VERSION=1.4.8 faio14x
-
-docker ps
-
-CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                            PORTS                                                                                                                                                                                                                                                                                                                                                                                  NAMES
-c09eb94d94d3        faio14x             "/usr/bin/supervisor…"   5 seconds ago       Up 4 seconds (health: starting)   0.0.0.0:32990->22/tcp, 0.0.0.0:32989->2375/tcp, 0.0.0.0:32988->2376/tcp, 0.0.0.0:32987->5984/tcp, 0.0.0.0:32986->6984/tcp, 0.0.0.0:32985->7050/tcp, 0.0.0.0:32984->7051/tcp, 0.0.0.0:32983->7054/tcp, 0.0.0.0:32982->7984/tcp, 0.0.0.0:32981->8051/tcp, 0.0.0.0:32980->8054/tcp, 0.0.0.0:32979->8984/tcp, 0.0.0.0:32978->9001/tcp, 0.0.0.0:32977->9051/tcp, 0.0.0.0:32976->10051/tcp   funny_jepsen
-
-
-docker cp c09eb94d94d3:/etc/hyperledger/cactus/fabric-aio-image.key ./fabric-aio-image.key
-ssh root@localhost -p 32990 -i fabric-aio-image.key
 ```
 
 ### Running Fabric CLI Container Commands

--- a/tools/docker/fabric-all-in-one/docker-compose-v2.x.yml
+++ b/tools/docker/fabric-all-in-one/docker-compose-v2.x.yml
@@ -9,16 +9,18 @@ services:
       context: ./
       dockerfile: Dockerfile_v2.x
     ports:
-        - "4022:22"   # SSH
-        - "7051:7051" # peer0.org1.example.com
-        - "8051:8051" # peer1.org1.example.com
-        - "7054:7054" # ca.org1.example.com
-        - "7050:7050" # orderer.example.com
+      - "4022:22" # SSH
+      - "7050:7050" # orderer.example.com
+      - "7051:7051" # peer0.org1.example.com
+      - "9051:9051" # peer0.org2.example.com
+      - "7054:7054" # ca_org1
+      - "8054:8054" # ca_org2
+      - "9054:9054" # ca_orderer
     environment:
       - FABRIC_VERSION=${CACTUS_FABRIC_ALL_IN_ONE_VERSION:-2.2.0}
       - CACTUS_FABRIC_TEST_LOOSE_MEMBERSHIP=1
     networks:
-       - testnet-2x
+      - testnet-2x
 
 networks:
   testnet-2x:

--- a/tools/docker/quorum-multi-party-all-in-one/Dockerfile
+++ b/tools/docker/quorum-multi-party-all-in-one/Dockerfile
@@ -3,9 +3,9 @@
 # Setup quorum-dev-quickstart
 ################################
 
-FROM node:16.17.0 AS quorum-dev-quickstart-setup
+FROM node:18.17.0 AS quorum-dev-quickstart-setup
 
-ENV QUORUM_QUICKSTART_VERSION=0.0.80
+ENV QUORUM_QUICKSTART_VERSION=0.1.5
 ENV ROOT_DIR=/opt/quorum-dev-quickstart
 
 WORKDIR "${ROOT_DIR}"
@@ -14,38 +14,41 @@ RUN quorum-dev-quickstart --clientType goquorum --outputPath ./ --monitoring def
 
 ################################
 # STAGE 2
-# docker-compose base
+# docker compose base
 ################################
 
-FROM docker:24.0.2-dind
+FROM docker:24.0.5-dind
 
 ENV ROOT_DIR=/opt/quorum-dev-quickstart
 
-# Install docker-compose and quorum-dev-quickstart setup dependencies
+# Install docker compose and quorum-dev-quickstart setup dependencies
 RUN apk update \
   && apk add --no-cache \
-    py-pip \
-    python3-dev \
-    libffi-dev \
-    openssl-dev \
-    gcc \
-    libc-dev \
-    rust \
-    cargo \
-    make \
-    bash \
-    ncurses \
-    supervisor \
-  && pip install docker-compose
+  docker-cli \
+  docker-cli-compose \
+  gcc \
+  libc-dev \
+  rust \
+  cargo \
+  make \
+  bash \
+  ncurses \
+  supervisor
+
+RUN addgroup -g 1000 quorum \
+  && adduser -u 1000 -G quorum -g docker -s /bin/sh -D quorum \
+  && addgroup docker \
+  && addgroup quorum docker
 
 # Copy quorum-dev-quickstart from the base
-COPY --from=quorum-dev-quickstart-setup "${ROOT_DIR}" "${ROOT_DIR}"
+COPY --chown=quorum:quorum --from=quorum-dev-quickstart-setup "${ROOT_DIR}" "${ROOT_DIR}"
 WORKDIR "${ROOT_DIR}"
+COPY --chown=quorum:quorum env-config.ini .env
 
 COPY healthcheck.sh /healthcheck.sh
 HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=500 CMD /healthcheck.sh
 
-COPY supervisord.conf /etc/supervisord.conf
+COPY --chown=quorum:quorum supervisord.conf /etc/supervisord.conf
 ENTRYPOINT ["/usr/bin/supervisord"]
 CMD ["--configuration", "/etc/supervisord.conf", "--nodaemon"]
 

--- a/tools/docker/quorum-multi-party-all-in-one/README.md
+++ b/tools/docker/quorum-multi-party-all-in-one/README.md
@@ -86,3 +86,7 @@ docker run \
   --publish 25000:25000 \
   cqmpaio
 ```
+
+## Updating the Quorum version
+- `env-config.ini` is the configuration file of `quorum-dev-quickstart` npm package (it's copied as `.env` in the container).
+- To use another version of quorum ledger update specific variables in `env-config.ini` and build the container.

--- a/tools/docker/quorum-multi-party-all-in-one/env-config.ini
+++ b/tools/docker/quorum-multi-party-all-in-one/env-config.ini
@@ -1,0 +1,22 @@
+# This file defines environment variables defaults for Docker-compose
+# but we also use it for shell scripts as a sourced file
+
+BESU_VERSION=23.4.1
+QUORUM_VERSION=23.4.0
+TESSERA_VERSION=23.4.0
+ETHSIGNER_VERSION=22.1.3
+QUORUM_EXPLORER_VERSION=4f60191
+
+LOCK_FILE=.quorumDevQuickstart.lock
+
+# GoQuorum consensus algorithm
+# istanbul, qbft, raft
+# !!! lower case ONLY here
+GOQUORUM_CONS_ALGO=qbft
+
+# Besu consensus algorithm
+# IBFT, QBFT, CLIQUE
+# PLEASE NOTE: IBFT used here refers to IBFT2.0 and not IBFT1.0 More information can be found https://besu.hyperledger.org/en/latest/HowTo/Configure/Consensus-Protocols/IBFT/
+# We use IBFT here to keep the API names consistent
+# !!! upper case ONLY here
+BESU_CONS_ALGO=QBFT

--- a/tools/docker/quorum-multi-party-all-in-one/supervisord.conf
+++ b/tools/docker/quorum-multi-party-all-in-one/supervisord.conf
@@ -15,6 +15,8 @@ stdout_logfile_maxbytes=0
 
 [program:quorum-network]
 command=%(ENV_ROOT_DIR)s/run.sh
+user=quorum
+environment=HOME="/opt/quorum-dev-quickstart",USER="quorum",TERM="linux"
 autostart=true
 autorestart=false
 stderr_logfile=/dev/stderr

--- a/tools/docker/sawtooth-all-in-one/Dockerfile
+++ b/tools/docker/sawtooth-all-in-one/Dockerfile
@@ -1,20 +1,15 @@
-FROM docker:24.0.2-dind
+FROM docker:24.0.5-dind
 
-# Install docker-compose and it's dependencies
 RUN apk update \
   && apk add --no-cache \
-    py-pip \
-    python3-dev \
-    libffi-dev \
-    openssl-dev \
-    gcc \
-    libc-dev \
-    rust \
-    cargo \
-    make \
-    supervisor \
-  && pip install wheel \
-  && pip install docker-compose
+  docker-cli \
+  docker-cli-compose \
+  gcc \
+  libc-dev \
+  rust \
+  cargo \
+  make \
+  supervisor
 
 # Copy sawtooth docker-compose
 COPY ./sawtooth-default.yaml /app/docker-compose.yaml

--- a/tools/docker/sawtooth-all-in-one/README.md
+++ b/tools/docker/sawtooth-all-in-one/README.md
@@ -18,11 +18,10 @@ docker-compose build && docker-compose up -d
 ```
 
 ### Docker
-> Excute from `tools/docker/sawtooth-all-in-one` or adjust the paths accordingly.
 
 ``` bash
 # Build
-DOCKER_BUILDKIT=1 docker build . -t cactus-sawtooth-all-in-one
+DOCKER_BUILDKIT=1 docker build ./tools/docker/sawtooth-all-in-one/ -t cactus-sawtooth-all-in-one
 
 # Run
 docker run --name sawtooth_all_in_one_ledger_1x --detach --privileged -p 8008:8008 cactus-sawtooth-all-in-one


### PR DESCRIPTION
- `quorum-multi-party-all-in-one`: use newest `quorum-quorum-dev-quickstart`, update quorum versions to most recent available. Run ledger as `quorum` user (required by newer versions). Use docker compose V2 from alpine package registry instead of V1 from pip.
- `besu-multi-party-all-in-one`: similar changes as for quorum-multi-party-all-in-on. Fix broken besu private transaction tests.
- `fabric-all-in-one`: Use docker compose V2 from alpine package registry instead of V1 from pip.
- `sawtooth-all-in-one`: Use docker compose V2 from alpine package registry instead of V1 from pip.

Closes: #2593
Closes: #2557