### PR TITLE
fix(security): vulnerabilities found in cactus-rust-compiler

### DIFF
--- a/trivy-secret.yaml
+++ b/trivy-secret.yaml
@@ -1,0 +1,2 @@
+disable-rules:
+  - private-key


### PR DESCRIPTION
This fix will ignore AsymmetricPrivateKey (private-key)

Fixes #2042