### PR TITLE
fix(cmd-api-server): fix CVE-2023-36665 protobufjs Prototype Pollution vuln

### DIFF
--- a/packages/cactus-cmd-api-server/package.json
+++ b/packages/cactus-cmd-api-server/package.json
@@ -119,7 +119,7 @@
     "grpc-tools": "1.12.4",
     "grpc_tools_node_protoc_ts": "5.3.3",
     "http-status-codes": "2.1.4",
-    "protobufjs": "7.2.4"
+    "protobufjs": "7.2.5"
   },
   "engines": {
     "node": ">=10",

--- a/packages/cactus-plugin-ledger-connector-fabric-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric-socketio/package.json
@@ -31,7 +31,7 @@
     "lodash": "4.17.21",
     "log4js": "6.4.1",
     "morgan": "1.10.0",
-    "protobufjs": "5.0.3",
+    "protobufjs": "7.2.5",
     "serve-favicon": "2.4.5",
     "shelljs": "0.8.5",
     "socket.io": "4.5.4"

--- a/weaver/samples/fabric/fabric-cli/package-local.json
+++ b/weaver/samples/fabric/fabric-cli/package-local.json
@@ -65,7 +65,7 @@
     "jest": "29.6.2",
     "pkg": "4.5.1",
     "prettier": "1.19.1",
-    "protobufjs": "6.11.3",
+    "protobufjs": "7.2.5",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"

--- a/weaver/samples/fabric/fabric-cli/package.json
+++ b/weaver/samples/fabric/fabric-cli/package.json
@@ -73,7 +73,7 @@
     "jest": "29.6.2",
     "pkg": "4.5.1",
     "prettier": "1.19.1",
-    "protobufjs": "6.11.3",
+    "protobufjs": "7.2.5",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6038,7 +6038,7 @@ __metadata:
     node-notifier: 8.0.2
     pkg: 4.5.1
     prettier: 1.19.1
-    protobufjs: 6.11.3
+    protobufjs: 7.2.5
     ts-jest: 29.1.1
     ts-node: 10.9.1
     typescript: 4.9.5
@@ -6239,7 +6239,7 @@ __metadata:
     lmify: 0.3.0
     node-forge: 1.3.0
     prom-client: 13.2.0
-    protobufjs: 7.2.4
+    protobufjs: 7.2.5
     run-time-error: 1.4.0
     rxjs: 7.8.1
     safe-stable-stringify: 2.4.3
@@ -7098,7 +7098,7 @@ __metadata:
     lodash: 4.17.21
     log4js: 6.4.1
     morgan: 1.10.0
-    protobufjs: 5.0.3
+    protobufjs: 7.2.5
     serve-favicon: 2.4.5
     shelljs: 0.8.5
     socket.io: 4.5.4
@@ -37330,7 +37330,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:6.11.3, protobufjs@npm:^6.11.3":
+"protobufjs@npm:7.2.5":
+  version: 7.2.5
+  resolution: "protobufjs@npm:7.2.5"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: 3770a072114061faebbb17cfd135bc4e187b66bc6f40cd8bac624368b0270871ec0cfb43a02b9fb4f029c8335808a840f1afba3c2e7ede7063b98ae6b98a703f
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^6.11.3":
   version: 6.11.3
   resolution: "protobufjs@npm:6.11.3"
   dependencies:
@@ -37354,26 +37374,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.2.4, protobufjs@npm:^7.2.4":
-  version: 7.2.4
-  resolution: "protobufjs@npm:7.2.4"
-  dependencies:
-    "@protobufjs/aspromise": ^1.1.2
-    "@protobufjs/base64": ^1.1.2
-    "@protobufjs/codegen": ^2.0.4
-    "@protobufjs/eventemitter": ^1.1.0
-    "@protobufjs/fetch": ^1.1.0
-    "@protobufjs/float": ^1.0.2
-    "@protobufjs/inquire": ^1.1.0
-    "@protobufjs/path": ^1.1.2
-    "@protobufjs/pool": ^1.1.0
-    "@protobufjs/utf8": ^1.1.0
-    "@types/node": ">=13.7.0"
-    long: ^5.0.0
-  checksum: a952cdf2a5e5250c16ae651b570849b6f5b20a5475c3eef63ffb290ad239aa2916adfc1cc676f7fc93c69f48113df268761c0c246f7f023118c85bdd1a170044
-  languageName: node
-  linkType: hard
-
 "protobufjs@npm:^7.0.0":
   version: 7.2.3
   resolution: "protobufjs@npm:7.2.3"
@@ -37391,6 +37391,26 @@ __metadata:
     "@types/node": ">=13.7.0"
     long: ^5.0.0
   checksum: 9afa6de5fced0139a5180c063718508fac3ea734a9f1aceb99712367b15473a83327f91193f16b63540f9112b09a40912f5f0441a9b0d3f3c6a1c7f707d78249
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.2.4":
+  version: 7.2.4
+  resolution: "protobufjs@npm:7.2.4"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: a952cdf2a5e5250c16ae651b570849b6f5b20a5475c3eef63ffb290ad239aa2916adfc1cc676f7fc93c69f48113df268761c0c246f7f023118c85bdd1a170044
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgraded all imports of protobufjs to non-vulnerable
versions (v7.2.5)

Fixes #2682

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>