### PR TITLE
build(plugin-keychain-x): fix tsc compiler errors - missing V1 suffix

### DIFF
--- a/packages/cactus-plugin-keychain-azure-kv/src/main/typescript/web-services/get-keychain-entry-endpoint.ts
+++ b/packages/cactus-plugin-keychain-azure-kv/src/main/typescript/web-services/get-keychain-entry-endpoint.ts
@@ -17,7 +17,7 @@ import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
 import { PluginKeychainAzureKv } from "../plugin-keychain-azure-kv";
 
 import OAS from "../../json/openapi.json";
-import { GetKeychainEntryRequest } from "../generated/openapi/typescript-axios";
+import { GetKeychainEntryRequestV1 } from "../generated/openapi/typescript-axios";
 
 export interface IGetKeychainEntryEndpointOptions {
   logLevel?: LogLevelDesc;
@@ -87,7 +87,7 @@ export class GetKeychainEntryEndpoint implements IWebServiceEndpoint {
   public async handleRequest(req: Request, res: Response): Promise<void> {
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
-    const { key } = req.body as GetKeychainEntryRequest;
+    const { key } = req.body as GetKeychainEntryRequestV1;
     try {
       const value = await this.options.connector.get(key);
       res.json({

--- a/packages/cactus-plugin-keychain-azure-kv/src/main/typescript/web-services/set-keychain-entry-endpoint.ts
+++ b/packages/cactus-plugin-keychain-azure-kv/src/main/typescript/web-services/set-keychain-entry-endpoint.ts
@@ -17,7 +17,7 @@ import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
 import { PluginKeychainAzureKv } from "../plugin-keychain-azure-kv";
 
 import OAS from "../../json/openapi.json";
-import { SetKeychainEntryRequest } from "../generated/openapi/typescript-axios";
+import { SetKeychainEntryRequestV1 } from "../generated/openapi/typescript-axios";
 
 export interface ISetKeychainEntryEndpointOptions {
   logLevel?: LogLevelDesc;
@@ -88,7 +88,7 @@ export class SetKeychainEntryEndpoint implements IWebServiceEndpoint {
     const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
     this.log.debug(reqTag);
     try {
-      const { key, value } = req.body as SetKeychainEntryRequest;
+      const { key, value } = req.body as SetKeychainEntryRequestV1;
       const resBody = await this.options.connector.set(key, value);
       res.json(resBody);
     } catch (ex) {

--- a/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/get-keychain-entry-endpoint-v1.ts
+++ b/packages/cactus-plugin-keychain-vault/src/main/typescript/web-services/get-keychain-entry-endpoint-v1.ts
@@ -16,7 +16,7 @@ import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
 
 import OAS from "../../json/openapi.json";
 import { PluginKeychainVault } from "../plugin-keychain-vault";
-import { GetKeychainEntryResponse } from "../generated/openapi/typescript-axios";
+import { GetKeychainEntryResponseV1 } from "../generated/openapi/typescript-axios";
 
 export interface IGetKeychainEntryEndpointV1Options {
   logLevel?: LogLevelDesc;
@@ -50,7 +50,7 @@ export class GetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
     this.log.debug(`Instantiated ${this.className} OK`);
   }
 
-  public get oasPath(): typeof OAS.paths["/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/get-keychain-entry"] {
+  public get oasPath(): (typeof OAS.paths)["/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/get-keychain-entry"] {
     return OAS.paths[
       "/api/v1/plugins/@hyperledger/cactus-plugin-keychain-vault/get-keychain-entry"
     ];
@@ -94,7 +94,7 @@ export class GetKeychainEntryEndpointV1 implements IWebServiceEndpoint {
     try {
       this.log.debug(`${tag} %o`, req.body);
       const value = await this.plugin.get(req.body.key);
-      const resBody: GetKeychainEntryResponse = {
+      const resBody: GetKeychainEntryResponseV1 = {
         key: req.body.key,
         value: value as string,
       };

--- a/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-keychain-vault/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -21,11 +21,11 @@ import {
 import {
   Configuration,
   DeleteKeychainEntryRequestV1,
-  GetKeychainEntryRequest,
+  GetKeychainEntryRequestV1,
   HasKeychainEntryRequestV1,
   IPluginKeychainVaultOptions,
   PluginKeychainVault,
-  SetKeychainEntryRequest,
+  SetKeychainEntryRequestV1,
 } from "../../../../main/typescript/public-api";
 
 import { DefaultApi as KeychainVaultApi } from "../../../../main/typescript/public-api";
@@ -138,7 +138,7 @@ test(`${testCase}`, async (t: Test) => {
     try {
       await apiClient.setKeychainEntryV1({
         value: value1,
-      } as SetKeychainEntryRequest);
+      } as SetKeychainEntryRequestV1);
     } catch (err) {
       const e = err as AxiosError<{ path: string }[]>;
       t2.equal(
@@ -174,7 +174,7 @@ test(`${testCase}`, async (t: Test) => {
 
   test(`${testCase} - ${fGet} - ${cWithoutParams}`, async (t2: Test) => {
     try {
-      await apiClient.getKeychainEntryV1({} as GetKeychainEntryRequest);
+      await apiClient.getKeychainEntryV1({} as GetKeychainEntryRequestV1);
     } catch (err) {
       const e = err as AxiosError<{ path: string }[]>;
       t2.equal(
@@ -214,7 +214,7 @@ test(`${testCase}`, async (t: Test) => {
         key: key1,
         value: value1,
         fake: 4,
-      } as SetKeychainEntryRequest);
+      } as SetKeychainEntryRequestV1);
     } catch (err) {
       const e = err as AxiosError<{ path: string }[]>;
       t2.equal(
@@ -262,7 +262,7 @@ test(`${testCase}`, async (t: Test) => {
       await apiClient.getKeychainEntryV1({
         key: key1,
         fake: 4,
-      } as GetKeychainEntryRequest);
+      } as GetKeychainEntryRequestV1);
     } catch (err) {
       const e = err as AxiosError<{ path: string }[]>;
       t2.equal(
@@ -286,7 +286,7 @@ test(`${testCase}`, async (t: Test) => {
       await apiClient.deleteKeychainEntryV1({
         key: key1,
         fake: 4,
-      } as GetKeychainEntryRequest);
+      } as GetKeychainEntryRequestV1);
     } catch (err) {
       const e = err as AxiosError;
       t2.equal(


### PR DESCRIPTION
This was caused by the bumping of the references in the openapi.json
files which had been pointing to older versions of the openapi.json
files through git direct links but now we have upgraded to them.

Previously the keychain request/response entities were missing the
V1 suffix and the cross-references were still using these older versions
prior to us making the bumps.

[skip ci]

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>