### PR TITLE
feat(cactus-plugin-ledger-connector-ethereum): add json-rpc proxy

### DIFF
--- a/packages/cactus-plugin-ledger-connector-ethereum/README.md
+++ b/packages/cactus-plugin-ledger-connector-ethereum/README.md
@@ -147,6 +147,19 @@ args: {
 },
 ```
 
+## JSON-RPC Proxy
+- Connector can be used with web3js to send any JSON-RPC request to the ethereum node.
+
+### Example
+``` typescript
+  const proxyUrl = new URL(
+    "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-ethereum/json-rpc",
+    apiHost,
+  );
+  const web3ProxyClient = new Web3(proxyUrl.toString());
+  const gasPrice = await web3ProxyClient.eth.getGasPrice();
+```
+
 ## Running the tests
 
 To check that all has been installed correctly and that the pugin has no errors run jest test suites.

--- a/packages/cactus-plugin-ledger-connector-ethereum/package.json
+++ b/packages/cactus-plugin-ledger-connector-ethereum/package.json
@@ -70,6 +70,7 @@
     "@hyperledger/cactus-core-api": "2.0.0-alpha.2",
     "axios": "0.21.4",
     "express": "4.17.3",
+    "http-proxy-middleware": "2.0.6",
     "minimist": "1.2.8",
     "prom-client": "13.2.0",
     "run-time-error": "1.4.0",

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/json/openapi.json
@@ -1159,6 +1159,9 @@
           }
         }
       }
+    },
+    "/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-ethereum/json-rpc": {
+      "summary": "Proxy endpoint to pass JSON-RPC requests to remote ethereum node."
     }
   }
 }

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
@@ -63,7 +63,7 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     address: string,
     port: number,
     contractAddress: string,
-    apiHost,
+    apiHost: string,
     apiConfig,
     ledger: GethTestLedger,
     apiClient: EthereumApi,
@@ -129,6 +129,9 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
       logLevel: testLogLevel,
       pluginRegistry: new PluginRegistry({ plugins: [keychainPlugin] }),
     });
+
+    await connector.getOrCreateWebServices();
+    await connector.registerWebServices(expressApp, wsApi);
   });
 
   afterAll(async () => {
@@ -143,9 +146,6 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
   test("setup ethereum connector", async () => {
     // Instantiate connector with the keychain plugin that already has the
     // private key we want to use for one of our tests
-    await connector.getOrCreateWebServices();
-    await connector.registerWebServices(expressApp, wsApi);
-
     const initTransferValue = web3.utils.toWei(5000, "ether");
     await apiClient.runTransactionV1({
       web3SigningCredential: {
@@ -360,6 +360,7 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
         maxPriorityFeePerGas: 0,
         maxFeePerGas: 0x40000000,
         gasLimit: 21000,
+        type: 2,
       },
       testEthAccount.privateKey,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6488,6 +6488,7 @@ __metadata:
     axios: 0.21.4
     chalk: 4.1.2
     express: 4.17.3
+    http-proxy-middleware: 2.0.6
     js-yaml: 4.1.0
     minimist: 1.2.8
     prom-client: 13.2.0
@@ -24695,7 +24696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^2.0.3":
+"http-proxy-middleware@npm:2.0.6, http-proxy-middleware@npm:^2.0.3":
   version: 2.0.6
   resolution: "http-proxy-middleware@npm:2.0.6"
   dependencies:


### PR DESCRIPTION
- Add proxy endpoint handling. Requests sent to this endpoint will be passed directly to the ethereum node.
- Add test to verify that proxy is working.
- Update README of ethereum connector.

**Pull Request Requirements**
[ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
[ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
[ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information.

**Character Limit**
[ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
[ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.