### PR TITLE
feat(cactus-plugin-ledger-connector-cdl-socketio): support subscription key auth

### DIFF
--- a/packages/cactus-plugin-ledger-connector-cdl-socketio/README.md
+++ b/packages/cactus-plugin-ledger-connector-cdl-socketio/README.md
@@ -36,7 +36,7 @@ This plugin provides `Cacti` a way to interact with Fujitsu CDL networks. Using 
 
 #### Configuring CDL API Gateway Access
 
-- Set the base URL of GW service in `cdlApiGateway.url`. Do not include `api/v1`, just the base URL. (example: `"http://localhost:3000"`).
+- Set the base URL of GW service in `cdlApiGateway.url` (example: `"http://localhost:3000"`).
 - If the service certificate is signed with a known CA (node uses Mozilla DB), then you can skip the next steps.
 - If the service is signed with unknown CA, you can specify the gateway certificate to trust manually:
   - Set `cdlApiGateway.caPath` to path of API Gateway certificate (in PEM format). (example: `"/etc/cactus/connector-cdl-socketio/CA/cdl-api-gateway-ca.pem"`)
@@ -67,14 +67,16 @@ npm run start
 
 ## Manual Tests
 
-- There are no automatic tests for this plugin.
-- `cdl-connector-manual.test` contains a Jest test script that will check every implemented operation on a running CDL instance.
+- There are no automatic tests for this plugin because there's no private instance of CDL available at a time.
+- `cdl-connector-manual.test` contains a Jest test script that will check every implemented operation on a running CDL service.
 - **You need access to a running instance of CDL in order to run this script.**
 - Before running the script you must update the following variables in it:
-  - `ACCESS_TOKEN` - JWT token for authorization in CDL gateway.
-  - `TOKEN_AGENT_ID` - Token agent ID.
+  - `authInfo` - either `accessToken` or `subscriptionKey` based configuration.
   - `VALIDATOR_KEY_PATH` - Path to validator public certificate.
 - Script can be used as a quick reference for using this connector plugin.
+- Since script is not part of project jest suite, to run in execute the following commands from a package dir:
+  - `npm run build`
+  - `npx jest dist/lib/test/typescript/integration/cdl-connector-manual.test.js`
 
 ## Contributing
 

--- a/packages/cactus-plugin-ledger-connector-cdl-socketio/src/main/typescript/connector/type-defs.ts
+++ b/packages/cactus-plugin-ledger-connector-cdl-socketio/src/main/typescript/connector/type-defs.ts
@@ -1,0 +1,59 @@
+import { type } from "os";
+
+export type SupportedFunctions =
+  | "registerHistoryData"
+  | "getLineage"
+  | "searchByHeader"
+  | "searchByGlobalData"
+  | "status";
+
+export type AuthInfoAccessTokenArgsType = {
+  accessToken: string;
+  trustAgentId: string;
+};
+
+export type AuthInfoSubscriptionKeyArgsType = {
+  subscriptionKey: string;
+  trustAgentId: string;
+  trustAgentRole: string;
+  trustUserId: string;
+  trustUserRole: string;
+};
+
+export type AuthInfoArgsType =
+  | AuthInfoAccessTokenArgsType
+  | AuthInfoSubscriptionKeyArgsType;
+
+export function isAuthInfoAccessTokenArgsType(
+  authInfo: AuthInfoArgsType,
+): authInfo is AuthInfoAccessTokenArgsType {
+  const typedAuthInfo = authInfo as AuthInfoAccessTokenArgsType;
+  return (
+    typedAuthInfo &&
+    typeof typedAuthInfo.accessToken !== "undefined" &&
+    typeof typedAuthInfo.trustAgentId !== "undefined"
+  );
+}
+
+export function isAuthInfoSubscriptionKeyArgsType(
+  authInfo: AuthInfoArgsType,
+): authInfo is AuthInfoSubscriptionKeyArgsType {
+  const typedAuthInfo = authInfo as AuthInfoSubscriptionKeyArgsType;
+  return (
+    typedAuthInfo &&
+    typeof typedAuthInfo.subscriptionKey !== "undefined" &&
+    typeof typedAuthInfo.trustAgentId !== "undefined" &&
+    typeof typedAuthInfo.trustAgentRole !== "undefined" &&
+    typeof typedAuthInfo.trustUserId !== "undefined" &&
+    typeof typedAuthInfo.trustUserRole !== "undefined"
+  );
+}
+
+export type FunctionArgsType = {
+  method: {
+    type: SupportedFunctions;
+    authInfo: AuthInfoArgsType;
+  };
+  args: any;
+  reqID?: string;
+};

--- a/packages/cactus-plugin-ledger-connector-cdl-socketio/src/test/typescript/integration/cdl-connector-manual.test.ts
+++ b/packages/cactus-plugin-ledger-connector-cdl-socketio/src/test/typescript/integration/cdl-connector-manual.test.ts
@@ -1,6 +1,6 @@
 /**
  * Manual tests for CDL connector.
- * Must be exectued on Azure environment with access to CDL service.
+ * Must be exectued with access to CDL service.
  * Check out CDL connector readme for instructions on how to run these tests.
  */
 
@@ -8,9 +8,22 @@
 // Constants
 //////////////////////////////////
 
-const ACCESS_TOKEN = "_____FILL_TOKEN_HERE_____"
-const TOKEN_AGENT_ID = "_____FILL_AGENT_ID_HERE_____"
-const VALIDATOR_KEY_PATH = "_____FILL_KEY_PATH_HERE_____"
+// Setup: Start validator first and store it's crt under this path
+const VALIDATOR_KEY_PATH =
+  "/etc/cactus/connector-cdl-socketio/CA/connector.crt";
+
+// Setup: Obtain eitehr accessToken or subscription key and fill matching authInfo structure below.
+// const authInfo = {
+//   accessToken: "_____accessToken_____"
+//   trustAgentId: "_____trustAgentId_____",
+// };
+const authInfo = {
+  subscriptionKey: "_____subscriptionKey_____",
+  trustAgentId: "_____trustAgentId_____",
+  trustAgentRole: "_____trustAgentRole_____",
+  trustUserId: "_____trustUserId_____",
+  trustUserRole: "_____trustUserRole_____",
+};
 
 const testLogLevel: LogLevelDesc = "info";
 const sutLogLevel: LogLevelDesc = "info";
@@ -51,8 +64,7 @@ describe("CDL Connector manual tests", () => {
       {},
       {
         type: "registerHistoryData",
-        accessToken: ACCESS_TOKEN,
-        trustAgentId: TOKEN_AGENT_ID,
+        authInfo,
       },
       args,
     );
@@ -76,8 +88,7 @@ describe("CDL Connector manual tests", () => {
       {},
       {
         type: "getLineage",
-        accessToken: ACCESS_TOKEN,
-        trustAgentId: TOKEN_AGENT_ID,
+        authInfo,
       },
       args,
     );
@@ -97,8 +108,7 @@ describe("CDL Connector manual tests", () => {
       {},
       {
         type: "searchByHeader",
-        accessToken: ACCESS_TOKEN,
-        trustAgentId: TOKEN_AGENT_ID,
+        authInfo,
       },
       args,
     );
@@ -117,8 +127,7 @@ describe("CDL Connector manual tests", () => {
       {},
       {
         type: "searchByGlobalData",
-        accessToken: ACCESS_TOKEN,
-        trustAgentId: TOKEN_AGENT_ID,
+        authInfo,
       },
       args,
     );
@@ -211,6 +220,60 @@ describe("CDL Connector manual tests", () => {
     expect(response.status).toEqual(200);
     expect(response.data.status).toEqual("OK.");
   });
+
+  test(
+    "Request fails when authInfo is missing",
+    async () => {
+      const response = await apiClient.sendSyncRequest(
+        {},
+        {
+          type: "registerHistoryData",
+        },
+        {
+          eventId: "",
+          lineageId: "",
+          tags: {},
+          properties: {
+            prop1: "shouldFail",
+            prop2: "shouldFail",
+          },
+        },
+      );
+      expect(response.status).toEqual(504);
+    },
+    syncReqTimeout * 2,
+  );
+
+  test(
+    "Request fails when mixed authInfo is used",
+    async () => {
+      const response = await apiClient.sendSyncRequest(
+        {},
+        {
+          type: "registerHistoryData",
+          authInfo: {
+            accessToken: "foo-accessToken",
+            subscriptionKey: "foo-subscriptionKey",
+            trustAgentId: "foo-trustAgentId",
+            trustAgentRole: "foo-trustAgentRole",
+            trustUserId: "foo-trustUserId",
+            trustUserRole: "foo-trustUserRole",
+          },
+        },
+        {
+          eventId: "",
+          lineageId: "",
+          tags: {},
+          properties: {
+            prop1: "shouldFail",
+            prop2: "shouldFail",
+          },
+        },
+      );
+      expect(response.status).toEqual(504);
+    },
+    syncReqTimeout * 2,
+  );
 
   test("Register single history data", async () => {
     const newEvent = await registerHistoryDataOnCDL({

--- a/packages/cactus-plugin-ledger-connector-cdl-socketio/tsconfig.json
+++ b/packages/cactus-plugin-ledger-connector-cdl-socketio/tsconfig.json
@@ -15,7 +15,8 @@
     "./src/main/typescript/common/core/bin/*.ts",
     "./src/main/typescript/common/core/config/*.ts",
     "./src/main/typescript/connector/*.ts",
-    "./src/main/typescript/*.ts"
+    "./src/main/typescript/*.ts",
+    "./src/test/typescript/integration/*.ts"
   ],
   "references": [
     {


### PR DESCRIPTION
- Add alternative auth method using subscriptionKey instead of accessToken.
- Both auth methods are supported but can't be used at the same time.
- Adjust manual test script to work with subscriptionKey.
- Build manual script as part of the main build.
- Update README.
- Remove default `api/v1/` URL prefix for compatibility with https://en-portal.research.global.fujitsu.com/

**Pull Request Requirements**
[ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
[ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
[ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information.

**Character Limit**
[ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
[ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.