### PR TITLE
build(codegen): fix URL of OpenAPI generator jar v6.6.0 not 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "codegen:cleanup": "rm --force --verbose ./openapitools.json",
     "codegen:lerna": "lerna run codegen",
     "codegen:warmup-mkdir": "make-dir ./node_modules/@openapitools/openapi-generator-cli/versions/",
-    "codegen:warmup-v6.6.0": "nwget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.6.0.jar -O ./node_modules/@openapitools/openapi-generator-cli/versions/6.6.0.jar",
+    "codegen:warmup-v6.6.0": "nwget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.6.0/openapi-generator-cli-6.6.0.jar -O ./node_modules/@openapitools/openapi-generator-cli/versions/6.6.0.jar",
     "watch-other": "lerna run --parallel watch",
     "watch-tsc": "tsc --build --watch",
     "watch": "run-p -r watch-*",


### PR DESCRIPTION
[skip ci]

Fixes #2680

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>