### PR TITLE
test(jest): reduce Jest log verbosity - make logs more compact

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   testEnvironment: "node",
   maxWorkers: 1,
   maxConcurrency: 1,
-  setupFilesAfterEnv: ["jest-extended/all"],
+  setupFilesAfterEnv: ["jest-extended/all", "./jest.setup.console.logs.js"],
   testTimeout: 60 * 60 * 1000,
   testMatch: [
     `**/cactus-*/src/test/typescript/{unit,integration,benchmark}/**/*.test.ts`,

--- a/jest.setup.console.logs.js
+++ b/jest.setup.console.logs.js
@@ -1,0 +1,2 @@
+const console = require("node:console");
+global.console = console;


### PR DESCRIPTION
Configure jest to override it's internal console logger with the
regular console object provided by the JS runtime.
This way it does not have the extra information printed that is
not useful for 99% of our use-cases (100% of the known ones).

Fixes #2595

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>