### PR TITLE
fix: use common conventions: tsconfig.json, package.json

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/package.json
+++ b/examples/cactus-example-carbon-accounting-backend/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/examples/cactus-example-carbon-accounting-business-logic-plugin/package.json
+++ b/examples/cactus-example-carbon-accounting-business-logic-plugin/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/examples/cactus-example-supply-chain-backend/package.json
+++ b/examples/cactus-example-supply-chain-backend/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/examples/cactus-example-supply-chain-business-logic-plugin/package.json
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/examples/cactus-workshop-examples-2022-11-14/package.json
+++ b/examples/cactus-workshop-examples-2022-11-14/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/examples/supply-chain-app/package.json
+++ b/examples/supply-chain-app/package.json
@@ -27,7 +27,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/extensions/cactus-plugin-htlc-coordinator-besu/package.json
+++ b/extensions/cactus-plugin-htlc-coordinator-besu/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/extensions/cactus-plugin-object-store-ipfs/package.json
+++ b/extensions/cactus-plugin-object-store-ipfs/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-api-client/package.json
+++ b/packages/cactus-api-client/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-cmd-socketio-server/package.json
+++ b/packages/cactus-cmd-socketio-server/package.json
@@ -1,10 +1,41 @@
 {
   "name": "@hyperledger/cactus-cmd-socketio-server",
   "version": "2.0.0-alpha.1",
+  "description": "Allows Cactus nodes to interact with HTLC ETH contracts",
+  "keywords": [
+    "Hyperledger",
+    "Cactus",
+    "Integration",
+    "Blockchain",
+    "Distributed Ledger Technology"
+  ],
+  "homepage": "https://github.com/hyperledger/cacti#readme",
+  "bugs": {
+    "url": "https://github.com/hyperledger/cacti/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hyperledger/cacti.git"
+  },
   "license": "Apache-2.0",
-  "main": "dist/src/main/typescript/index.js",
-  "module": "dist/src/main/typescript/index.js",
-  "types": "dist/src/main/typescript/index.d.ts",
+  "author": {
+    "name": "Hyperledger Cactus Contributors",
+    "email": "cactus@lists.hyperledger.org",
+    "url": "https://www.hyperledger.org/use/cacti"
+  },
+  "contributors": [
+    {
+      "name": "Please add yourself to the list of contributors",
+      "email": "your.name@example.com",
+      "url": "https://example.com"
+    }
+  ],
+  "main": "dist/lib/main/typescript/index.js",
+  "module": "dist/lib/main/typescript/index.js",
+  "types": "dist/lib/main/typescript/index.d.ts",
+  "files": [
+    "dist/*"
+  ],
   "scripts": {
     "build": "npm run build-ts && npm run build:dev:backend:postbuild",
     "build-ts": "tsc",

--- a/packages/cactus-cmd-socketio-server/tsconfig.json
+++ b/packages/cactus-cmd-socketio-server/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "outDir": "./dist/",
-    "tsBuildInfoFile": "../../.build-cache/cactus-cmd-socketio-server.tsbuildinfo",
+    "outDir": "./dist/lib",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "../../.build-cache/cactus-cmd-socketio-server.tsbuildinfo"
   },
   "include": [
     "./src/main/typescript/business-logic-plugin/*.ts",
@@ -13,9 +14,7 @@
     "./src/main/typescript/util/*.ts",
     "./src/main/typescript/routing-interface/**/*.ts"
   ],
-  "exclude": [
-    "copyStaticAssets.ts"
-  ],
+  "exclude": ["copyStaticAssets.ts"],
   "references": [
     {
       "path": "../cactus-common/tsconfig.json"

--- a/packages/cactus-common/package.json
+++ b/packages/cactus-common/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-core-api/package.json
+++ b/packages/cactus-core-api/package.json
@@ -60,7 +60,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-core/package.json
+++ b/packages/cactus-core/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-consortium-manual/package.json
+++ b/packages/cactus-plugin-consortium-manual/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-htlc-eth-besu-erc20/package.json
+++ b/packages/cactus-plugin-htlc-eth-besu-erc20/package.json
@@ -1,92 +1,92 @@
 {
-    "name": "@hyperledger/cactus-plugin-htlc-eth-besu-erc20",
-    "version": "2.0.0-alpha.1",
-    "description": "Allows Cactus nodes to interact with HTLC contracts with ERC-20 Tokens",
-    "keywords": [
-        "Hyperledger",
-        "Cactus",
-        "Integration",
-        "Blockchain",
-        "Distributed Ledger Technology"
-    ],
-    "homepage": "https://github.com/hyperledger/cacti#readme",
-    "bugs": {
-        "url": "https://github.com/hyperledger/cacti/issues"
+  "name": "@hyperledger/cactus-plugin-htlc-eth-besu-erc20",
+  "version": "2.0.0-alpha.1",
+  "description": "Allows Cactus nodes to interact with HTLC contracts with ERC-20 Tokens",
+  "keywords": [
+    "Hyperledger",
+    "Cactus",
+    "Integration",
+    "Blockchain",
+    "Distributed Ledger Technology"
+  ],
+  "homepage": "https://github.com/hyperledger/cacti#readme",
+  "bugs": {
+    "url": "https://github.com/hyperledger/cacti/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hyperledger/cacti.git"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Hyperledger Cactus Contributors",
+    "email": "cactus@lists.hyperledger.org",
+    "url": "https://www.hyperledger.org/use/cacti"
+  },
+  "contributors": [
+    {
+      "name": "Please add yourself to the list of contributors",
+      "email": "your.name@example.com",
+      "url": "https://example.com"
     },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/hyperledger/cacti.git"
+    {
+      "name": "Peter Somogyvari",
+      "email": "peter.somogyvari@accenture.com",
+      "url": "https://accenture.com"
     },
-    "license": "Apache-2.0",
-    "author": {
-        "name": "Hyperledger Cactus Contributors",
-        "email": "cactus@lists.hyperledger.org",
-        "url": "https://www.hyperledger.org/use/cactus"
-    },
-    "contributors": [
-        {
-            "name": "Please add yourself to the list of contributors",
-            "email": "your.name@example.com",
-            "url": "https://example.com"
-        },
-        {
-            "name": "Peter Somogyvari",
-            "email": "peter.somogyvari@accenture.com",
-            "url": "https://accenture.com"
-        },
-        {
-            "name": "Jordi Giron",
-            "email": "jordi.giron.amezcua@accenture.com",
-            "url": "https://accenture.com"
-        }
-    ],
-    "main": "dist/lib/main/typescript/index.js",
-    "module": "dist/lib/main/typescript/index.js",
-    "browser": "dist/cactus-plugin-htlc-eth-besu-erc20.web.umd.js",
-    "types": "dist/lib/main/typescript/index.d.ts",
-    "files": [
-        "dist/*"
-    ],
-    "scripts": {
-        "codegen": "run-p 'codegen:*'",
-        "codegen:openapi": "npm run generate-sdk",
-        "generate-sdk": "run-p 'generate-sdk:*'",
-        "generate-sdk:typescript-axios": "openapi-generator-cli generate -i ./src/main/json/openapi.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
-        "generate-sdk:kotlin": "openapi-generator-cli generate -i ./src/main/json/openapi.json -g kotlin -o ./src/main/kotlin/generated/openapi/kotlin-client/ --reserved-words-mappings protected=protected",
-        "watch": "npm-watch",
-        "webpack": "npm-run-all webpack:dev",
-        "webpack:dev": "npm-run-all webpack:dev:node webpack:dev:web",
-        "webpack:dev:node": "webpack --env=dev --target=node --config ../../webpack.config.js",
-        "webpack:dev:web": "webpack --env=dev --target=web --config ../../webpack.config.js"
-    },
-    "dependencies": {
-        "@hyperledger/cactus-common": "2.0.0-alpha.1",
-        "@hyperledger/cactus-core": "2.0.0-alpha.1",
-        "@hyperledger/cactus-core-api": "2.0.0-alpha.1",
-        "@hyperledger/cactus-plugin-ledger-connector-besu": "2.0.0-alpha.1",
-        "axios": "0.21.4",
-        "express": "4.17.1",
-        "joi": "17.9.1",
-        "openapi-types": "9.1.0",
-        "typescript-optional": "2.0.1"
-    },
-    "devDependencies": {
-        "@types/express": "4.17.13"
-    },
-    "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-    },
-    "publishConfig": {
-        "access": "public"
-    },
-    "browserMinified": "dist/cactus-plugin-htlc-eth-besu-erc20.web.umd.min.js",
-    "mainMinified": "dist/cactus-plugin-htlc-eth-besu-erc20.node.umd.min.js",
-    "watch": {
-        "codegen:openapi": {
-            "patterns": [
-                "./src/main/json/openapi.json"
-            ]
-        }
+    {
+      "name": "Jordi Giron",
+      "email": "jordi.giron.amezcua@accenture.com",
+      "url": "https://accenture.com"
     }
+  ],
+  "main": "dist/lib/main/typescript/index.js",
+  "module": "dist/lib/main/typescript/index.js",
+  "browser": "dist/cactus-plugin-htlc-eth-besu-erc20.web.umd.js",
+  "types": "dist/lib/main/typescript/index.d.ts",
+  "files": [
+    "dist/*"
+  ],
+  "scripts": {
+    "codegen": "run-p 'codegen:*'",
+    "codegen:openapi": "npm run generate-sdk",
+    "generate-sdk": "run-p 'generate-sdk:*'",
+    "generate-sdk:typescript-axios": "openapi-generator-cli generate -i ./src/main/json/openapi.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
+    "generate-sdk:kotlin": "openapi-generator-cli generate -i ./src/main/json/openapi.json -g kotlin -o ./src/main/kotlin/generated/openapi/kotlin-client/ --reserved-words-mappings protected=protected",
+    "watch": "npm-watch",
+    "webpack": "npm-run-all webpack:dev",
+    "webpack:dev": "npm-run-all webpack:dev:node webpack:dev:web",
+    "webpack:dev:node": "webpack --env=dev --target=node --config ../../webpack.config.js",
+    "webpack:dev:web": "webpack --env=dev --target=web --config ../../webpack.config.js"
+  },
+  "dependencies": {
+    "@hyperledger/cactus-common": "2.0.0-alpha.1",
+    "@hyperledger/cactus-core": "2.0.0-alpha.1",
+    "@hyperledger/cactus-core-api": "2.0.0-alpha.1",
+    "@hyperledger/cactus-plugin-ledger-connector-besu": "2.0.0-alpha.1",
+    "axios": "0.21.4",
+    "express": "4.17.1",
+    "joi": "17.9.1",
+    "openapi-types": "9.1.0",
+    "typescript-optional": "2.0.1"
+  },
+  "devDependencies": {
+    "@types/express": "4.17.13"
+  },
+  "engines": {
+    "node": ">=10",
+    "npm": ">=6"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "browserMinified": "dist/cactus-plugin-htlc-eth-besu-erc20.web.umd.min.js",
+  "mainMinified": "dist/cactus-plugin-htlc-eth-besu-erc20.node.umd.min.js",
+  "watch": {
+    "codegen:openapi": {
+      "patterns": [
+        "./src/main/json/openapi.json"
+      ]
+    }
+  }
 }

--- a/packages/cactus-plugin-htlc-eth-besu/package.json
+++ b/packages/cactus-plugin-htlc-eth-besu/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-keychain-aws-sm/package.json
+++ b/packages/cactus-plugin-keychain-aws-sm/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-keychain-azure-kv/package.json
+++ b/packages/cactus-plugin-keychain-azure-kv/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-keychain-google-sm/package.json
+++ b/packages/cactus-plugin-keychain-google-sm/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-keychain-memory-wasm/package.json
+++ b/packages/cactus-plugin-keychain-memory-wasm/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-keychain-memory/package.json
+++ b/packages/cactus-plugin-keychain-memory/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-keychain-vault/package.json
+++ b/packages/cactus-plugin-keychain-vault/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-ledger-connector-besu/package.json
+++ b/packages/cactus-plugin-ledger-connector-besu/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-ledger-connector-corda/package.json
+++ b/packages/cactus-plugin-ledger-connector-corda/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-ledger-connector-fabric/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/package.json
@@ -1,22 +1,53 @@
 {
   "name": "@hyperledger/cactus-plugin-ledger-connector-go-ethereum-socketio",
   "version": "2.0.0-alpha.1",
+  "description": "Allows Cactus nodes to connect to a Ethereum ledger ",
+  "keywords": [
+    "Hyperledger",
+    "Cactus",
+    "Integration",
+    "Blockchain",
+    "Distributed Ledger Technology"
+  ],
+  "homepage": "https://github.com/hyperledger/cacti#readme",
+  "bugs": {
+    "url": "https://github.com/hyperledger/cacti/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hyperledger/cacti.git"
+  },
   "license": "Apache-2.0",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "author": {
+    "name": "Hyperledger Cactus Contributors",
+    "email": "cactus@lists.hyperledger.org",
+    "url": "https://www.hyperledger.org/use/cacti"
+  },
+  "contributors": [
+    {
+      "name": "Please add yourself to the list of contributors",
+      "email": "your.name@example.com",
+      "url": "https://example.com"
+    }
+  ],
+  "main": "dist/lib/main/typescript/index.js",
+  "module": "dist/lib/main/typescript/index.js",
+  "types": "dist/lib/main/typescript/index.d.ts",
   "scripts": {
     "start": "cd ./dist && node common/core/bin/www.js",
     "debug": "nodemon --inspect ./dist/common/core/bin/www.js",
     "build": "npm run build-ts && npm run build:dev:backend:postbuild",
     "build-ts": "tsc",
     "build:dev:backend:postbuild": "npm run init-ethereum",
-    "init-ethereum": "cp -af ../../yarn.lock ./dist/yarn.lock"
+    "init-ethereum": "cp -af ../../yarn.lock ./dist/lib/yarn.lock"
   },
+  "files": [
+    "dist/*"
+  ],
   "dependencies": {
     "@hyperledger/cactus-cmd-socketio-server": "2.0.0-alpha.1",
     "@hyperledger/cactus-common": "2.0.0-alpha.1",
-    "@types/node": "14.17.32",
+    "@types/node": "15.14.7",
     "body-parser": "1.17.2",
     "cookie-parser": "1.4.6",
     "debug": "3.1.0",
@@ -27,7 +58,6 @@
     "log4js": "6.4.1",
     "morgan": "1.10.0",
     "serve-favicon": "2.4.5",
-    "shelljs": "0.8.5",
     "socket.io": "4.5.4",
     "web3": "1.8.1"
   },
@@ -38,6 +68,17 @@
     "@types/config": "0.0.41",
     "@types/cookie-parser": "1.4.3",
     "@types/express": "4.17.13",
-    "@types/http-errors": "2.0.1"
+    "@types/http-errors": "2.0.1",
+    "@types/node": "15.14.7",
+    "@types/shelljs": "0.8.12",
+    "shelljs": "0.8.5",
+    "socket.io-client": "4.5.4"
+  },
+  "engines": {
+    "node": ">=10",
+    "npm": ">=6"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/package.json
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/package.json
@@ -13,11 +13,12 @@
     "config": "1.31.0",
     "ethereumjs-common": "1.5.2",
     "ethereumjs-tx": "2.1.2",
+    "socket.io-client": "4.5.4",
     "ts-node": "9.1.1",
-    "web3": "1.7.0",
-    "socket.io-client": "4.5.4"
+    "web3": "1.7.0"
   },
   "devDependencies": {
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "@types/shelljs": "^0.8.12"
   }
 }

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/validatorDriver_getNonceHex.ts
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/validatorDriver_getNonceHex.ts
@@ -60,7 +60,7 @@ import { io } from "socket.io-client";
     reqID: reqID,
   };
 
-  const json2str = (jsonObj) => {
+  const json2str = (jsonObj: object) => {
     try {
       return JSON.stringify(jsonObj);
     } catch (error) {
@@ -68,25 +68,25 @@ import { io } from "socket.io-client";
     }
   };
 
-  socket.on("connect_error", (err) => {
+  socket.on("connect_error", (err: object) => {
     console.log("####connect_error:", err);
     // end communication
     socket.disconnect();
     process.exit(0);
   });
 
-  socket.on("connect_timeout", (err) => {
+  socket.on("connect_timeout", (err: object) => {
     console.log("####Error:", err);
     // end communication
     socket.disconnect();
     process.exit(0);
   });
 
-  socket.on("error", (err) => {
+  socket.on("error", (err: object) => {
     console.log("####Error:", err);
   });
 
-  socket.on("eventReceived", function (res) {
+  socket.on("eventReceived", function (res: object) {
     // output the data received from the client
     console.log("#[recv]eventReceived, res: " + json2str(res));
   });

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/validatorDriver_getNumericBalance.ts
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/validatorDriver_getNumericBalance.ts
@@ -57,7 +57,7 @@ import { io } from "socket.io-client";
     reqID: reqID,
   };
 
-  const json2str = (jsonObj) => {
+  const json2str = (jsonObj: object) => {
     try {
       return JSON.stringify(jsonObj);
     } catch (error) {
@@ -65,25 +65,25 @@ import { io } from "socket.io-client";
     }
   };
 
-  socket.on("connect_error", (err) => {
+  socket.on("connect_error", (err: object) => {
     console.log("####connect_error:", err);
     // end communication
     socket.disconnect();
     process.exit(0);
   });
 
-  socket.on("connect_timeout", (err) => {
+  socket.on("connect_timeout", (err: object) => {
     console.log("####Error:", err);
     // end communication
     socket.disconnect();
     process.exit(0);
   });
 
-  socket.on("error", (err) => {
+  socket.on("error", (err: object) => {
     console.log("####Error:", err);
   });
 
-  socket.on("eventReceived", function (res) {
+  socket.on("eventReceived", function (res: object) {
     // output the data received from the client
     console.log("#[recv]eventReceived, res: " + json2str(res));
   });

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/validatorDriver_sendRawTransaction.ts
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/validatorDriver_sendRawTransaction.ts
@@ -65,7 +65,7 @@ import { io } from "socket.io-client";
 
   const gas = 21000;
 
-  const json2str = (jsonObj) => {
+  const json2str = (jsonObj: any) => {
     try {
       return JSON.stringify(jsonObj);
     } catch (error) {
@@ -75,7 +75,7 @@ import { io } from "socket.io-client";
 
   const makeTxTransferNumericAsset = () => {
     //web3_v1.2.9_support
-    web3.eth.getTransactionCount("0x" + fromAddress).then((_nance) => {
+    web3.eth.getTransactionCount("0x" + fromAddress).then((_nance: any) => {
       const txnCount = _nance;
       //  NOTE: No need to count up.
 
@@ -115,25 +115,25 @@ import { io } from "socket.io-client";
     });
   };
 
-  socket.on("connect_error", (err) => {
+  socket.on("connect_error", (err: object) => {
     console.log("####connect_error:", err);
     // end communication
     socket.disconnect();
     process.exit(0);
   });
 
-  socket.on("connect_timeout", (err) => {
+  socket.on("connect_timeout", (err: object) => {
     console.log("####Error:", err);
     // end communication
     socket.disconnect();
     process.exit(0);
   });
 
-  socket.on("error", (err) => {
+  socket.on("error", (err: any) => {
     console.log("####Error:", err);
   });
 
-  socket.on("eventReceived", function (res) {
+  socket.on("eventReceived", function (res: object) {
     // output the data received from the client
     console.log("#[recv]eventReceived, res: " + json2str(res));
   });

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/validatorDriver_transferNumericAsset.ts
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/validatorDriver_transferNumericAsset.ts
@@ -70,7 +70,7 @@ import { io } from "socket.io-client";
     reqID: reqID,
   };
 
-  const json2str = (jsonObj) => {
+  const json2str = (jsonObj: object) => {
     try {
       return JSON.stringify(jsonObj);
     } catch (error) {
@@ -78,25 +78,25 @@ import { io } from "socket.io-client";
     }
   };
 
-  socket.on("connect_error", (err) => {
+  socket.on("connect_error", (err: object) => {
     console.log("####connect_error:", err);
     // end communication
     socket.disconnect();
     process.exit(0);
   });
 
-  socket.on("connect_timeout", (err) => {
+  socket.on("connect_timeout", (err: object) => {
     console.log("####Error:", err);
     // end communication
     socket.disconnect();
     process.exit(0);
   });
 
-  socket.on("error", (err) => {
+  socket.on("error", (err: object) => {
     console.log("####Error:", err);
   });
 
-  socket.on("eventReceived", function (res) {
+  socket.on("eventReceived", function (res: any) {
     // output the data received from the client
     console.log("#[recv]eventReceived, res: " + json2str(res));
   });

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/tsconfig.json
@@ -1,20 +1,24 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src/main/typescript",
+    "rootDir": "./src",
     "composite": true,
-    "outDir": "./dist",
+    "outDir": "./dist/lib/",
+    "declarationDir": "./dist/lib",
     "sourceMap": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "tsBuildInfoFile": "../../.build-cache/cactus-plugin-ledger-connector-go-ethereum-socketio.tsbuildinfo",
+    "tsBuildInfoFile": "../../.build-cache/cactus-plugin-ledger-connector-go-ethereum-socketio.tsbuildinfo"
   },
   "include": [
     "./src/main/typescript/common/core/*.ts",
     "./src/main/typescript/common/core/bin/*.ts",
     "./src/main/typescript/common/core/config/*.ts",
     "./src/main/typescript/connector/*.ts",
-    "./src/main/typescript/*.ts"
+    "./src/main/typescript/*.ts",
+    "./src/test/typescript/**/*.ts",
+    "src/**/*.json",
+    "src/**/*.sol"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-ledger-connector-iroha/package.json
+++ b/packages/cactus-plugin-ledger-connector-iroha/package.json
@@ -22,7 +22,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-ledger-connector-iroha2/package.json
+++ b/packages/cactus-plugin-ledger-connector-iroha2/package.json
@@ -24,7 +24,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-ledger-connector-quorum/package.json
+++ b/packages/cactus-plugin-ledger-connector-quorum/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-ledger-connector-sawtooth-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-sawtooth-socketio/package.json
@@ -1,17 +1,45 @@
 {
   "name": "@hyperledger/cactus-plugin-ledger-connector-sawtooth-socketio",
   "version": "2.0.0-alpha.1",
+  "description": "Allows Cactus nodes to connect to a Sawtooth ledger",
+  "keywords": [
+    "Hyperledger",
+    "Cactus",
+    "Integration",
+    "Blockchain",
+    "Distributed Ledger Technology"
+  ],
+  "homepage": "https://github.com/hyperledger/cacti#readme",
+  "bugs": {
+    "url": "https://github.com/hyperledger/cacti/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hyperledger/cacti.git"
+  },
   "license": "Apache-2.0",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "author": {
+    "name": "Hyperledger Cactus Contributors",
+    "email": "cactus@lists.hyperledger.org",
+    "url": "https://www.hyperledger.org/use/cacti"
+  },
+  "contributors": [
+    {
+      "name": "Please add yourself to the list of contributors",
+      "email": "your.name@example.com",
+      "url": "https://example.com"
+    }
+  ],
+  "main": "dist/lib/main/typescript/index.js",
+  "module": "dist/lib/main/typescript/index.js",
+  "types": "dist/lib/main/typescript/index.d.ts",
   "scripts": {
     "start": "cd ./dist && node common/core/bin/www.js",
     "debug": "nodemon --inspect ./dist/common/core/bin/www.js",
     "build": "npm run build-ts && npm run build:dev:backend:postbuild",
     "build-ts": "tsc",
     "build:dev:backend:postbuild": "npm run init-sawtooth",
-    "init-sawtooth": "cp -af ../../yarn.lock ./dist/yarn.lock"
+    "init-sawtooth": "cp -af ../../yarn.lock ./dist/lib/yarn.lock"
   },
   "dependencies": {
     "@hyperledger/cactus-cmd-socketio-server": "2.0.0-alpha.1",
@@ -39,5 +67,15 @@
     "@types/cookie-parser": "1.4.3",
     "@types/express": "4.17.13",
     "@types/http-errors": "2.0.1"
+  },
+  "engines": {
+    "node": ">=10",
+    "npm": ">=6"
+  },
+  "files": [
+    "dist/*"
+  ],
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/cactus-plugin-ledger-connector-sawtooth-socketio/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-sawtooth-socketio/tsconfig.json
@@ -1,20 +1,21 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src/main/typescript",
+    "rootDir": "./src",
     "composite": true,
-    "outDir": "./dist",
+    "outDir": "./dist/lib",
     "sourceMap": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "tsBuildInfoFile": "../../.build-cache/cactus-plugin-ledger-connector-sawtooth-socketio.tsbuildinfo",
+    "tsBuildInfoFile": "../../.build-cache/cactus-plugin-ledger-connector-sawtooth-socketio.tsbuildinfo"
   },
   "include": [
     "./src/main/typescript/common/core/*.ts",
     "./src/main/typescript/common/core/bin/*.ts",
     "./src/main/typescript/common/core/config/*.ts",
     "./src/main/typescript/connector/*.ts",
-    "./src/main/typescript/*.ts"
+    "./src/main/typescript/*.ts",
+    "./src/test/typescript/integration/*.ts"
   ],
   "references": [
     {

--- a/packages/cactus-plugin-ledger-connector-tcs-huawei-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-tcs-huawei-socketio/package.json
@@ -1,7 +1,42 @@
 {
   "name": "@hyperledger/cactus-plugin-ledger-connector-tcs-huawei-socketio",
   "version": "2.0.0-alpha.1",
+  "description": "Allows Cactus nodes to connect to a Trusted Cross-chain Service-Huawei",
+  "keywords": [
+    "Hyperledger",
+    "Cactus",
+    "Integration",
+    "Blockchain",
+    "Distributed Ledger Technology"
+  ],
+  "homepage": "https://github.com/hyperledger/cacti#readme",
+  "bugs": {
+    "url": "https://github.com/hyperledger/cacti/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hyperledger/cacti.git"
+  },
   "license": "Apache-2.0",
+  "author": {
+    "name": "Hyperledger Cactus Contributors",
+    "email": "cactus@lists.hyperledger.org",
+    "url": "https://www.hyperledger.org/use/cacti"
+  },
+  "contributors": [
+    {
+      "name": "Please add yourself to the list of contributors",
+      "email": "your.name@example.com",
+      "url": "https://example.com"
+    }
+  ],
+  "main": "dist/lib/main/typescript/index.js",
+  "module": "dist/lib/main/typescript/index.js",
+  "browser": "dist/cactus-plugin-htlc-eth-besu.web.umd.js",
+  "types": "dist/lib/main/typescript/index.d.ts",
+  "files": [
+    "dist/*"
+  ],
   "scripts": {
     "start": "cd ./dist && node common/core/bin/www.js",
     "debug": "nodemon --inspect ./dist/common/core/bin/www.js",
@@ -33,5 +68,12 @@
     "@types/cookie-parser": "1.4.3",
     "@types/express": "4.17.13",
     "@types/http-errors": "2.0.1"
+  },
+  "engines": {
+    "node": ">=10",
+    "npm": ">=6"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/cactus-plugin-ledger-connector-tcs-huawei-socketio/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-tcs-huawei-socketio/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "./src/main/typescript",
     "composite": true,
-    "outDir": "./dist",
+    "outDir": "./dist/lib/",
+    "declarationDir": "dist/lib", 
+    "resolveJsonModule": true,
+    "rootDir": "./src",
     "sourceMap": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "tsBuildInfoFile": "../../.build-cache/cactus-plugin-ledger-connector-tcs-huawei-socketio.tsbuildinfo",
+    "tsBuildInfoFile": "../../.build-cache/cactus-plugin-ledger-connector-tcs-huawei-socketio.tsbuildinfo"
   },
   "include": [
     "./src/main/typescript/common/core/*.ts",

--- a/packages/cactus-plugin-ledger-connector-ubiquity/package.json
+++ b/packages/cactus-plugin-ledger-connector-ubiquity/package.json
@@ -1,102 +1,102 @@
 {
-    "name": "@hyperledger/cactus-plugin-ledger-connector-ubiquity",
-    "version": "2.0.0-alpha.1",
-    "description": "Allows Cacti nodes to connect to a set of public blockchains.",
-    "keywords": [
-        "Hyperledger",
-        "Cactus",
-        "Integration",
-        "Blockchain",
-        "Distributed Ledger Technology",
-        "Ubiquity"
-    ],
-    "homepage": "https://github.com/hyperledger/cacti#readme",
-    "bugs": {
-        "url": "https://github.com/hyperledger/cacti/issues"
+  "name": "@hyperledger/cactus-plugin-ledger-connector-ubiquity",
+  "version": "2.0.0-alpha.1",
+  "description": "Allows Cacti nodes to connect to a set of public blockchains.",
+  "keywords": [
+    "Hyperledger",
+    "Cactus",
+    "Integration",
+    "Blockchain",
+    "Distributed Ledger Technology",
+    "Ubiquity"
+  ],
+  "homepage": "https://github.com/hyperledger/cacti#readme",
+  "bugs": {
+    "url": "https://github.com/hyperledger/cacti/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hyperledger/cacti.git"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Hyperledger Cactus Contributors",
+    "email": "cactus@lists.hyperledger.org",
+    "url": "https://www.hyperledger.org/use/cacti"
+  },
+  "contributors": [
+    {
+      "name": "Please add yourself to the list of contributors",
+      "email": "your.name@example.com",
+      "url": "https://example.com"
     },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/hyperledger/cacti.git"
-    },
-    "license": "Apache-2.0",
-    "author": {
-        "name": "Hyperledger Cactus Contributors",
-        "email": "cactus@lists.hyperledger.org",
-        "url": "https://www.hyperledger.org/use/cactus"
-    },
-    "contributors": [
-        {
-            "name": "Please add yourself to the list of contributors",
-            "email": "your.name@example.com",
-            "url": "https://example.com"
-        },
-        {
-            "name": "Rafael Belchior",
-            "email": "rbelchior@blockdaemon.com",
-            "url": "https://blockdaemon.com"
-        }
-    ],
-    "main": "dist/lib/main/typescript/index.js",
-    "module": "dist/lib/main/typescript/index.js",
-    "browser": "dist/cactus-plugin-ledger-connector-ubiquity.web.umd.js",
-    "types": "dist/lib/main/typescript/index.d.ts",
-    "files": [
-        "dist/*"
-    ],
-    "scripts": {
-        "codegen": "run-p 'codegen:*'",
-        "codegen:openapi": "npm run generate-sdk",
-        "generate-sdk": "openapi-generator-cli generate -i ./src/main/json/openapi.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
-        "watch": "npm-watch",
-        "webpack": "npm-run-all webpack:dev",
-        "webpack:dev": "npm-run-all webpack:dev:node webpack:dev:web",
-        "webpack:dev:node": "webpack --env=dev --target=node --config ../../webpack.config.js",
-        "webpack:dev:web": "webpack --env=dev --target=web --config ../../webpack.config.js",
-        "tsc": "tsc --project ./tsconfig.json"
-    },
-    "dependencies": {
-        "@hyperledger/cactus-core": "2.0.0-alpha.1",
-        "@hyperledger/cactus-core-api": "2.0.0-alpha.1",
-        "@ubiquity/ubiquity-ts-client-modified": "https://github.com/RafaelAPB/ubiquity-ts-client-mirror.git",
-        "dotenv": "16.0.1",
-        "prom-client": "13.2.0",
-        "typescript-optional": "2.0.1"
-    },
-    "devDependencies": {
-        "@hyperledger/cactus-common": "2.0.0-alpha.1",
-        "@hyperledger/cactus-test-tooling": "2.0.0-alpha.1",
-        "@types/express": "4.17.8"
-    },
-    "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-    },
-    "publishConfig": {
-        "access": "public"
-    },
-    "browserMinified": "dist/cactus-plugin-ledger-connector-ubiquity.web.umd.min.js",
-    "mainMinified": "dist/cactus-plugin-ledger-connector-ubiquity.node.umd.min.js",
-    "watch": {
-        "codegen:openapi": {
-            "patterns": [
-                "./src/main/json/openapi.json"
-            ]
-        },
-        "tsc": {
-            "patterns": [
-                "src/",
-                "src/*/json/**/openapi*"
-            ],
-            "ignore": [
-                "src/**/generated/*"
-            ],
-            "extensions": [
-                "ts",
-                "json"
-            ],
-            "quiet": true,
-            "verbose": false,
-            "runOnChangeOnly": true
-        }
+    {
+      "name": "Rafael Belchior",
+      "email": "rbelchior@blockdaemon.com",
+      "url": "https://blockdaemon.com"
     }
+  ],
+  "main": "dist/lib/main/typescript/index.js",
+  "module": "dist/lib/main/typescript/index.js",
+  "browser": "dist/cactus-plugin-ledger-connector-ubiquity.web.umd.js",
+  "types": "dist/lib/main/typescript/index.d.ts",
+  "files": [
+    "dist/*"
+  ],
+  "scripts": {
+    "codegen": "run-p 'codegen:*'",
+    "codegen:openapi": "npm run generate-sdk",
+    "generate-sdk": "openapi-generator-cli generate -i ./src/main/json/openapi.json -g typescript-axios -o ./src/main/typescript/generated/openapi/typescript-axios/ --reserved-words-mappings protected=protected",
+    "watch": "npm-watch",
+    "webpack": "npm-run-all webpack:dev",
+    "webpack:dev": "npm-run-all webpack:dev:node webpack:dev:web",
+    "webpack:dev:node": "webpack --env=dev --target=node --config ../../webpack.config.js",
+    "webpack:dev:web": "webpack --env=dev --target=web --config ../../webpack.config.js",
+    "tsc": "tsc --project ./tsconfig.json"
+  },
+  "dependencies": {
+    "@hyperledger/cactus-core": "2.0.0-alpha.1",
+    "@hyperledger/cactus-core-api": "2.0.0-alpha.1",
+    "@ubiquity/ubiquity-ts-client-modified": "https://github.com/RafaelAPB/ubiquity-ts-client-mirror.git",
+    "dotenv": "16.0.1",
+    "prom-client": "13.2.0",
+    "typescript-optional": "2.0.1"
+  },
+  "devDependencies": {
+    "@hyperledger/cactus-common": "2.0.0-alpha.1",
+    "@hyperledger/cactus-test-tooling": "2.0.0-alpha.1",
+    "@types/express": "4.17.8"
+  },
+  "engines": {
+    "node": ">=10",
+    "npm": ">=6"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "browserMinified": "dist/cactus-plugin-ledger-connector-ubiquity.web.umd.min.js",
+  "mainMinified": "dist/cactus-plugin-ledger-connector-ubiquity.node.umd.min.js",
+  "watch": {
+    "codegen:openapi": {
+      "patterns": [
+        "./src/main/json/openapi.json"
+      ]
+    },
+    "tsc": {
+      "patterns": [
+        "src/",
+        "src/*/json/**/openapi*"
+      ],
+      "ignore": [
+        "src/**/generated/*"
+      ],
+      "extensions": [
+        "ts",
+        "json"
+      ],
+      "quiet": true,
+      "verbose": false,
+      "runOnChangeOnly": true
+    }
+  }
 }

--- a/packages/cactus-plugin-ledger-connector-xdai/package.json
+++ b/packages/cactus-plugin-ledger-connector-xdai/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-odap-hermes/package.json
+++ b/packages/cactus-plugin-odap-hermes/package.json
@@ -18,7 +18,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-plugin-persistence-ethereum/package.json
+++ b/packages/cactus-plugin-persistence-ethereum/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-api-client/package.json
+++ b/packages/cactus-test-api-client/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-cmd-api-server/package.json
+++ b/packages/cactus-test-cmd-api-server/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-plugin-consortium-manual/package.json
+++ b/packages/cactus-test-plugin-consortium-manual/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/package.json
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-plugin-htlc-eth-besu/package.json
+++ b/packages/cactus-test-plugin-htlc-eth-besu/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-plugin-ledger-connector-besu/package.json
+++ b/packages/cactus-test-plugin-ledger-connector-besu/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-plugin-ledger-connector-quorum/package.json
+++ b/packages/cactus-test-plugin-ledger-connector-quorum/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-tooling/package.json
+++ b/packages/cactus-test-tooling/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-verifier-client/package.json
+++ b/packages/cactus-test-verifier-client/package.json
@@ -21,7 +21,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/packages/cactus-test-verifier-client/tsconfig.json
+++ b/packages/cactus-test-verifier-client/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "outDir": "./dist/",
+    "outDir": "./dist/lib",
     "declarationDir": "dist/",
     "resolveJsonModule": true,
     "rootDir": "./src",

--- a/packages/cactus-verifier-client/package.json
+++ b/packages/cactus-verifier-client/package.json
@@ -29,7 +29,7 @@
   "author": {
     "name": "Hyperledger Cactus Contributors",
     "email": "cactus@lists.hyperledger.org",
-    "url": "https://www.hyperledger.org/use/cactus"
+    "url": "https://www.hyperledger.org/use/cacti"
   },
   "contributors": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7174,7 +7174,8 @@ __metadata:
     "@types/cookie-parser": 1.4.3
     "@types/express": 4.17.13
     "@types/http-errors": 2.0.1
-    "@types/node": 14.17.32
+    "@types/node": 15.14.7
+    "@types/shelljs": 0.8.12
     body-parser: 1.17.2
     cookie-parser: 1.4.6
     debug: 3.1.0
@@ -7187,6 +7188,7 @@ __metadata:
     serve-favicon: 2.4.5
     shelljs: 0.8.5
     socket.io: 4.5.4
+    socket.io-client: 4.5.4
     web3: 1.8.1
   languageName: unknown
   linkType: soft
@@ -11501,7 +11503,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/glob@npm:*, @types/glob@npm:^7.1.1":
+"@types/glob@npm:*, @types/glob@npm:^7.1.1, @types/glob@npm:~7.2.0":
   version: 7.2.0
   resolution: "@types/glob@npm:7.2.0"
   dependencies:
@@ -12193,6 +12195,16 @@ __metadata:
     "@types/glob": "*"
     "@types/node": "*"
   checksum: 559b81efba72f2b231485b26510aad68cccfe98dc74087d67dafd5511462997884db0ef18e0e56bf61a3a5789aa65a54dc04845a488bb0528d4a699e6151b99c
+  languageName: node
+  linkType: hard
+
+"@types/shelljs@npm:0.8.12":
+  version: 0.8.12
+  resolution: "@types/shelljs@npm:0.8.12"
+  dependencies:
+    "@types/glob": ~7.2.0
+    "@types/node": "*"
+  checksum: ffb47809abef9ee53f900c6b49adb1382d1d78af7f8b50dd474534e3f73127bc4a3849394e4c9de16481cd50203b12464141b4b49d48e88ba6b4c7cc2c85948c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- change package.json and tsconfig.json files to follow common
convention

Peter's additions to fix the broken build:
- Included shelljs typings as a dev dependency for the package called
cactus-plugin-ledger-connector-go-ethereum-socketio
- Also included "socket.io-client" as another missing dev dependency for
the package above.

Closes: https://github.com/hyperledger/cacti/issues/2216

Co-authored-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Signed-off-by: Tomasz Awramski <tomasz.awramski@fujitsu.com>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>