### PR TITLE
build(tools/docker/indy-sdk-cli): fix deprecation deb.nodesource.com/setup_16.x

### DIFF
--- a/tools/docker/indy-sdk-cli/Dockerfile
+++ b/tools/docker/indy-sdk-cli/Dockerfile
@@ -22,8 +22,9 @@ RUN apt-get update \
         make \
     && rm -rf /var/lib/apt/lists/*
 
-# NodeJS
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+# NodeJS - Updated to use the new NodeSource installation method
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource-archive-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nodesource-archive-keyring.gpg] https://deb.nodesource.com/node bionic main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Indy-sdk
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \


### PR DESCRIPTION
**Change Description:**

In the Dockerfile, the issue related to NodeJS was addressed by updating the NodeJS installation method to use the new NodeSource installation method. The previous method using `curl -sL https://deb.nodesource.com/setup_16.x | bash -` had become deprecated, so the new method was applied for compatibility with the latest practices.

The specific changes made in the Dockerfile are as follows:

1. Removed the old installation method for NodeJS:

   ```Dockerfile
   # Removed the deprecated NodeJS installation method
   # RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
   ```

2. Added the new NodeSource installation method:

   ```Dockerfile
   # Added the new NodeSource installation method for NodeJS
   RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource-archive-keyring.gpg \
       && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nodesource-archive-keyring.gpg] https://deb.nodesource.com/node bionic main" | tee /etc/apt/sources.list.d/nodesource.list
   ```

Fixes #2701  