### PR TITLE
test(ghcr-rust-compiler): fix image build - anstream v0.5.0 cannot be built

### DIFF
--- a/tools/docker/rust-compiler/Dockerfile
+++ b/tools/docker/rust-compiler/Dockerfile
@@ -1,7 +1,7 @@
-FROM rust:1.68.0-slim-bullseye
+FROM rust:1.72.0-slim-bullseye
 
 RUN apt update
 
 # wasm-pack dependencies+install
 RUN apt install -y build-essential pkg-config libssl-dev
-RUN cargo install wasm-pack
+RUN cargo install --version=0.12.1 wasm-pack


### PR DESCRIPTION
1. Upgraded the rust version of the image to v1.72.0 - short term fix
2. The longer term fix is that I locked down the version of wasm-pack to
the current latest stable (v0.12.1) so that the auto-upgrade
doesn't bite is again like this where the newer wasm-pack
starts demanding a newer rust compiler which we don't
have because we are pinning to a specific version through
the image tag that's being used.

Fixes #2641

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>