### PR TITLE
style(cmd-api-server): fix any linter in getOrCreateWebServices()

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -593,7 +593,7 @@ export class ApiServer {
     const { "/api/v1/api-server/healthcheck": oasPath } = OAS.paths;
     const { http } = oasPath.get["x-hyperledger-cactus"];
     const { path: httpPath, verbLowerCase: httpVerb } = http;
-    (app as any)[httpVerb](httpPath, healthcheckHandler);
+    (app as express.Express)[httpVerb as keyof express.Express](httpPath, healthcheckHandler);
 
     this.wsApi.on("connection", (socket: SocketIoSocket) => {
       const { id } = socket;
@@ -628,7 +628,7 @@ export class ApiServer {
       oasPathPrometheus.get["x-hyperledger-cactus"];
     const { path: httpPathPrometheus, verbLowerCase: httpVerbPrometheus } =
       httpPrometheus;
-    (app as any)[httpVerbPrometheus](
+    (app as express.Express)[httpVerbPrometheus as keyof express.Express](
       httpPathPrometheus,
       prometheusExporterHandler,
     );


### PR DESCRIPTION
## Description:
This pull request addresses issue #2676  by fixing an Unexpected any linter warning in the getOrCreateWebServices() method of the ApiServer class. The warning occurred due to a typecast using (app as any). 

### Changes:
Replaced (app as any) with (app as express.Express)[httpVerbPrometheus as keyof express.Express](httpPathPrometheus, prometheusExporterHandler);

### Importance of keyof:
The use of keyof here is crucial because it ensures that httpVerbPrometheus and httpVerb are treated as the valid key of the express.Express type. This is necessary because HTTP verbs, like GET, POST, PUT etc... should be treated as keys within the express.Express type. By casting httpVerbPrometheus as keyof express.Express, we enforce type safety and prevent potential runtime errors that could occur if an invalid HTTP verb is used. In essence, it ensures that only valid HTTP verbs are accepted, improving the robustness of the code. 

### Benefits:
This change enhances code readability and maintainability using appropriate types and expressions.