### PR TITLE
docs(examples): fix Mongoose Prototype Pollution vulnerability

### DIFF
--- a/examples/test-run-transaction/supply-chain-app-stub/package.json
+++ b/examples/test-run-transaction/supply-chain-app-stub/package.json
@@ -8,9 +8,7 @@
     "cors": "2.8.5",
     "express": "4.17.3",
     "moment": "2.29.4",
-    "mongodb": "3.7.3",
-    "mongoose": "5.13.14",
-    "ts-node": "9.1.1",
+    "ts-node": "10.9.1",
     "typescript": "4.9.5",
     "helmet": "4.6.0"
   },


### PR DESCRIPTION
Both mongoose and the mongodb NodeJS driver dependency appeared to be
completely unused so instead of upgrading I just removed them.

Fixes #2669

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>