### PR TITLE
fix(security): crash in HeaderParser in dicer

### DIFF
--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -75,7 +75,7 @@
     "express": "4.17.3",
     "express-http-proxy": "1.6.2",
     "express-jwt": "8.4.1",
-    "express-openapi-validator": "4.12.12",
+    "express-openapi-validator": "5.0.4",
     "express-rate-limit": "6.7.0",
     "fs-extra": "10.0.0",
     "google-protobuf": "3.18.0-rc.2",

--- a/packages/cactus-core/package.json
+++ b/packages/cactus-core/package.json
@@ -54,7 +54,7 @@
     "@hyperledger/cactus-core-api": "2.0.0-alpha.1",
     "express": "4.17.3",
     "express-jwt-authz": "2.4.1",
-    "express-openapi-validator": "4.13.8",
+    "express-openapi-validator": "5.0.4",
     "typescript-optional": "2.0.1"
   },
   "devDependencies": {

--- a/packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -164,7 +164,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSet} without required key: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("key"), "Rejected because key is required");
     }
@@ -183,7 +183,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fGet} without required key: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("key"), "Rejected because key is required");
     }
@@ -202,7 +202,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fHas} without required key: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("key"), "Rejected because key is required");
     }
@@ -221,7 +221,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDelete} without required key: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("key"), "Rejected because key is required");
     }
@@ -242,7 +242,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSet} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -265,7 +265,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fGet} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -288,7 +288,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fHas} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -311,7 +311,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDelete} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -119,7 +119,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSet} without required key: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("key"), "Rejected because key is required");
     }
@@ -138,7 +138,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fGet} without required key: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("key"), "Rejected because key is required");
     }
@@ -157,7 +157,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fHas} without required key: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("key"), "Rejected because key is required");
     }
@@ -176,7 +176,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDelete} without required key: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("key"), "Rejected because key is required");
     }
@@ -197,7 +197,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSet} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -220,7 +220,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fGet} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -243,7 +243,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fHas} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -266,7 +266,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDelete} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -147,7 +147,7 @@ test(`${testCase}`, async (t: Test) => {
         `Endpoint ${fSet} without required key: response.status === 400 OK`,
       );
       const fields = e?.response?.data.map((param) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields?.includes("key"), "Rejected because key is required");
     }
@@ -165,7 +165,7 @@ test(`${testCase}`, async (t: Test) => {
         `Endpoint ${fHas} without required key: response.status === 400 OK`,
       );
       const fields = e?.response?.data.map((param) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields?.includes("key"), "Rejected because key is required");
     }
@@ -183,7 +183,7 @@ test(`${testCase}`, async (t: Test) => {
         `Endpoint ${fGet} without required key: response.status === 400 OK`,
       );
       const fields = e?.response?.data.map((param) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields?.includes("key"), "Rejected because key is required");
     }
@@ -201,7 +201,7 @@ test(`${testCase}`, async (t: Test) => {
         `Endpoint ${fDelete} without required key: response.status === 400 OK`,
       );
       const fields = e?.response?.data.map((param) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields?.includes("key"), "Rejected because key is required");
     }
@@ -223,7 +223,7 @@ test(`${testCase}`, async (t: Test) => {
         `Endpoint ${fSet} with fake=4: response.status === 400 OK`,
       );
       const fields = e?.response?.data.map((param) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields?.includes("fake"),
@@ -247,7 +247,7 @@ test(`${testCase}`, async (t: Test) => {
         `Endpoint ${fHas} with fake=4: response.status === 400 OK`,
       );
       const fields = e?.response?.data.map((param) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields?.includes("fake"),
@@ -271,7 +271,7 @@ test(`${testCase}`, async (t: Test) => {
         `Endpoint ${fGet} with fake=4: response.status === 400 OK`,
       );
       const fields =
-        e?.response?.data.map((param) => param.path.replace(".body.", "")) ||
+        e?.response?.data.map((param) => param.path.replace("/body/", "")) ||
         [];
       t2.ok(
         fields.includes("fake"),
@@ -295,7 +295,7 @@ test(`${testCase}`, async (t: Test) => {
         `Endpoint ${fDelete} with fake=4: response.status === 400 OK`,
       );
       const fields = e?.response?.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields?.includes("fake"),

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/openapi/openapi-validation.test.ts
@@ -207,7 +207,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} without required contractName and bytecode: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractName"),
@@ -249,7 +249,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -310,7 +310,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} without required contractName: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractName"),
@@ -345,7 +345,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -408,7 +408,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} without required consistencyStrategy: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("consistencyStrategy"),
@@ -448,7 +448,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -549,7 +549,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSign} without required keychainId: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("keychainId"),
@@ -605,7 +605,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSign} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -640,7 +640,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fBalance} without required address: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("address"), "Rejected because address is required");
     }
@@ -662,7 +662,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fBalance} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -693,7 +693,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fBlock} without required blockHashOrBlockNumber: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("blockHashOrBlockNumber"),
@@ -718,7 +718,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fBlock} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -755,7 +755,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fPastLogs} without required address: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("address"), "Rejected because address is required");
     }
@@ -777,7 +777,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fPastLogs} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -845,7 +845,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRecord} without required transactionHash: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("transactionHash"),
@@ -870,7 +870,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRecord} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-plugin-ledger-connector-corda/package.json
+++ b/packages/cactus-plugin-ledger-connector-corda/package.json
@@ -60,7 +60,7 @@
     "@hyperledger/cactus-core": "2.0.0-alpha.1",
     "@hyperledger/cactus-core-api": "2.0.0-alpha.1",
     "axios": "0.21.4",
-    "express-openapi-validator": "3.10.0",
+    "express-openapi-validator": "5.0.4",
     "internal-ip": "6.2.0",
     "joi": "17.9.1",
     "node-ssh": "13.1.0",

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/openapi/openapi-validation-go.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/openapi/openapi-validation-go.test.ts
@@ -235,7 +235,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeployGo} without required targetPeerAddresses: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("targetPeerAddresses"),
@@ -297,7 +297,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeployGo} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -320,7 +320,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} without required channelId: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("channelId"),
@@ -359,7 +359,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -421,7 +421,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} without required contractName: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractName"),
@@ -460,7 +460,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-plugin-ledger-connector-iroha/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-ledger-connector-iroha/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -190,7 +190,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} without required params: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("params"), "Rejected because params is required");
     }
@@ -223,7 +223,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation-no-keychain.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation-no-keychain.test.ts
@@ -197,7 +197,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} without required contractJSON and bytecode: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractJSON"),
@@ -233,7 +233,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -269,7 +269,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} without required contractJSON and methodName: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractJSON"),
@@ -308,7 +308,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/openapi/openapi-validation.test.ts
@@ -186,7 +186,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} without required contractName and bytecode: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractName"),
@@ -221,7 +221,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -282,7 +282,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} without required methodName: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("methodName"),
@@ -320,7 +320,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -371,7 +371,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} without required transactionConfig: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("transactionConfig"),
@@ -406,7 +406,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts
+++ b/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts
@@ -148,7 +148,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} without required contractJSON: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractJSON"),
@@ -182,7 +182,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -243,7 +243,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} without required contractJSON: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractJSON"),
@@ -280,7 +280,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -172,7 +172,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} without required keychainId: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("keychainId"),
@@ -205,7 +205,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fDeploy} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -266,7 +266,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} without required contractName: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractName"),
@@ -303,7 +303,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInvoke} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -366,7 +366,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} without required consistencyStrategy: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("consistencyStrategy"),
@@ -408,7 +408,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRun} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/openapi/openapi-validation.test.ts
+++ b/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/openapi/openapi-validation.test.ts
@@ -297,7 +297,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fGetNodeJwt} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -320,7 +320,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fGetConsortiumJws} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts
@@ -224,7 +224,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInitialize} without required connectorId: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("connectorId"),
@@ -254,7 +254,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInitialize} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -368,7 +368,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fNew} without required contractAddress: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractAddress"),
@@ -405,7 +405,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fNew} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -469,7 +469,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRefund} without required id: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("id"), "Rejected because id is required");
     }
@@ -494,7 +494,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRefund} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -611,7 +611,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fWithdraw} without required id: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("id"), "Rejected because id is required");
     }
@@ -638,7 +638,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fWithdraw} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -685,7 +685,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fStatus} without required id: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("ids"), "Rejected because ids is required");
     }
@@ -711,7 +711,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fStatus} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -758,7 +758,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSingleStatus} without required id: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("id"), "Rejected because id is required");
     }
@@ -785,7 +785,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSingleStatus} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: any) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts
@@ -214,7 +214,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInitialize} without required connectorId: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("connectorId"),
@@ -244,7 +244,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fInitialize} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -323,7 +323,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fNew} without required contractAddress: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("contractAddress"),
@@ -359,7 +359,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fNew} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -422,7 +422,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRefund} without required id: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("id"), "Rejected because id is required");
     }
@@ -447,7 +447,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fRefund} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -527,7 +527,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fWithdraw} without required id: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("id"), "Rejected because id is required");
     }
@@ -555,7 +555,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fWithdraw} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -644,7 +644,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fStatus} without required ids: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("ids"), "Rejected because ids is required");
     }
@@ -670,7 +670,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fStatus} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),
@@ -759,7 +759,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSingleStatus} without required id: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(fields.includes("id"), "Rejected because id is required");
     }
@@ -787,7 +787,7 @@ test(testCase, async (t: Test) => {
         `Endpoint ${fSingleStatus} with fake=4: response.status === 400 OK`,
       );
       const fields = e.response.data.map((param: { path: string }) =>
-        param.path.replace(".body.", ""),
+        param.path.replace("/body/", ""),
       );
       t2.ok(
         fields.includes("fake"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,26 +372,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apidevtools/json-schema-ref-parser@npm:8.0.0":
-  version: 8.0.0
-  resolution: "@apidevtools/json-schema-ref-parser@npm:8.0.0"
-  dependencies:
-    "@jsdevtools/ono": ^7.1.0
-    call-me-maybe: ^1.0.1
-    js-yaml: ^3.13.1
-  checksum: 3875f3c2fcde9330fa2da5fa8bf4150fb50dc8b5f43b02c5315b79c471b1e1603c3b0320c31f2be80fbc81376efd19e87c8d13da21daadd92544354b6d43d2e7
-  languageName: node
-  linkType: hard
-
-"@apidevtools/json-schema-ref-parser@npm:9.0.9":
-  version: 9.0.9
-  resolution: "@apidevtools/json-schema-ref-parser@npm:9.0.9"
+"@apidevtools/json-schema-ref-parser@npm:^9.1.2":
+  version: 9.1.2
+  resolution: "@apidevtools/json-schema-ref-parser@npm:9.1.2"
   dependencies:
     "@jsdevtools/ono": ^7.1.3
     "@types/json-schema": ^7.0.6
     call-me-maybe: ^1.0.1
     js-yaml: ^4.1.0
-  checksum: b21f6bdd37d2942c3967ee77569bc74fadd1b922f688daf5ef85057789a2c3a7f4afc473aa2f3a93ec950dabb6ef365f8bd9cf51e4e062a1ee1e59b989f8f9b4
+  checksum: 5bd6885db0fd6633879bb4638b7a3aead6b061cb6422083c6be505ee6873be54e3376380df164c73edd8901d4145a9bfe9bc0b008a568fd8b0626b1df96fae8f
   languageName: node
   linkType: hard
 
@@ -6275,7 +6264,7 @@ __metadata:
     express: 4.17.3
     express-http-proxy: 1.6.2
     express-jwt: 8.4.1
-    express-openapi-validator: 4.12.12
+    express-openapi-validator: 5.0.4
     express-rate-limit: 6.7.0
     fs-extra: 10.0.0
     google-protobuf: 3.18.0-rc.2
@@ -6406,7 +6395,7 @@ __metadata:
     "@types/express": 4.17.13
     express: 4.17.3
     express-jwt-authz: 2.4.1
-    express-openapi-validator: 4.13.8
+    express-openapi-validator: 5.0.4
     typescript-optional: 2.0.1
     uuid: 8.3.2
   languageName: unknown
@@ -7071,7 +7060,7 @@ __metadata:
     "@types/temp": 0.9.1
     axios: 0.21.4
     express: 4.17.3
-    express-openapi-validator: 3.10.0
+    express-openapi-validator: 5.0.4
     internal-ip: 6.2.0
     joi: 17.9.1
     node-ssh: 13.1.0
@@ -8448,7 +8437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsdevtools/ono@npm:7.1.3, @jsdevtools/ono@npm:^7.1.0, @jsdevtools/ono@npm:^7.1.3":
+"@jsdevtools/ono@npm:7.1.3, @jsdevtools/ono@npm:^7.1.3":
   version: 7.1.3
   resolution: "@jsdevtools/ono@npm:7.1.3"
   checksum: 2297fcd472ba810bffe8519d2249171132844c7174f3a16634f9260761c8c78bc0428a4190b5b6d72d45673c13918ab9844d706c3ed4ef8f62ab11a2627a08ad
@@ -11826,7 +11815,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/multer@npm:1.4.7, @types/multer@npm:^1.4.5, @types/multer@npm:^1.4.7":
+"@types/multer@npm:1.4.7, @types/multer@npm:^1.4.7":
   version: 1.4.7
   resolution: "@types/multer@npm:1.4.7"
   dependencies:
@@ -13413,6 +13402,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-draft-04@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "ajv-draft-04@npm:1.0.0"
+  peerDependencies:
+    ajv: ^8.5.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 3f11fa0e7f7359bef6608657f02ab78e9cc62b1fb7bdd860db0d00351b3863a1189c1a23b72466d2d82726cab4eb20725c76f5e7c134a89865e2bfd0e6828137
+  languageName: node
+  linkType: hard
+
 "ajv-formats@npm:2.1.1, ajv-formats@npm:^2.1.1":
   version: 2.1.1
   resolution: "ajv-formats@npm:2.1.1"
@@ -13465,7 +13466,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.12.0, ajv@npm:^8.6.3":
+"ajv@npm:8.12.0, ajv@npm:^8.11.2, ajv@npm:^8.6.3":
   version: 8.12.0
   resolution: "ajv@npm:8.12.0"
   dependencies:
@@ -13499,7 +13500,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.11.0, ajv@npm:^6.12.0, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.12.5, ajv@npm:^6.12.6, ajv@npm:^6.5.3":
+"ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.11.0, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.12.5, ajv@npm:^6.5.3":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -16222,16 +16223,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"busboy@npm:^0.2.11":
-  version: 0.2.14
-  resolution: "busboy@npm:0.2.14"
-  dependencies:
-    dicer: 0.2.5
-    readable-stream: 1.1.x
-  checksum: 9df9fca6d96dab9edd03f568bde31f215794e6fabd73c75d2b39a4be2e8b73a45121d987dea5db881f3fb499737c261b372106fe72d08b8db92afaed8d751165
-  languageName: node
-  linkType: hard
-
 "busboy@npm:^1.0.0, busboy@npm:^1.6.0":
   version: 1.6.0
   resolution: "busboy@npm:1.6.0"
@@ -17948,17 +17939,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:^1.0.4, content-type@npm:~1.0.2, content-type@npm:~1.0.4":
-  version: 1.0.4
-  resolution: "content-type@npm:1.0.4"
-  checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
-  languageName: node
-  linkType: hard
-
-"content-type@npm:~1.0.5":
+"content-type@npm:^1.0.5, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 566271e0a251642254cde0f845f9dd4f9856e52d988f4eb0d0dcffbb7a1f8ec98de7a5215fc628f3bce30fe2fb6fd2bc064b562d721658c59b544e2d34ea2766
+  languageName: node
+  linkType: hard
+
+"content-type@npm:~1.0.2, content-type@npm:~1.0.4":
+  version: 1.0.4
+  resolution: "content-type@npm:1.0.4"
+  checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
   languageName: node
   linkType: hard
 
@@ -18904,16 +18895,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deasync@npm:^0.1.19":
-  version: 0.1.24
-  resolution: "deasync@npm:0.1.24"
-  dependencies:
-    bindings: ^1.5.0
-    node-addon-api: ^1.7.1
-  checksum: 7e87a1faa8511fb157620f9470160efd352cb7fda2c76e45e58acf40fdc96fde89f846f253ee714ec338c45b07b465196776a89947f29a261cbf28a5b3662f73
-  languageName: node
-  linkType: hard
-
 "debounce-fn@npm:^4.0.0":
   version: 4.0.0
   resolution: "debounce-fn@npm:4.0.0"
@@ -19694,16 +19675,6 @@ __metadata:
     asap: ^2.0.0
     wrappy: 1
   checksum: 895389c6aead740d2ab5da4d3466d20fa30f738010a4d3f4dcccc9fc645ca31c9d10b7e1804ae489b1eb02c7986f9f1f34ba132d409b043082a86d9a4e745624
-  languageName: node
-  linkType: hard
-
-"dicer@npm:0.2.5":
-  version: 0.2.5
-  resolution: "dicer@npm:0.2.5"
-  dependencies:
-    readable-stream: 1.1.x
-    streamsearch: 0.1.2
-  checksum: a6f0ce9ac5099c7ffeaec7398d711eea1dd803eb99036d0f05342e9ed46a4235a5ed0ea01ad5d6c785fdb0aae6d61d2722e6e64f9fabdfe39885f7f52eb635ee
   languageName: node
   linkType: hard
 
@@ -22538,57 +22509,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-openapi-validator@npm:3.10.0":
-  version: 3.10.0
-  resolution: "express-openapi-validator@npm:3.10.0"
+"express-openapi-validator@npm:5.0.4":
+  version: 5.0.4
+  resolution: "express-openapi-validator@npm:5.0.4"
   dependencies:
-    ajv: ^6.12.0
-    content-type: ^1.0.4
-    deasync: ^0.1.19
-    js-yaml: ^3.13.1
-    json-schema-ref-parser: ^8.0.0
-    lodash.merge: ^4.6.2
-    lodash.uniq: ^4.5.0
-    lodash.zipobject: ^4.1.3
-    media-typer: ^1.1.0
-    multer: ^1.4.2
-    ono: ^7.1.1
-    path-to-regexp: ^6.1.0
-  dependenciesMeta:
-    deasync:
-      optional: true
-  checksum: 85760725a546302d13698e3ab63356e658c27b4167ff1ecab4562c768912d74fe5c87a3b3c040e5b8efc3f5c0566b1b422e608dfe068a41b7bf77688d207fedc
-  languageName: node
-  linkType: hard
-
-"express-openapi-validator@npm:4.12.12":
-  version: 4.12.12
-  resolution: "express-openapi-validator@npm:4.12.12"
-  dependencies:
-    "@types/multer": ^1.4.5
-    ajv: ^6.12.6
-    content-type: ^1.0.4
-    json-schema-ref-parser: ^9.0.7
-    lodash.clonedeep: ^4.5.0
-    lodash.get: ^4.4.2
-    lodash.uniq: ^4.5.0
-    lodash.zipobject: ^4.1.3
-    media-typer: ^1.1.0
-    multer: ^1.4.2
-    ono: ^7.1.3
-    path-to-regexp: ^6.2.0
-  checksum: 3230ba7032dccb26426887c91147e97039b43c945645c979659d9adf2d903fdd4a93eac851966c12b41c64c0a98149227771683fdccf7b914edcc1ef04734997
-  languageName: node
-  linkType: hard
-
-"express-openapi-validator@npm:4.13.8":
-  version: 4.13.8
-  resolution: "express-openapi-validator@npm:4.13.8"
-  dependencies:
+    "@apidevtools/json-schema-ref-parser": ^9.1.2
     "@types/multer": ^1.4.7
-    ajv: ^6.12.6
-    content-type: ^1.0.4
-    json-schema-ref-parser: ^9.0.9
+    ajv: ^8.11.2
+    ajv-draft-04: ^1.0.0
+    ajv-formats: ^2.1.1
+    content-type: ^1.0.5
     lodash.clonedeep: ^4.5.0
     lodash.get: ^4.4.2
     lodash.uniq: ^4.5.0
@@ -22597,7 +22527,7 @@ __metadata:
     multer: ^1.4.5-lts.1
     ono: ^7.1.3
     path-to-regexp: ^6.2.0
-  checksum: a20a82c37115ed0125207f5c54983a012dcc4699b70e97be99ee80d12abe572c787af566338e3bcb37d04e69a48f6d565d454e189dbab709ede8b0c6d286b86f
+  checksum: 5f41d632324fd4217ca74353cb9c9bf50ada6f6ecd5396e9a059f6ce05e66c4698706bb14b7a4ea5a88a4190b82327e37d899dd9a22301dfd6717e24930c81b6
   languageName: node
   linkType: hard
 
@@ -29237,24 +29167,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema-ref-parser@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "json-schema-ref-parser@npm:8.0.0"
-  dependencies:
-    "@apidevtools/json-schema-ref-parser": 8.0.0
-  checksum: c8864e7ff0a42b3035dfa224a0bbf759f7bd3671095744b2b8d9e7b05fbd27d5905d2dcbc1c578b662fc4b479202813f4620073f7cdd28197749926290311d47
-  languageName: node
-  linkType: hard
-
-"json-schema-ref-parser@npm:^9.0.7, json-schema-ref-parser@npm:^9.0.9":
-  version: 9.0.9
-  resolution: "json-schema-ref-parser@npm:9.0.9"
-  dependencies:
-    "@apidevtools/json-schema-ref-parser": 9.0.9
-  checksum: e05166a84c702f54f192edb2eb2e39236c3b03c30561777d63fd156ecd3aa3d2fffc0806a5703384bfba3c78800b1dc05f8da1ea25e6470b35a823210f7d48c4
-  languageName: node
-  linkType: hard
-
 "json-schema-traverse@npm:^0.3.0":
   version: 0.3.1
   resolution: "json-schema-traverse@npm:0.3.1"
@@ -32643,22 +32555,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multer@npm:^1.4.2":
-  version: 1.4.4
-  resolution: "multer@npm:1.4.4"
-  dependencies:
-    append-field: ^1.0.0
-    busboy: ^0.2.11
-    concat-stream: ^1.5.2
-    mkdirp: ^0.5.4
-    object-assign: ^4.1.1
-    on-finished: ^2.3.0
-    type-is: ^1.6.4
-    xtend: ^4.0.0
-  checksum: b5550d250aeee9c4d630eaecd133af0899239f6b10cec4b448ddd0a808025b383520b8227198a8612f60c2cd2094bcb60de93d973084f889d4e40efe6dbd641e
-  languageName: node
-  linkType: hard
-
 "multiaddr-to-uri@npm:^8.0.0":
   version: 8.0.0
   resolution: "multiaddr-to-uri@npm:8.0.0"
@@ -33236,15 +33132,6 @@ __metadata:
   version: 3.1.1
   resolution: "node-abort-controller@npm:3.1.1"
   checksum: 2c340916af9710328b11c0828223fc65ba320e0d082214a211311bf64c2891028e42ef276b9799188c4ada9e6e1c54cf7a0b7c05dd9d59fcdc8cd633304c8047
-  languageName: node
-  linkType: hard
-
-"node-addon-api@npm:^1.7.1":
-  version: 1.7.2
-  resolution: "node-addon-api@npm:1.7.2"
-  dependencies:
-    node-gyp: latest
-  checksum: 938922b3d7cb34ee137c5ec39df6289a3965e8cab9061c6848863324c21a778a81ae3bc955554c56b6b86962f6ccab2043dd5fa3f33deab633636bd28039333f
   languageName: node
   linkType: hard
 
@@ -34301,7 +34188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:2.4.1, on-finished@npm:^2.3.0":
+"on-finished@npm:2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -34369,7 +34256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ono@npm:^7.1.1, ono@npm:^7.1.3":
+"ono@npm:^7.1.3":
   version: 7.1.3
   resolution: "ono@npm:7.1.3"
   dependencies:
@@ -35407,7 +35294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^6.1.0, path-to-regexp@npm:^6.2.0":
+"path-to-regexp@npm:^6.2.0":
   version: 6.2.0
   resolution: "path-to-regexp@npm:6.2.0"
   checksum: a6aca74d2d6e2e7594d812f653cf85e9cb5054d3a8d80f099722a44ef6ad22639b02078e5ea83d11db16321c3e4359e3f1ab0274fa78dad0754a6e53f630b0fc
@@ -41014,13 +40901,6 @@ __metadata:
     debug: ^4.3.4
     fs-extra: ^8.1.0
   checksum: c1df5612b785ffa4b6bbf16460590b62994c57265bc55a5166eebeeb0daf648e84bc52dc6d57e0cd4e5c7609bda93076753c63ff54589febd1e0b95590f0e443
-  languageName: node
-  linkType: hard
-
-"streamsearch@npm:0.1.2":
-  version: 0.1.2
-  resolution: "streamsearch@npm:0.1.2"
-  checksum: d2db57cbfbf7947ab9c75a7b4c80a8ef8d24850cf0a1a24258bb6956c97317ce1eab7dbcbf9c5aba3e6198611af1053b02411057bbedb99bf9c64b8275248997
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Addresses the advisory:
https://github.com/hyperledger/cacti/security/dependabot/176

The dicer dependency is included via the express-openapi-validator
package which needed to be upgraded project-wide for a fix.

The test cases for verifying that the OpenAPI validation still works had
to be updated because the way invalid field names are represented by
the new version of the validator have been changed. It used to say if
in the request body there was a problematic field ".body.SOME_FIELD"
but now it says instead "/body/SOME_FIELD" so a minor change was needed
in the test cases assertions to make sure they are not ending up with
false negative results.

URL https://github.com/advisories/GHSA-wm7h-9275-46v2
CVE ID CVE-2022-24434
GHSA ID GHSA-wm7h-9275-46v2

Fixes https://github.com/hyperledger/cacti/issues/2616

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>