### PR TITLE
style: fix unexpected any linter w in startCockpitFileServer

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -513,7 +513,8 @@ export class ApiServer {
         this.log.debug(`PROXY ${srcHost} => ${destHost} :: ${thePath}`);
 
         // make sure self signed certs are accepted if it was configured as such by the user
-        (proxyReqOpts as any).rejectUnauthorized = rejectUnauthorized;
+        (proxyReqOpts as Record<string, unknown>).rejectUnauthorized =
+          rejectUnauthorized;
         return proxyReqOpts;
       },
     });


### PR DESCRIPTION
The linter warning for unexpected any was fixed with Record<string, unknown>

[skip ci]

Closes: #2677
