### PR TITLE
docs(examples): fix CVE-2022-24785 - test-run-transaction/supply-chain-app-stub

### DIFF
--- a/examples/test-run-transaction/supply-chain-app-stub/package.json
+++ b/examples/test-run-transaction/supply-chain-app-stub/package.json
@@ -7,7 +7,7 @@
     "body-parser": "1.19.2",
     "cors": "2.8.5",
     "express": "4.17.3",
-    "moment": "2.29.1",
+    "moment": "2.29.4",
     "mongodb": "3.7.3",
     "mongoose": "5.13.14",
     "ts-node": "9.1.1",


### PR DESCRIPTION
CVE-2022-24785
- https://nvd.nist.gov/vuln/detail/cve-2022-24785

GHSA-8hfj-j24r-96c4
- https://github.com/advisories/GHSA-8hfj-j24r-96c4

Fixes #2608

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>