### PR TITLE
feat(cactus-plugin-ledger-connector-cdl-socketio): separate endpoint for subscription key

### DIFF
--- a/packages/cactus-plugin-ledger-connector-cdl-socketio/README.md
+++ b/packages/cactus-plugin-ledger-connector-cdl-socketio/README.md
@@ -36,12 +36,13 @@ This plugin provides `Cacti` a way to interact with Fujitsu CDL networks. Using 
 
 #### Configuring CDL API Gateway Access
 
-- Set the base URL of GW service in `cdlApiGateway.url` (example: `"http://localhost:3000"`).
+- Set the base URL of GW service in `cdlApiGateway.url` (when using JWT access token - DEFAULT) and/or `cdlApiSubscriptionGateway.url` (when using subscription-key)
+  - Example: `"http://localhost:3000"`
 - If the service certificate is signed with a known CA (node uses Mozilla DB), then you can skip the next steps.
 - If the service is signed with unknown CA, you can specify the gateway certificate to trust manually:
-  - Set `cdlApiGateway.caPath` to path of API Gateway certificate (in PEM format). (example: `"/etc/cactus/connector-cdl-socketio/CA/cdl-api-gateway-ca.pem"`)
-  - (optional) If server name in cert doesn't match the one in `cdlApiGateway.url`, you can overwrite it in `cdlApiGateway.serverName`
-- (not recommended - only for development): To ignore certificate rejection (e.g. use self-signed certificate) set `cdlApiGateway.skipCertCheck` to `true`.
+  - Set `cdlApiGateway.caPath`/`cdlApiSubscriptionGateway.caPath` to path of API Gateway certificate (in PEM format). (example: `"/etc/cactus/connector-cdl-socketio/CA/cdl-api-gateway-ca.pem"`)
+  - (optional) If server name in cert doesn't match the one in `url`, you can overwrite it in `cdlApiGateway.serverName`/`cdlApiSubscriptionGateway.serverName`
+- (not recommended - only for development): To ignore certificate rejection (e.g. use self-signed certificate) set `cdlApiGateway.skipCertCheck`/`cdlApiSubscriptionGateway.skipCertCheck` to `true`.
 
 ### Docker
 

--- a/packages/cactus-plugin-ledger-connector-cdl-socketio/sample-config/default.yaml
+++ b/packages/cactus-plugin-ledger-connector-cdl-socketio/sample-config/default.yaml
@@ -9,3 +9,8 @@ cdlApiGateway:
     #skipCertCheck: true # Set to true to ignore self-signed and other rejected certificates
     #caPath: "/etc/cactus/connector-cdl-socketio/CA/cdl-api-gateway-ca.pem" # CA of CDL API gateway server in PEM format to use
     #serverName: "cdl.fujitsu" # Overwrite server name from cdlApiGateway.url to match one specified in CA
+cdlApiSubscriptionGateway:
+    url: "http://localhost:3000"
+    #skipCertCheck: true # Set to true to ignore self-signed and other rejected certificates
+    #caPath: "/etc/cactus/connector-cdl-socketio/CA/cdl-api-gateway-ca.pem" # CA of CDL API gateway server in PEM format to use
+    #serverName: "cdl.fujitsu" # Overwrite server name from cdlApiGateway.url to match one specified in CA

--- a/packages/cactus-plugin-ledger-connector-cdl-socketio/src/main/typescript/connector/type-defs.ts
+++ b/packages/cactus-plugin-ledger-connector-cdl-socketio/src/main/typescript/connector/type-defs.ts
@@ -1,5 +1,3 @@
-import { type } from "os";
-
 export type SupportedFunctions =
   | "registerHistoryData"
   | "getLineage"
@@ -57,3 +55,9 @@ export type FunctionArgsType = {
   args: any;
   reqID?: string;
 };
+
+export const HTTP_HEADER_SUBSCRIPTION_KEY = "Ocp-Apim-Subscription-Key";
+export const HTTP_HEADER_TRUST_USER_ID = "Trust-User-Id";
+export const HTTP_HEADER_TRUST_USER_ROLE = "Trust-User-Role";
+export const HTTP_HEADER_TRUST_AGENT_ID = "Trust-Agent-Id";
+export const HTTP_HEADER_TRUST_AGENT_ROLE = "Trust-Agent-Role";


### PR DESCRIPTION
- Add separate configurations for endpoints supporting access token and subscription key separately.
- This is required by current public instance of CDL.

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information.

**Character Limit**
- [X] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [X] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.