### PR TITLE
feat(cactus-plugin-ledger-connector-ethereum): support London fork gas prices

### DIFF
--- a/packages/cactus-plugin-ledger-connector-ethereum/package.json
+++ b/packages/cactus-plugin-ledger-connector-ethereum/package.json
@@ -74,9 +74,9 @@
     "sanitize-html": "2.7.0",
     "socket.io-client": "4.5.4",
     "typescript-optional": "2.0.1",
-    "web3": "4.0.3",
-    "web3-eth-contract": "4.0.3",
-    "web3-utils": "4.0.3"
+    "web3": "4.1.2",
+    "web3-eth": "4.2.0",
+    "web3-eth-contract": "4.1.0"
   },
   "devDependencies": {
     "@hyperledger/cactus-plugin-keychain-memory": "2.0.0-alpha.2",
@@ -86,9 +86,7 @@
     "@types/minimist": "1.2.2",
     "@types/sanitize-html": "2.6.2",
     "chalk": "4.1.2",
-    "socket.io": "4.5.4",
-    "web3-eth": "4.0.3",
-    "web3-eth-accounts": "4.0.3"
+    "socket.io": "4.5.4"
   },
   "engines": {
     "node": ">=10",

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/json/openapi.json
@@ -207,10 +207,59 @@
           }
         }
       },
+      "GasTransactionConfigLegacy": {
+        "type": "object",
+        "description": "Transaction gas settings in networks before EIP-1559 (London fork).",
+        "required": [],
+        "properties": {
+          "gas": {
+            "type": "string",
+            "description": "A maximum amount of gas a user is willing to provide for the execution of the transaction. (gasLimit)"
+          },
+          "gasPrice": {
+            "type": "string",
+            "description": "A price (in Wei) a user is willing to pay for each unit of gas used during the execution of the transaction. In EIP-1559 (London fork) networks, it will be set as both maxFeePerGas and maxPriorityFeePerGas."
+          }
+        }
+      },
+      "GasTransactionConfigEIP1559": {
+        "type": "object",
+        "description": "Transaction gas settings in networks after EIP-1559 (London fork).",
+        "required": [],
+        "properties": {
+          "gasLimit": {
+            "type": "string",
+            "description": "A maximum amount of gas a user is willing to provide for the execution of the transaction.",
+            "nullable": false
+          },
+          "maxFeePerGas": {
+            "type": "string",
+            "description": "A maximum fee (including the base fee and the tip) a user is willing to pay per unit of gas.",
+            "nullable": false
+          },
+          "maxPriorityFeePerGas": {
+            "type": "string",
+            "description": "A maximum tip amount a user is willing to pay per unit of gas.",
+            "nullable": false
+          }
+        }
+      },
+      "GasTransactionConfig": {
+        "type": "object",
+        "description": "Transaction gas settings.",
+        "required": [],
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/GasTransactionConfigLegacy"
+          },
+          {
+            "$ref": "#/components/schemas/GasTransactionConfigEIP1559"
+          }
+        ]
+      },
       "EthereumTransactionConfig": {
         "type": "object",
         "required": [],
-        "additionalProperties": true,
         "properties": {
           "rawTransaction": {
             "type": "string",
@@ -225,17 +274,15 @@
           "value": {
             "type": "string"
           },
-          "gas": {
-            "type": "string"
-          },
-          "gasPrice": {
-            "type": "string"
-          },
           "nonce": {
             "type": "string"
           },
           "data": {
             "type": "string"
+          },
+          "gasConfig": {
+            "$ref": "#/components/schemas/GasTransactionConfig",
+            "nullable": false
           }
         }
       },
@@ -450,12 +497,8 @@
             "maxLength": 100,
             "nullable": false
           },
-          "gas": {
-            "type": "number",
-            "nullable": false
-          },
-          "gasPrice": {
-            "type": "number",
+          "gasConfig": {
+            "$ref": "#/components/schemas/GasTransactionConfig",
             "nullable": false
           },
           "nonce": {
@@ -504,12 +547,8 @@
             "$ref": "#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
-          "gas": {
-            "type": "number",
-            "nullable": false
-          },
-          "gasPrice": {
-            "type": "string",
+          "gasConfig": {
+            "$ref": "#/components/schemas/GasTransactionConfig",
             "nullable": false
           },
           "timeoutMs": {
@@ -574,11 +613,9 @@
           "value": {
             "type": "string"
           },
-          "gas": {
-            "type": "string"
-          },
-          "gasPrice": {
-            "type": "string"
+          "gasConfig": {
+            "$ref": "#/components/schemas/GasTransactionConfig",
+            "nullable": false
           },
           "nonce": {
             "type": "string"
@@ -640,11 +677,9 @@
           "value": {
             "type": "string"
           },
-          "gas": {
-            "type": "string"
-          },
-          "gasPrice": {
-            "type": "string"
+          "gasConfig": {
+            "$ref": "#/components/schemas/GasTransactionConfig",
+            "nullable": false
           },
           "nonce": {
             "type": "string"
@@ -799,12 +834,7 @@
       },
       "Web3BlockHeader": {
         "type": "object",
-        "required": [
-          "sha3Uncles",
-          "transactionRoot",
-          "gasLimit",
-          "gasUsed"
-        ],
+        "required": ["sha3Uncles", "transactionRoot", "gasLimit", "gasUsed"],
         "properties": {
           "number": {
             "type": "string"
@@ -1145,7 +1175,7 @@
           }
         },
         "operationId": "invokeContractV1",
-        "summary": "Invokes a contract on a besu ledger",
+        "summary": "Invokes a contract on an ethereum ledger",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -1179,7 +1209,7 @@
           }
         },
         "operationId": "invokeContractV1NoKeychain",
-        "summary": "Invokes a contract on a besu ledger",
+        "summary": "Invokes a contract on an ethereum ledger",
         "parameters": [],
         "requestBody": {
           "content": {

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -124,16 +124,10 @@ export interface DeployContractSolidityBytecodeJsonObjectV1Request {
     'web3SigningCredential': Web3SigningCredential;
     /**
      * 
-     * @type {number}
+     * @type {GasTransactionConfig}
      * @memberof DeployContractSolidityBytecodeJsonObjectV1Request
      */
-    'gas'?: number;
-    /**
-     * 
-     * @type {string}
-     * @memberof DeployContractSolidityBytecodeJsonObjectV1Request
-     */
-    'gasPrice'?: string;
+    'gasConfig'?: GasTransactionConfig;
     /**
      * The amount of milliseconds to wait for a transaction receipt with theaddress of the contract(which indicates successful deployment) beforegiving up and crashing.
      * @type {number}
@@ -191,16 +185,10 @@ export interface DeployContractSolidityBytecodeV1Request {
     'keychainId': string;
     /**
      * 
-     * @type {number}
+     * @type {GasTransactionConfig}
      * @memberof DeployContractSolidityBytecodeV1Request
      */
-    'gas'?: number;
-    /**
-     * 
-     * @type {number}
-     * @memberof DeployContractSolidityBytecodeV1Request
-     */
-    'gasPrice'?: number;
+    'gasConfig'?: GasTransactionConfig;
     /**
      * 
      * @type {number}
@@ -281,8 +269,6 @@ export type EthContractInvocationWeb3Method = typeof EthContractInvocationWeb3Me
  * @interface EthereumTransactionConfig
  */
 export interface EthereumTransactionConfig {
-    [key: string]: any;
-
     /**
      * 
      * @type {string}
@@ -312,18 +298,6 @@ export interface EthereumTransactionConfig {
      * @type {string}
      * @memberof EthereumTransactionConfig
      */
-    'gas'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof EthereumTransactionConfig
-     */
-    'gasPrice'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof EthereumTransactionConfig
-     */
     'nonce'?: string;
     /**
      * 
@@ -331,6 +305,63 @@ export interface EthereumTransactionConfig {
      * @memberof EthereumTransactionConfig
      */
     'data'?: string;
+    /**
+     * 
+     * @type {GasTransactionConfig}
+     * @memberof EthereumTransactionConfig
+     */
+    'gasConfig'?: GasTransactionConfig;
+}
+/**
+ * @type GasTransactionConfig
+ * Transaction gas settings.
+ * @export
+ */
+export type GasTransactionConfig = GasTransactionConfigEIP1559 | GasTransactionConfigLegacy;
+
+/**
+ * Transaction gas settings in networks after EIP-1559 (London fork).
+ * @export
+ * @interface GasTransactionConfigEIP1559
+ */
+export interface GasTransactionConfigEIP1559 {
+    /**
+     * A maximum amount of gas a user is willing to provide for the execution of the transaction.
+     * @type {string}
+     * @memberof GasTransactionConfigEIP1559
+     */
+    'gasLimit'?: string;
+    /**
+     * A maximum fee (including the base fee and the tip) a user is willing to pay per unit of gas.
+     * @type {string}
+     * @memberof GasTransactionConfigEIP1559
+     */
+    'maxFeePerGas'?: string;
+    /**
+     * A maximum tip amount a user is willing to pay per unit of gas.
+     * @type {string}
+     * @memberof GasTransactionConfigEIP1559
+     */
+    'maxPriorityFeePerGas'?: string;
+}
+/**
+ * Transaction gas settings in networks before EIP-1559 (London fork).
+ * @export
+ * @interface GasTransactionConfigLegacy
+ */
+export interface GasTransactionConfigLegacy {
+    /**
+     * A maximum amount of gas a user is willing to provide for the execution of the transaction. (gasLimit)
+     * @type {string}
+     * @memberof GasTransactionConfigLegacy
+     */
+    'gas'?: string;
+    /**
+     * A price (in Wei) a user is willing to pay for each unit of gas used during the execution of the transaction. In EIP-1559 (London fork) networks, it will be set as both maxFeePerGas and maxPriorityFeePerGas.
+     * @type {string}
+     * @memberof GasTransactionConfigLegacy
+     */
+    'gasPrice'?: string;
 }
 /**
  * 
@@ -376,16 +407,10 @@ export interface InvokeContractJsonObjectV1Request {
     'value'?: string;
     /**
      * 
-     * @type {string}
+     * @type {GasTransactionConfig}
      * @memberof InvokeContractJsonObjectV1Request
      */
-    'gas'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof InvokeContractJsonObjectV1Request
-     */
-    'gasPrice'?: string;
+    'gasConfig'?: GasTransactionConfig;
     /**
      * 
      * @type {string}
@@ -451,16 +476,10 @@ export interface InvokeContractV1Request {
     'value'?: string;
     /**
      * 
-     * @type {string}
+     * @type {GasTransactionConfig}
      * @memberof InvokeContractV1Request
      */
-    'gas'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof InvokeContractV1Request
-     */
-    'gasPrice'?: string;
+    'gasConfig'?: GasTransactionConfig;
     /**
      * 
      * @type {string}
@@ -1521,7 +1540,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Invokes a contract on a besu ledger
+         * @summary Invokes a contract on an ethereum ledger
          * @param {InvokeContractV1Request} [invokeContractV1Request] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1555,7 +1574,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Invokes a contract on a besu ledger
+         * @summary Invokes a contract on an ethereum ledger
          * @param {InvokeContractJsonObjectV1Request} [invokeContractJsonObjectV1Request] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1733,7 +1752,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Invokes a contract on a besu ledger
+         * @summary Invokes a contract on an ethereum ledger
          * @param {InvokeContractV1Request} [invokeContractV1Request] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1744,7 +1763,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Invokes a contract on a besu ledger
+         * @summary Invokes a contract on an ethereum ledger
          * @param {InvokeContractJsonObjectV1Request} [invokeContractJsonObjectV1Request] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1827,7 +1846,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Invokes a contract on a besu ledger
+         * @summary Invokes a contract on an ethereum ledger
          * @param {InvokeContractV1Request} [invokeContractV1Request] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1837,7 +1856,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Invokes a contract on a besu ledger
+         * @summary Invokes a contract on an ethereum ledger
          * @param {InvokeContractJsonObjectV1Request} [invokeContractJsonObjectV1Request] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1922,7 +1941,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Invokes a contract on a besu ledger
+     * @summary Invokes a contract on an ethereum ledger
      * @param {InvokeContractV1Request} [invokeContractV1Request] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -1934,7 +1953,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Invokes a contract on a besu ledger
+     * @summary Invokes a contract on an ethereum ledger
      * @param {InvokeContractJsonObjectV1Request} [invokeContractJsonObjectV1Request] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/plugin-ledger-connector-ethereum.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/plugin-ledger-connector-ethereum.ts
@@ -5,13 +5,14 @@ import type {
 
 import { Express } from "express";
 import Web3, {
-  ContractAbi,
+  Contract,
   HttpProvider,
+  Transaction,
   TransactionReceiptBase,
   WebSocketProvider,
 } from "web3";
 import { NewHeadsSubscription } from "web3-eth";
-import { Contract, PayableMethodObject } from "web3-eth-contract";
+import { PayableMethodObject } from "web3-eth-contract";
 
 import OAS from "../json/openapi.json";
 
@@ -58,6 +59,7 @@ import {
   WatchBlocksV1Options,
   InvokeRawWeb3EthMethodV1Request,
   InvokeRawWeb3EthContractV1Request,
+  EthereumTransactionConfig,
 } from "./generated/openapi/typescript-axios";
 
 import { RunTransactionEndpoint } from "./web-services/run-transaction-endpoint";
@@ -68,7 +70,11 @@ import { GetPrometheusExporterMetricsEndpointV1 } from "./web-services/get-prome
 import { InvokeRawWeb3EthMethodEndpoint } from "./web-services/invoke-raw-web3eth-method-v1-endpoint";
 import { InvokeRawWeb3EthContractEndpoint } from "./web-services/invoke-raw-web3eth-contract-v1-endpoint";
 
-import { isWeb3SigningCredentialNone } from "./types/model-type-guards";
+import {
+  isGasTransactionConfigEIP1559,
+  isGasTransactionConfigLegacy,
+  isWeb3SigningCredentialNone,
+} from "./types/model-type-guards";
 import { PrometheusExporter } from "./prometheus-exporter/prometheus-exporter";
 import { RuntimeError } from "run-time-error";
 import {
@@ -482,7 +488,7 @@ export class PluginLedgerConnectorEthereum
         "Can't estimate maxFeePerGas - could not get recent baseFeePerGas",
       );
     }
-    const estimate = BigInt(2) * baseFee + BigInt(priorityFee);
+    const estimate = baseFee + BigInt(priorityFee);
     return estimate.toString();
   }
 
@@ -507,7 +513,7 @@ export class PluginLedgerConnectorEthereum
     const contractInstance = new this.web3.eth.Contract(abi, contractAddress);
 
     const isSafeToCall = await this.isSafeToCallContractMethod(
-      contractInstance as unknown as Contract<ContractAbi>,
+      contractInstance,
       req.methodName,
     );
     if (!isSafeToCall) {
@@ -535,18 +541,10 @@ export class PluginLedgerConnectorEthereum
         | Web3SigningCredentialPrivateKeyHex
         | Web3SigningCredentialCactusKeychainRef;
 
-      if (!req.gas) {
-        const estimatedGas = await method.estimateGas();
-        req.gas = estimatedGas.toString();
-      }
-
-      const maxFeePerGas = await this.estimateMaxFeePerGas();
       const transactionConfig = {
         from: web3SigningCredential.ethAccount,
         to: contractAddress,
-        maxPriorityFeePerGas: req.gasPrice ?? 0,
-        maxFeePerGas,
-        gasLimit: req.gas,
+        gasConfig: req.gasConfig,
         value: req.value,
         nonce: req.nonce,
         data: method.encodeABI(),
@@ -638,7 +636,7 @@ export class PluginLedgerConnectorEthereum
 
     try {
       const txHash = await this.web3.eth.personal.sendTransaction(
-        transactionConfig,
+        await this.getTransactionFromTxConfig(transactionConfig),
         secret,
       );
       const transactionReceipt = await this.pollForTxReceipt(txHash);
@@ -665,7 +663,7 @@ export class PluginLedgerConnectorEthereum
       web3SigningCredential as Web3SigningCredentialPrivateKeyHex;
 
     const signedTx = await this.web3.eth.accounts.signTransaction(
-      transactionConfig,
+      await this.getTransactionFromTxConfig(transactionConfig),
       secret,
     );
 
@@ -697,18 +695,6 @@ export class PluginLedgerConnectorEthereum
     // Now use the found keychain plugin to actually perform the lookup of
     // the private key that we need to run the transaction.
     const privateKeyHex = await keychainPlugin?.get(keychainEntryKey as string);
-
-    if (!transactionConfig.gas) {
-      this.log.debug(
-        `${fnTag} Gas not specified in the transaction values. Using the estimate from web3`,
-      );
-      const estimatedGas = await this.web3.eth.estimateGas(transactionConfig);
-      transactionConfig.gas = estimatedGas.toString();
-      this.log.debug(
-        `${fnTag} Gas estimated from web3 is: `,
-        transactionConfig.gas,
-      );
-    }
 
     return this.transactPrivateKey({
       transactionConfig,
@@ -773,8 +759,7 @@ export class PluginLedgerConnectorEthereum
       transactionConfig: {
         data: bytecode,
         from: web3SigningCredential.ethAccount,
-        gas: req.gas,
-        gasPrice: req.gasPrice,
+        gasConfig: req.gasConfig,
       },
       web3SigningCredential,
     });
@@ -901,7 +886,7 @@ export class PluginLedgerConnectorEthereum
     const contract = new this.web3.eth.Contract(args.abi, args.address);
 
     const isSafeToCall = await this.isSafeToCallContractMethod(
-      contract as unknown as Contract<ContractAbi>,
+      contract,
       args.contractMethod,
     );
     if (!isSafeToCall) {
@@ -916,5 +901,62 @@ export class PluginLedgerConnectorEthereum
     return methodRef(...contractMethodArgs)[args.invocationType](
       args.invocationParams,
     );
+  }
+
+  /**
+   * Convert connector transaction config to web3js transaction object.
+   * @param txConfig connector transaction config
+   * @returns web3js transaction
+   */
+  private async getTransactionFromTxConfig(
+    txConfig: EthereumTransactionConfig,
+  ): Promise<Transaction> {
+    const tx: Transaction = {
+      from: txConfig.from,
+      to: txConfig.to,
+      value: txConfig.value,
+      nonce: txConfig.nonce,
+      data: txConfig.data,
+    };
+
+    // Apply gas config to the transaction
+    if (txConfig.gasConfig) {
+      if (isGasTransactionConfigLegacy(txConfig.gasConfig)) {
+        if (isGasTransactionConfigEIP1559(txConfig.gasConfig)) {
+          throw new RuntimeError(
+            `Detected mixed gasConfig! Use either legacy or EIP-1559 mode. gasConfig - ${JSON.stringify(
+              txConfig.gasConfig,
+            )}`,
+          );
+        }
+        tx.maxPriorityFeePerGas = txConfig.gasConfig.gasPrice;
+        tx.maxFeePerGas = txConfig.gasConfig.gasPrice;
+        tx.gasLimit = txConfig.gasConfig.gas;
+      } else {
+        tx.maxPriorityFeePerGas = txConfig.gasConfig.maxPriorityFeePerGas;
+        tx.maxFeePerGas = txConfig.gasConfig.maxFeePerGas;
+        tx.gasLimit = txConfig.gasConfig.gasLimit;
+      }
+    }
+
+    if (tx.maxPriorityFeePerGas && !tx.maxFeePerGas) {
+      tx.maxFeePerGas = await this.estimateMaxFeePerGas(
+        tx.maxPriorityFeePerGas.toString(),
+      );
+      this.log.info(
+        `Estimated maxFeePerGas of ${tx.maxFeePerGas} becuase maxPriorityFeePerGas was provided.`,
+      );
+    }
+
+    // Fill missing gas fields (do it last)
+    if (!tx.gasLimit) {
+      const estimatedGas = await this.web3.eth.estimateGas(tx);
+      this.log.debug(
+        `Gas not specified in the transaction values, estimated ${estimatedGas.toString()}`,
+      );
+      tx.gasLimit = estimatedGas;
+    }
+
+    return tx;
   }
 }

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/types/model-type-guards.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/types/model-type-guards.ts
@@ -1,4 +1,7 @@
 import {
+  GasTransactionConfig,
+  GasTransactionConfigEIP1559,
+  GasTransactionConfigLegacy,
   Web3SigningCredentialCactusKeychainRef,
   Web3SigningCredentialGethKeychainPassword,
   Web3SigningCredentialNone,
@@ -38,5 +41,26 @@ export function isWeb3SigningCredentialCactusKeychainRef(x?: {
     !!x?.keychainId &&
     typeof x?.keychainId === "string" &&
     x?.keychainId.trim().length > 0
+  );
+}
+
+export function isGasTransactionConfigLegacy(
+  gasConfig: GasTransactionConfig,
+): gasConfig is GasTransactionConfigLegacy {
+  const typedGasConfig = gasConfig as GasTransactionConfigLegacy;
+  return (
+    typeof typedGasConfig.gas !== "undefined" ||
+    typeof typedGasConfig.gasPrice !== "undefined"
+  );
+}
+
+export function isGasTransactionConfigEIP1559(
+  gasConfig: GasTransactionConfig,
+): gasConfig is GasTransactionConfigEIP1559 {
+  const typedGasConfig = gasConfig as GasTransactionConfigEIP1559;
+  return (
+    typeof typedGasConfig.gasLimit !== "undefined" ||
+    typeof typedGasConfig.maxFeePerGas !== "undefined" ||
+    typeof typedGasConfig.maxPriorityFeePerGas !== "undefined"
   );
 }

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/web-services/watch-blocks-v1-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/web-services/watch-blocks-v1-endpoint.ts
@@ -119,6 +119,6 @@ export class WatchBlocksV1Endpoint {
     });
 
     log.debug("Subscribing to Web3 new block headers event...");
-    return newBlocksSubscription as unknown as NewHeadsSubscription;
+    return newBlocksSubscription as NewHeadsSubscription;
   }
 }

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
@@ -18,8 +18,7 @@ import http from "http";
 import { v4 as uuidV4 } from "uuid";
 import { AddressInfo } from "net";
 import { Server as SocketIoServer } from "socket.io";
-import Web3 from "web3";
-import { Web3Account } from "web3-eth-accounts";
+import Web3, { HexString } from "web3";
 
 import {
   LogLevelDesc,
@@ -51,7 +50,10 @@ const containerImageVersion = "2023-07-27-2a8c48ed6";
 
 describe("Ethereum contract deploy and invoke using keychain tests", () => {
   const keychainEntryKey = uuidV4();
-  let testEthAccount: Web3Account,
+  let testEthAccount: {
+      address: HexString;
+      privateKey: HexString;
+    },
     web3: Web3,
     addressInfo,
     address: string,
@@ -171,7 +173,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         secret: "",
         type: Web3SigningCredentialType.GethKeychainPassword,
       },
-      gas: 1000000,
       contractJSON: HelloWorldContractJson,
     });
     expect(deployOut).toBeTruthy();
@@ -194,7 +195,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         secret: "",
         type: Web3SigningCredentialType.GethKeychainPassword,
       },
-      gas: "1000000",
       contractJSON: HelloWorldContractJson,
     });
     expect(invokeOut).toBeTruthy();
@@ -210,7 +210,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         secret: "",
         type: Web3SigningCredentialType.GethKeychainPassword,
       },
-      gas: 1000000,
       constructorArgs: ["Johnny"],
       contractJSON: HelloWorldWithArgContractJson,
     });
@@ -228,7 +227,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-        gas: 1000000,
       } as DeployContractSolidityBytecodeJsonObjectV1Request);
       fail(
         "Expected deployContractSolBytecodeJsonObjectV1 call to fail but it succeeded.",
@@ -288,7 +286,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         methodName: "setName",
         contractAddress,
         params: [newName],
-        gas: "1000000",
         web3SigningCredential: {
           ethAccount: WHALE_ACCOUNT_ADDRESS,
           secret: "",
@@ -336,6 +333,7 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("invoke Web3SigningCredentialType.PrivateKeyHex", async () => {
+    const priorityFee = web3.utils.toWei(2, "gwei");
     const nonce = await web3.eth.getTransactionCount(testEthAccount.address);
     const newName = `DrCactus${uuidV4()}`;
     const setNameOut = await apiClient.invokeContractV1NoKeychain({
@@ -344,6 +342,9 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       methodName: "setName",
       contractAddress,
       params: [newName],
+      gasConfig: {
+        maxPriorityFeePerGas: priorityFee,
+      },
       web3SigningCredential: {
         ethAccount: testEthAccount.address,
         secret: testEthAccount.privateKey,
@@ -361,7 +362,9 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         methodName: "setName",
         contractAddress,
         params: [newName],
-        gas: "1000000",
+        gasConfig: {
+          maxPriorityFeePerGas: priorityFee,
+        },
         web3SigningCredential: {
           ethAccount: testEthAccount.address,
           secret: testEthAccount.privateKey,
@@ -380,7 +383,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       methodName: "getName",
       contractAddress,
       params: [],
-      gas: "1000000",
       web3SigningCredential: {
         ethAccount: testEthAccount.address,
         secret: testEthAccount.privateKey,

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
@@ -18,8 +18,7 @@ import http from "http";
 import { v4 as uuidV4 } from "uuid";
 import { AddressInfo } from "net";
 import { Server as SocketIoServer } from "socket.io";
-import Web3 from "web3";
-import { Web3Account } from "web3-eth-accounts";
+import Web3, { HexString } from "web3";
 
 import {
   LogLevelDesc,
@@ -54,7 +53,10 @@ const containerImageVersion = "2023-07-27-2a8c48ed6";
 
 describe("Ethereum contract deploy and invoke using keychain tests", () => {
   const keychainEntryKey = uuidV4();
-  let testEthAccount: Web3Account,
+  let testEthAccount: {
+      address: HexString;
+      privateKey: HexString;
+    },
     web3: Web3,
     addressInfo,
     address: string,
@@ -175,7 +177,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         secret: "",
         type: Web3SigningCredentialType.GethKeychainPassword,
       },
-      gas: 1000000,
     });
     expect(deployOut).toBeTruthy();
     expect(deployOut.data).toBeTruthy();
@@ -196,7 +197,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         secret: "",
         type: Web3SigningCredentialType.GethKeychainPassword,
       },
-      gas: "1000000",
     });
     expect(invokeOut).toBeTruthy();
     expect(invokeOut.data).toBeTruthy();
@@ -213,7 +213,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         secret: "",
         type: Web3SigningCredentialType.GethKeychainPassword,
       },
-      gas: 1000000,
       constructorArgs: ["Johnny"],
     });
     expect(deployOut).toBeTruthy();
@@ -231,7 +230,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-        gas: 1000000,
       } as DeployContractSolidityBytecodeV1Request);
       fail(
         "Expected deployContractSolBytecodeV1 call to fail but it succeeded.",
@@ -292,7 +290,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         methodName: "setName",
         keychainId: keychainPlugin.getKeychainId(),
         params: [newName],
-        gas: "1000000",
         web3SigningCredential: {
           ethAccount: WHALE_ACCOUNT_ADDRESS,
           secret: "",
@@ -385,6 +382,7 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   });
 
   test("invoke Web3SigningCredentialType.PrivateKeyHex", async () => {
+    const priorityFee = web3.utils.toWei(2, "gwei");
     const nonce = await web3.eth.getTransactionCount(testEthAccount.address);
     const newName = `DrCactus${uuidV4()}`;
     const setNameOut = await apiClient.invokeContractV1({
@@ -393,6 +391,9 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       methodName: "setName",
       keychainId: keychainPlugin.getKeychainId(),
       params: [newName],
+      gasConfig: {
+        maxPriorityFeePerGas: priorityFee,
+      },
       web3SigningCredential: {
         ethAccount: testEthAccount.address,
         secret: testEthAccount.privateKey,
@@ -410,7 +411,9 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         methodName: "setName",
         keychainId: keychainPlugin.getKeychainId(),
         params: [newName],
-        gas: "1000000",
+        gasConfig: {
+          maxPriorityFeePerGas: priorityFee,
+        },
         web3SigningCredential: {
           ethAccount: testEthAccount.address,
           secret: testEthAccount.privateKey,
@@ -429,7 +432,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       methodName: "getName",
       keychainId: keychainPlugin.getKeychainId(),
       params: [],
-      gas: "1000000",
       web3SigningCredential: {
         ethAccount: testEthAccount.address,
         secret: testEthAccount.privateKey,
@@ -445,6 +447,7 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   test("invoke Web3SigningCredentialType.CactusKeychainRef", async () => {
     const newName = `DrCactus${uuidV4()}`;
     const nonce = await web3.eth.getTransactionCount(testEthAccount.address);
+    const priorityFee = web3.utils.toWei(2, "gwei");
 
     const web3SigningCredential: Web3SigningCredentialCactusKeychainRef = {
       ethAccount: testEthAccount.address,
@@ -460,7 +463,9 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       methodName: "setName",
       keychainId: keychainPlugin.getKeychainId(),
       params: [newName],
-      gas: "1000000",
+      gasConfig: {
+        maxPriorityFeePerGas: priorityFee,
+      },
       web3SigningCredential,
       nonce: nonce.toString(),
     });
@@ -474,7 +479,9 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         methodName: "setName",
         keychainId: keychainPlugin.getKeychainId(),
         params: [newName],
-        gas: "1000000",
+        gasConfig: {
+          maxPriorityFeePerGas: priorityFee,
+        },
         web3SigningCredential: {
           ethAccount: WHALE_ACCOUNT_ADDRESS,
           secret: "",
@@ -493,7 +500,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       methodName: "getName",
       keychainId: keychainPlugin.getKeychainId(),
       params: [],
-      gas: "1000000",
       web3SigningCredential,
     });
     expect(invokeGetNameOut).toBeTruthy();

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-contract-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-contract-v1.test.ts
@@ -93,7 +93,6 @@ describe("invokeRawWeb3EthContract Tests", () => {
         secret: "",
         type: Web3SigningCredentialType.GethKeychainPassword,
       },
-      gas: 1000000,
     });
     expect(deployOut).toBeTruthy();
     expect(deployOut.transactionReceipt).toBeTruthy();

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-transact-and-gas-fees.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-transact-and-gas-fees.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for running transactions with different gas configurations (both legacy and EIP-1559)
+ */
+
+//////////////////////////////////
+// Constants
+//////////////////////////////////
+
+// Log settings
+const testLogLevel: LogLevelDesc = "info";
+
+import "jest-extended";
+import express from "express";
+import bodyParser from "body-parser";
+import http from "http";
+import { v4 as uuidV4 } from "uuid";
+import { AddressInfo } from "net";
+import { Server as SocketIoServer } from "socket.io";
+import Web3 from "web3";
+
+import {
+  LogLevelDesc,
+  IListenOptions,
+  Servers,
+} from "@hyperledger/cactus-common";
+import { PluginRegistry } from "@hyperledger/cactus-core";
+import { Configuration, Constants } from "@hyperledger/cactus-core-api";
+import { pruneDockerAllIfGithubAction } from "@hyperledger/cactus-test-tooling";
+import {
+  GethTestLedger,
+  WHALE_ACCOUNT_ADDRESS,
+} from "@hyperledger/cactus-test-geth-ledger";
+
+import {
+  PluginLedgerConnectorEthereum,
+  Web3SigningCredentialType,
+  DefaultApi as EthereumApi,
+} from "../../../main/typescript/public-api";
+
+const containerImageName = "ghcr.io/outsh/cactus_geth_all_in_one";
+const containerImageVersion = "test-v01";
+
+describe("Running ethereum transactions with different gas configurations", () => {
+  let web3: Web3,
+    addressInfo,
+    address: string,
+    port: number,
+    apiHost,
+    apiConfig,
+    ledger: GethTestLedger,
+    apiClient: EthereumApi,
+    connector: PluginLedgerConnectorEthereum,
+    rpcApiHttpHost: string;
+  const expressApp = express();
+  expressApp.use(bodyParser.json({ limit: "250mb" }));
+  const server = http.createServer(expressApp);
+  const wsApi = new SocketIoServer(server, {
+    path: Constants.SocketIoConnectionPathV1,
+  });
+
+  //////////////////////////////////
+  // Setup
+  //////////////////////////////////
+
+  beforeAll(async () => {
+    const pruning = pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+    await expect(pruning).resolves.toBeTruthy();
+
+    //ledger = new GethTestLedger({ emitContainerLogs: true, testLogLevel });
+    ledger = new GethTestLedger({
+      containerImageName,
+      containerImageVersion,
+    });
+    await ledger.start();
+
+    const listenOptions: IListenOptions = {
+      hostname: "0.0.0.0",
+      port: 0,
+      server,
+    };
+    addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
+    ({ address, port } = addressInfo);
+    apiHost = `http://${address}:${port}`;
+    apiConfig = new Configuration({ basePath: apiHost });
+    apiClient = new EthereumApi(apiConfig);
+    rpcApiHttpHost = await ledger.getRpcApiHttpHost();
+    web3 = new Web3(rpcApiHttpHost);
+
+    connector = new PluginLedgerConnectorEthereum({
+      instanceId: uuidV4(),
+      rpcApiHttpHost,
+      logLevel: testLogLevel,
+      pluginRegistry: new PluginRegistry({ plugins: [] }),
+    });
+    await connector.getOrCreateWebServices();
+    await connector.registerWebServices(expressApp, wsApi);
+  });
+
+  afterAll(async () => {
+    await ledger.stop();
+    await ledger.destroy();
+    await Servers.shutdown(server);
+
+    const pruning = pruneDockerAllIfGithubAction({ logLevel: testLogLevel });
+    await expect(pruning).resolves.toBeTruthy();
+  });
+
+  test("sending transfer without gas config works", async () => {
+    const testEthAccount = web3.eth.accounts.create();
+    const transferValue = web3.utils.toWei(1, "ether");
+    await apiClient.runTransactionV1({
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      transactionConfig: {
+        from: WHALE_ACCOUNT_ADDRESS,
+        to: testEthAccount.address,
+        value: transferValue,
+      },
+    });
+
+    const balance = await web3.eth.getBalance(testEthAccount.address);
+    expect(balance).toBeTruthy();
+    expect(balance.toString()).toEqual(transferValue);
+  });
+
+  test("sending transfer with mixed gas config fails", async () => {
+    const testEthAccount = web3.eth.accounts.create();
+    const transferValue = web3.utils.toWei(1, "ether");
+    const maxFee = await connector.estimateMaxFeePerGas(
+      web3.utils.toWei(2, "gwei"),
+    );
+
+    try {
+      await apiClient.runTransactionV1({
+        web3SigningCredential: {
+          ethAccount: WHALE_ACCOUNT_ADDRESS,
+          secret: "",
+          type: Web3SigningCredentialType.GethKeychainPassword,
+        },
+        transactionConfig: {
+          from: WHALE_ACCOUNT_ADDRESS,
+          to: testEthAccount.address,
+          value: transferValue,
+          gasConfig: {
+            gas: "300000",
+            maxFeePerGas: maxFee,
+          },
+        },
+      });
+      fail(
+        "Expected runTransactionV1 with mixed config to fail but it succeeded.",
+      );
+    } catch (error) {
+      console.log("runTransactionV1 with mixed config failed as expected");
+    }
+
+    const balance = await web3.eth.getBalance(testEthAccount.address);
+    expect(balance.toString()).toEqual("0");
+  });
+
+  test("sending transfer with only legacy gas price works", async () => {
+    const testEthAccount = web3.eth.accounts.create();
+    const transferValue = web3.utils.toWei(1, "ether");
+    const maxFee = await connector.estimateMaxFeePerGas(
+      web3.utils.toWei(2, "gwei"),
+    );
+
+    await apiClient.runTransactionV1({
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      transactionConfig: {
+        from: WHALE_ACCOUNT_ADDRESS,
+        to: testEthAccount.address,
+        value: transferValue,
+        gasConfig: {
+          gasPrice: maxFee,
+        },
+      },
+    });
+
+    const balance = await web3.eth.getBalance(testEthAccount.address);
+    expect(balance).toBeTruthy();
+    expect(balance.toString()).toEqual(transferValue);
+  });
+
+  test("sending transfer with only legacy gas (limit) works", async () => {
+    const testEthAccount = web3.eth.accounts.create();
+    const transferValue = web3.utils.toWei(1, "ether");
+
+    await apiClient.runTransactionV1({
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      transactionConfig: {
+        from: WHALE_ACCOUNT_ADDRESS,
+        to: testEthAccount.address,
+        value: transferValue,
+        gasConfig: {
+          gas: "300000",
+        },
+      },
+    });
+
+    const balance = await web3.eth.getBalance(testEthAccount.address);
+    expect(balance).toBeTruthy();
+    expect(balance.toString()).toEqual(transferValue);
+  });
+
+  test("sending transfer with both legacy gas (limit) and gas price works", async () => {
+    const testEthAccount = web3.eth.accounts.create();
+    const transferValue = web3.utils.toWei(1, "ether");
+    const maxFee = await connector.estimateMaxFeePerGas(
+      web3.utils.toWei(2, "gwei"),
+    );
+
+    await apiClient.runTransactionV1({
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      transactionConfig: {
+        from: WHALE_ACCOUNT_ADDRESS,
+        to: testEthAccount.address,
+        value: transferValue,
+        gasConfig: {
+          gas: "300000",
+          gasPrice: maxFee,
+        },
+      },
+    });
+
+    const balance = await web3.eth.getBalance(testEthAccount.address);
+    expect(balance).toBeTruthy();
+    expect(balance.toString()).toEqual(transferValue);
+  });
+
+  test("sending transfer with only maxFeePerGas works", async () => {
+    const testEthAccount = web3.eth.accounts.create();
+    const transferValue = web3.utils.toWei(1, "ether");
+    const maxFee = await connector.estimateMaxFeePerGas(
+      web3.utils.toWei(2, "gwei"),
+    );
+
+    await apiClient.runTransactionV1({
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      transactionConfig: {
+        from: WHALE_ACCOUNT_ADDRESS,
+        to: testEthAccount.address,
+        value: transferValue,
+        gasConfig: {
+          maxFeePerGas: maxFee,
+        },
+      },
+    });
+
+    const balance = await web3.eth.getBalance(testEthAccount.address);
+    expect(balance).toBeTruthy();
+    expect(balance.toString()).toEqual(transferValue);
+  });
+
+  test("sending transfer with only maxPriorityFeePerGas works", async () => {
+    const testEthAccount = web3.eth.accounts.create();
+    const transferValue = web3.utils.toWei(1, "ether");
+
+    await connector.transact({
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      transactionConfig: {
+        from: WHALE_ACCOUNT_ADDRESS,
+        to: testEthAccount.address,
+        value: transferValue,
+        gasConfig: {
+          maxPriorityFeePerGas: web3.utils.toWei(2, "gwei"),
+        },
+      },
+    });
+
+    const balance = await web3.eth.getBalance(testEthAccount.address);
+    expect(balance).toBeTruthy();
+    expect(balance.toString()).toEqual(transferValue);
+  });
+
+  test("sending transfer with only maxPriorityFeePerGas works", async () => {
+    const testEthAccount = web3.eth.accounts.create();
+    const transferValue = web3.utils.toWei(1, "ether");
+    const priorityFee = web3.utils.toWei(2, "gwei");
+    const maxFee = await connector.estimateMaxFeePerGas(priorityFee);
+
+    await apiClient.runTransactionV1({
+      web3SigningCredential: {
+        ethAccount: WHALE_ACCOUNT_ADDRESS,
+        secret: "",
+        type: Web3SigningCredentialType.GethKeychainPassword,
+      },
+      transactionConfig: {
+        from: WHALE_ACCOUNT_ADDRESS,
+        to: testEthAccount.address,
+        value: transferValue,
+        gasConfig: {
+          maxFeePerGas: maxFee,
+          maxPriorityFeePerGas: priorityFee,
+        },
+      },
+    });
+
+    const balance = await web3.eth.getBalance(testEthAccount.address);
+    expect(balance).toBeTruthy();
+    expect(balance.toString()).toEqual(transferValue);
+  });
+});

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/manual/geth-alchemy-integration-manual-check.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/manual/geth-alchemy-integration-manual-check.test.ts
@@ -83,8 +83,6 @@ describe("Alchemy integration manual tests", () => {
         secret: ETH_PRIVATE_KEY,
         type: Web3SigningCredentialType.PrivateKeyHex,
       },
-      gas: 300000,
-      gasPrice: 400000,
     });
     expect(deployOut).toBeTruthy();
     expect(deployOut.transactionReceipt).toBeTruthy();
@@ -109,7 +107,6 @@ describe("Alchemy integration manual tests", () => {
         secret: ETH_PRIVATE_KEY,
         type: Web3SigningCredentialType.PrivateKeyHex,
       },
-      gas: "300000",
     });
     expect(invokeOut).toBeTruthy();
     expect(invokeOut.callOutput).toBeTruthy();

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/unit/model-type-guards.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/unit/model-type-guards.test.ts
@@ -1,5 +1,7 @@
 import "jest-extended";
 import {
+  isGasTransactionConfigEIP1559,
+  isGasTransactionConfigLegacy,
   isWeb3SigningCredentialGethKeychainPassword,
   isWeb3SigningCredentialNone,
   isWeb3SigningCredentialPrivateKeyHex,
@@ -41,5 +43,65 @@ describe("Type guards for OpenAPI spec model type definitions", () => {
 
     expect(isWeb3SigningCredentialNone(valid)).toBe(true);
     expect(isWeb3SigningCredentialNone({})).not.toBe(true);
+  });
+
+  test("isGasTransactionConfigLegacy()", () => {
+    expect(
+      isGasTransactionConfigLegacy({
+        gas: "1234",
+      }),
+    ).toBe(true);
+    expect(
+      isGasTransactionConfigLegacy({
+        gasPrice: "1234",
+      }),
+    ).toBe(true);
+
+    expect(
+      isGasTransactionConfigLegacy({
+        gasLimit: "1234",
+      }),
+    ).toBe(false);
+    expect(
+      isGasTransactionConfigLegacy({
+        maxFeePerGas: "1234",
+      }),
+    ).toBe(false);
+    expect(
+      isGasTransactionConfigLegacy({
+        maxPriorityFeePerGas: "1234",
+      }),
+    ).toBe(false);
+    expect(isGasTransactionConfigLegacy({})).toBe(false);
+  });
+
+  test("isGasTransactionConfigEIP1559()", () => {
+    expect(
+      isGasTransactionConfigEIP1559({
+        gasLimit: "1234",
+      }),
+    ).toBe(true);
+    expect(
+      isGasTransactionConfigEIP1559({
+        maxFeePerGas: "1234",
+      }),
+    ).toBe(true);
+    expect(
+      isGasTransactionConfigEIP1559({
+        maxPriorityFeePerGas: "1234",
+      }),
+    ).toBe(true);
+
+    expect(
+      isGasTransactionConfigEIP1559({
+        gas: "1234",
+      }),
+    ).toBe(false);
+    expect(
+      isGasTransactionConfigEIP1559({
+        gasPrice: "1234",
+      }),
+    ).toBe(false);
+    expect(isGasTransactionConfigEIP1559({})).toBe(false);
   });
 });

--- a/packages/cactus-test-plugin-ledger-connector-ethereum/package.json
+++ b/packages/cactus-test-plugin-ledger-connector-ethereum/package.json
@@ -57,8 +57,7 @@
     "@hyperledger/cactus-plugin-keychain-memory": "2.0.0-alpha.2",
     "@hyperledger/cactus-plugin-ledger-connector-ethereum": "2.0.0-alpha.2",
     "@hyperledger/cactus-verifier-client": "2.0.0-alpha.2",
-    "web3": "4.0.3",
-    "web3-utils": "4.0.3"
+    "web3-eth-contract": "4.1.0"
   },
   "devDependencies": {
     "@hyperledger/cactus-test-geth-ledger": "2.0.0-alpha.2",

--- a/packages/cactus-test-plugin-ledger-connector-ethereum/src/test/typescript/integration/api-client/verifier-integration-with-ethereum-connector.test.ts
+++ b/packages/cactus-test-plugin-ledger-connector-ethereum/src/test/typescript/integration/api-client/verifier-integration-with-ethereum-connector.test.ts
@@ -249,7 +249,6 @@ describe("Verifier integration with ethereum connector tests", () => {
           secret: "",
           type: Web3SigningCredentialType.GethKeychainPassword,
         },
-        gas: 1000000,
       });
       expect(deployOut).toBeTruthy();
       expect(deployOut.transactionReceipt).toBeTruthy();
@@ -415,7 +414,7 @@ describe("Verifier integration with ethereum connector tests", () => {
         contractCommon.abi,
         contractCommon.address,
       );
-      const methodRef = web3Contract.methods.setName as (
+      const methodRef = web3Contract.methods.setName as unknown as (
         ...args: unknown[]
       ) => PayableMethodObject;
       const web3Encode = methodRef(...methodEncode.params).encodeABI();
@@ -445,7 +444,7 @@ describe("Verifier integration with ethereum connector tests", () => {
         contractCommon.abi,
         contractCommon.address,
       );
-      const methodRef = web3Contract.methods.setName as (
+      const methodRef = web3Contract.methods.setName as unknown as (
         ...args: unknown[]
       ) => PayableMethodObject;
       const web3Encode = await methodRef(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6488,11 +6488,9 @@ __metadata:
     socket.io: 4.5.4
     socket.io-client: 4.5.4
     typescript-optional: 2.0.1
-    web3: 4.0.3
-    web3-eth: 4.0.3
-    web3-eth-accounts: 4.0.3
-    web3-eth-contract: 4.0.3
-    web3-utils: 4.0.3
+    web3: 4.1.2
+    web3-eth: 4.2.0
+    web3-eth-contract: 4.1.0
   bin:
     cacti-ethereum-connector-status: dist/lib/scripts/get-ethereum-connector-status.js
   languageName: unknown
@@ -7053,8 +7051,7 @@ __metadata:
     "@hyperledger/cactus-verifier-client": 2.0.0-alpha.2
     "@types/lodash": 4.14.195
     lodash: 4.17.21
-    web3: 4.0.3
-    web3-utils: 4.0.3
+    web3-eth-contract: 4.1.0
   languageName: unknown
   linkType: soft
 
@@ -42854,6 +42851,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web3-core@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "web3-core@npm:4.2.0"
+  dependencies:
+    web3-errors: ^1.1.2
+    web3-eth-iban: ^4.0.6
+    web3-providers-http: ^4.0.6
+    web3-providers-ipc: ^4.0.6
+    web3-providers-ws: ^4.0.6
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+    web3-validator: ^2.0.2
+  dependenciesMeta:
+    web3-providers-ipc:
+      optional: true
+  checksum: d3514d078d74ab13d2ca25738499dc58347fd7f42af4e98fe31367b404f7fc6260a7ad3cd1c1480077c2960fb874f9e3fdbaf8fb1424d0537c76d8c0e88dc74e
+  languageName: node
+  linkType: hard
+
 "web3-errors@npm:^1.0.2":
   version: 1.0.2
   resolution: "web3-errors@npm:1.0.2"
@@ -42869,6 +42885,15 @@ __metadata:
   dependencies:
     web3-types: ^1.1.1
   checksum: 1ac088d49e32f0952f4098a618cf1a89b318b052b6b9e58c9d54976e6b43ef5cd7583c2411275c6d6f7b0f3990e9cf6b2c86c1c1023d50b014cbd04fc18ac73e
+  languageName: node
+  linkType: hard
+
+"web3-errors@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "web3-errors@npm:1.1.2"
+  dependencies:
+    web3-types: ^1.2.0
+  checksum: 7f9e8a476aa8514a2926743680e5561950f684be0cd6ff87e6fb12a7978fa568492aee0f502ee68e88686c5a904348d32935dbcb852ba00b7612efb8baf14d34
   languageName: node
   linkType: hard
 
@@ -42965,6 +42990,19 @@ __metadata:
     web3-types: ^1.1.1
     web3-utils: ^4.0.5
   checksum: 99e197707396a1083e46f28d5b6bc3af299ad17d196d00a78ce9b87c6dc4b00ce0b68750c7bc0a7809916f8f1d834b6de5c35dc7e04454b990b30f64beafc82c
+  languageName: node
+  linkType: hard
+
+"web3-eth-abi@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "web3-eth-abi@npm:4.1.2"
+  dependencies:
+    "@ethersproject/abi": ^5.7.0
+    "@ethersproject/bignumber": ^5.7.0
+    web3-errors: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+  checksum: 72c4374a29e6db0e2ddf74a8cc952c74a9cda16150c3a6df7fd54848ee00519b544dd313eadbfea53584f01eccd0ba285f5119bc8323bb5199678639ad28eda3
   languageName: node
   linkType: hard
 
@@ -43129,6 +43167,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web3-eth-accounts@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "web3-eth-accounts@npm:4.0.6"
+  dependencies:
+    "@ethereumjs/rlp": ^4.0.1
+    crc-32: ^1.2.2
+    ethereum-cryptography: ^2.0.0
+    web3-errors: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+    web3-validator: ^2.0.2
+  checksum: 07fc3f5b6ccb862696ea2c34cc104323ad2b1e85c54bb8bd8dcb61154b09f592a2cc899ff0ac7bdd2a2e6f39afe3a4cdf2e7630ddc9b4150bf0b45e7004fe209
+  languageName: node
+  linkType: hard
+
 "web3-eth-contract@npm:1.10.0":
   version: 1.10.0
   resolution: "web3-eth-contract@npm:1.10.0"
@@ -43241,18 +43294,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-eth-contract@npm:4.0.3":
-  version: 4.0.3
-  resolution: "web3-eth-contract@npm:4.0.3"
+"web3-eth-contract@npm:4.1.0, web3-eth-contract@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "web3-eth-contract@npm:4.1.0"
   dependencies:
-    web3-core: ^4.0.3
-    web3-errors: ^1.0.2
-    web3-eth: ^4.0.3
-    web3-eth-abi: ^4.0.3
-    web3-types: ^1.0.2
-    web3-utils: ^4.0.3
-    web3-validator: ^1.0.2
-  checksum: 24f5cc9645af7c2c6ffe6ff2dd819c576904b959e4d2388bb9565014bfa256c75903450b9de48a6e734bbca4a5542c441246497a858ed392cf71340bb1e961ca
+    web3-core: ^4.2.0
+    web3-errors: ^1.1.2
+    web3-eth: ^4.2.0
+    web3-eth-abi: ^4.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+    web3-validator: ^2.0.2
+  checksum: 063f2c12f10c17040362f7a88865a7a727f875d7a51e69f5c804b16e61813d79af7b1c1016a856c8a2ceb585ba8f60881eb66e4df5106ff36ce4bae16fe0340b
   languageName: node
   linkType: hard
 
@@ -43400,6 +43453,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web3-eth-ens@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "web3-eth-ens@npm:4.0.6"
+  dependencies:
+    "@adraffy/ens-normalize": ^1.8.8
+    web3-core: ^4.2.0
+    web3-errors: ^1.1.2
+    web3-eth: ^4.2.0
+    web3-eth-contract: ^4.1.0
+    web3-net: ^4.0.6
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+    web3-validator: ^2.0.2
+  checksum: 8417a5938c59f2a7d04b103c36868ea612d88afc18c35783ab60c48b375d355b47b994d753ad8507a304b3845d2f8e5d812e9ada5105ad276051f7305ccedafa
+  languageName: node
+  linkType: hard
+
 "web3-eth-iban@npm:1.10.0":
   version: 1.10.0
   resolution: "web3-eth-iban@npm:1.10.0"
@@ -43479,6 +43549,18 @@ __metadata:
     web3-utils: ^4.0.5
     web3-validator: ^2.0.1
   checksum: 305c1c87dfdc41ff8c61d91ac3ec620dac6dbd1a037dde1f252892d9f90fb6d34d7bf6ceb41548f8a7ff036a2ef47cc550426653c11052ac08d50b8e943c0298
+  languageName: node
+  linkType: hard
+
+"web3-eth-iban@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "web3-eth-iban@npm:4.0.6"
+  dependencies:
+    web3-errors: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+    web3-validator: ^2.0.2
+  checksum: 7932961def8972aae01b409e28a98ccda6aece344bd3741bf967304b878a1722d77805d364ff61ca71c70cda937aadb077b506c9671e6b33db88c6a4e59ce5e8
   languageName: node
   linkType: hard
 
@@ -43591,6 +43673,20 @@ __metadata:
     web3-utils: ^4.0.5
     web3-validator: ^2.0.1
   checksum: b56951dae5589b626fc167c5eb68e89386a51513acc272e7ac2245d510fda2ca883ae73feab2d155f1fcc2f409dd934f93aa685fb9574239886d05e2261f9db7
+  languageName: node
+  linkType: hard
+
+"web3-eth-personal@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "web3-eth-personal@npm:4.0.6"
+  dependencies:
+    web3-core: ^4.2.0
+    web3-eth: ^4.2.0
+    web3-rpc-methods: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+    web3-validator: ^2.0.2
+  checksum: 7d6066b3cdaa20e6c19b581c44feea546fe0dd32b5f7db502626db2bd90de1e034cf36dcb5262fe3fdb145665925ae4cc81cb3ae051b7cf38765cd0a7e638ca8
   languageName: node
   linkType: hard
 
@@ -43734,25 +43830,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-eth@npm:4.0.3":
-  version: 4.0.3
-  resolution: "web3-eth@npm:4.0.3"
-  dependencies:
-    setimmediate: ^1.0.5
-    web3-core: ^4.0.3
-    web3-errors: ^1.0.2
-    web3-eth-abi: ^4.0.3
-    web3-eth-accounts: ^4.0.3
-    web3-net: ^4.0.3
-    web3-providers-ws: ^4.0.3
-    web3-rpc-methods: ^1.0.2
-    web3-types: ^1.0.2
-    web3-utils: ^4.0.3
-    web3-validator: ^1.0.2
-  checksum: ce758d952cd1bd414a9449defc68d6a3c8fc1d183dfb152a2130e774018bef9ff7af70844884cabe5b4e5238823a061eba2c7622e49ea7afe8f3cec112930f2e
-  languageName: node
-  linkType: hard
-
 "web3-eth@npm:4.1.1, web3-eth@npm:^4.0.3, web3-eth@npm:^4.1.1":
   version: 4.1.1
   resolution: "web3-eth@npm:4.1.1"
@@ -43769,6 +43846,25 @@ __metadata:
     web3-utils: ^4.0.5
     web3-validator: ^2.0.1
   checksum: 9ffc2800f050e74c98def916249cbb56e314f6aa3eb14b29915a2acf87ab77f4535d472eeb1c23f356f6a9dde9d5c66caeb1cf7c257e432814c4e0c5b90f5b0d
+  languageName: node
+  linkType: hard
+
+"web3-eth@npm:4.2.0, web3-eth@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "web3-eth@npm:4.2.0"
+  dependencies:
+    setimmediate: ^1.0.5
+    web3-core: ^4.2.0
+    web3-errors: ^1.1.2
+    web3-eth-abi: ^4.1.2
+    web3-eth-accounts: ^4.0.6
+    web3-net: ^4.0.6
+    web3-providers-ws: ^4.0.6
+    web3-rpc-methods: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+    web3-validator: ^2.0.2
+  checksum: e8453ced9c2e9b12a2c80d0383d568ba597c9ca052b4a847794758a6c1589c35b919ceddedef8aaab7abdb800d15ff4cb6103c7ccbccb41e6e3cf1bb61344071
   languageName: node
   linkType: hard
 
@@ -43861,6 +43957,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web3-net@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "web3-net@npm:4.0.6"
+  dependencies:
+    web3-core: ^4.2.0
+    web3-rpc-methods: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+  checksum: 840ae451ca7cd7386cf68d1839bd4bf9ceda987bd8e74dee179375ab4297d36fddff7b4ec1472f66779326714e8c90912f612c124facea75c2039b3ac06d1e42
+  languageName: node
+  linkType: hard
+
 "web3-providers-http@npm:1.10.0":
   version: 1.10.0
   resolution: "web3-providers-http@npm:1.10.0"
@@ -43949,6 +44057,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web3-providers-http@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "web3-providers-http@npm:4.0.6"
+  dependencies:
+    cross-fetch: ^3.1.5
+    web3-errors: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+  checksum: a15b282a711c8a67ec69f2f54e057ef23ae67cd0f9bbe0f6189a8f7059bb5d80b55a1635eb2f13ff6e3a2fed13e18b67cdf60305ae1a35ff95fc1b288daaf7b5
+  languageName: node
+  linkType: hard
+
 "web3-providers-ipc@npm:1.10.0":
   version: 1.10.0
   resolution: "web3-providers-ipc@npm:1.10.0"
@@ -44027,6 +44147,17 @@ __metadata:
     web3-types: ^1.1.1
     web3-utils: ^4.0.5
   checksum: 90746b699e1ea884c816618ff6ac98330557c9f7cc3ca0c9b033dcac9b7979b354acbaf05b8e37d1c0d05f386042b4c54b3f1bbeccf89d67cda45829843ba560
+  languageName: node
+  linkType: hard
+
+"web3-providers-ipc@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "web3-providers-ipc@npm:4.0.6"
+  dependencies:
+    web3-errors: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+  checksum: 2939b47ab2828106f79df5a7c96b3a15802565ce8f72b8b3684af65925a930c9298ed691e94589871ba87e70a4f626669f9087e25b7aa9086fca205dc415b8ac
   languageName: node
   linkType: hard
 
@@ -44121,6 +44252,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web3-providers-ws@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "web3-providers-ws@npm:4.0.6"
+  dependencies:
+    "@types/ws": 8.5.3
+    isomorphic-ws: ^5.0.0
+    web3-errors: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+    ws: ^8.8.1
+  checksum: af43ccabafcf85ef363bcb13796cee1c8849283fff822d25d7044774917fe5827c8f93dcf55dd98d1540b3198cb1c4bc65b01985af1791f764ef6a8a5f197f4a
+  languageName: node
+  linkType: hard
+
 "web3-rpc-methods@npm:^1.0.2, web3-rpc-methods@npm:^1.1.1":
   version: 1.1.1
   resolution: "web3-rpc-methods@npm:1.1.1"
@@ -44129,6 +44274,17 @@ __metadata:
     web3-types: ^1.1.1
     web3-validator: ^2.0.1
   checksum: ce9ebe6ae06903732246fdf3798d26b834428530cb4d0ad569c3913f955856e4ce8c57210a713946514e8780521b19f4f677725b625c57791140cf849048f074
+  languageName: node
+  linkType: hard
+
+"web3-rpc-methods@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "web3-rpc-methods@npm:1.1.2"
+  dependencies:
+    web3-core: ^4.2.0
+    web3-types: ^1.2.0
+    web3-validator: ^2.0.2
+  checksum: 452dcd18993d7fa2ab37a062d39a317100223b65f13fa9ecc0e95d91e05312e013b7cc3e21aaaf583f8a3261e819022d69d1c1ab1ac65a40afe14d28ff11becf
   languageName: node
   linkType: hard
 
@@ -44227,6 +44383,13 @@ __metadata:
   version: 1.1.1
   resolution: "web3-types@npm:1.1.1"
   checksum: d477bf427581ed7350129d9c79958321afdbcb0f2ac9a956fc00ff1c534fc021d8fe8c9b8fb787926f7c487a29074bc85bda7eee3098e5abbe91fbb3e11b89f0
+  languageName: node
+  linkType: hard
+
+"web3-types@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "web3-types@npm:1.2.0"
+  checksum: ed8c42df578fc51cb4a56d60d9dd018f0fbbf7cf4992ac4150361e2985e8a6fc91fde9589f74201495d7795ac563eecf62ec2e7496858433f3ba0350e1808bbc
   languageName: node
   linkType: hard
 
@@ -44360,6 +44523,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web3-utils@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "web3-utils@npm:4.0.6"
+  dependencies:
+    ethereum-cryptography: ^2.0.0
+    web3-errors: ^1.1.2
+    web3-types: ^1.2.0
+    web3-validator: ^2.0.2
+  checksum: dadc688fefe893f06ecc4d961400ad68a81f49c5484e5a06397902f30980dd3bb4945fddc45b732f90e7fa574531ee8355aaba5b417aad2cfcbf935faf843ec8
+  languageName: node
+  linkType: hard
+
 "web3-validator@npm:^1.0.2":
   version: 1.0.2
   resolution: "web3-validator@npm:1.0.2"
@@ -44383,6 +44558,19 @@ __metadata:
     web3-types: ^1.1.1
     zod: ^3.21.4
   checksum: 4382a0d034751ca04d3f919efd4f1115abecee8541585179158662e46dd10b051c4ee29c885067d7aeff618dec971c4a2075baeb7df63249e3ed5b2d5695b782
+  languageName: node
+  linkType: hard
+
+"web3-validator@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "web3-validator@npm:2.0.2"
+  dependencies:
+    ethereum-cryptography: ^2.0.0
+    util: ^0.12.5
+    web3-errors: ^1.1.2
+    web3-types: ^1.2.0
+    zod: ^3.21.4
+  checksum: 690eb297c517dd4016c9a9e6929236d394367793903242e788bd43a323c7934cf4a47e68b7f6526f9f0d1c8cf4d9bee0693331e4edff489e17b749e9d2538542
   languageName: node
   linkType: hard
 
@@ -44521,6 +44709,30 @@ __metadata:
     web3-utils: ^4.0.5
     web3-validator: ^2.0.1
   checksum: 572d728920c3cf3a254cda835a8f7dc80de46be48f06814c052f1399c6163a26dfc8e8a565ce17468c1d20761671d40efa77bdeb77cec9efea8e7796b83fd26d
+  languageName: node
+  linkType: hard
+
+"web3@npm:4.1.2":
+  version: 4.1.2
+  resolution: "web3@npm:4.1.2"
+  dependencies:
+    web3-core: ^4.2.0
+    web3-errors: ^1.1.2
+    web3-eth: ^4.2.0
+    web3-eth-abi: ^4.1.2
+    web3-eth-accounts: ^4.0.6
+    web3-eth-contract: ^4.1.0
+    web3-eth-ens: ^4.0.6
+    web3-eth-iban: ^4.0.6
+    web3-eth-personal: ^4.0.6
+    web3-net: ^4.0.6
+    web3-providers-http: ^4.0.6
+    web3-providers-ws: ^4.0.6
+    web3-rpc-methods: ^1.1.2
+    web3-types: ^1.2.0
+    web3-utils: ^4.0.6
+    web3-validator: ^2.0.2
+  checksum: ecc4d83df7d011a238ee6edd7455255036b8b63f3086ab960689d60b865cac157cb457a790500ac583b585bb3211096b0e01571e558f453e8437a7e3a01177da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Add legacy and EIP1559 gas configuration options to transaction requests.
- Legacy gas configuration is updated to EIP1559 using the same logic as web3 libraries.
- Update the tests to work with new API.
- Added test suite to test new features - `geth-transact-and-gas-fees.test.ts`

Depends on #2581

Signed-off-by: Michal Bajer <michal.bajer@fujitsu.com>
