### PR TITLE
test(cmd-api-server): fix expected Non-exempt unprotected got Failed to start

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -783,7 +783,7 @@ export class ApiServer {
         !unprotectedEndpointExemptions.some((pt) => nse.getPath().match(pt)),
     );
     if (nonExempts.length > 0) {
-      const csv = nonExempts.join(", ");
+      const csv = nonExempts.map((ep) => ep.getPath()).join(", ");
       const { E_NON_EXEMPT_UNPROTECTED_ENDPOINTS } = ApiServer;
       throw new Error(`${E_NON_EXEMPT_UNPROTECTED_ENDPOINTS} ${csv}`);
     }


### PR DESCRIPTION
1. Refactored the assertion to inspect the nested inner exception's message
instead of the outer, more generic one.
2. Also fixed a bug in the ApiServer class where it was constructing a comma
seperated list of unprotected endpoints incorrectly and ended up with
[object object] as the CSV instead of a list of the HTTP URLs of the endpoints.

Fixes #2711

[skip ci]

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>