### PR TITLE
docs(examples/cbdc): fix mismatch of Fabric identities in GET and POST requests

### DIFF
--- a/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/cbdc-erc-20/javascript/lib/tokenERC20.js
+++ b/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/cbdc-erc-20/javascript/lib/tokenERC20.js
@@ -373,7 +373,7 @@ class TokenERC20Contract extends Contract {
    * @param {Integer} amount amount of tokens to be minted
    * @returns {Object} The balance
    */
-  async Mint(ctx, amount) {
+  async Mint(ctx, amount, minter) {
     //check contract options are already set first to execute the function
     await this.CheckInitialized(ctx);
 
@@ -383,9 +383,6 @@ class TokenERC20Contract extends Contract {
     if (clientMSPID !== "Org1MSP") {
       throw new Error("client is not authorized to mint new tokens");
     }
-
-    // Get ID of submitting client identity
-    const minter = ctx.clientIdentity.getID();
 
     const amountInt = parseInt(amount);
     if (amountInt <= 0) {

--- a/examples/cactus-example-cbdc-bridging-frontend/src/api-calls/fabric-api.js
+++ b/examples/cactus-example-cbdc-bridging-frontend/src/api-calls/fabric-api.js
@@ -27,12 +27,14 @@ export async function getFabricBalance(frontendUser) {
 }
 
 export async function mintTokensFabric(frontendUser, amount) {
+  const fabricID = getFabricId(frontendUser);
+
   const response = await axios.post(
     "http://localhost:4000/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/run-transaction",
     {
       contractName: FABRIC_CONTRACT_CBDC_ERC20_NAME,
       channelName: FABRIC_CHANNEL_NAME,
-      params: [amount.toString()],
+      params: [amount.toString(), fabricID],
       methodName: "Mint",
       invocationType: "FabricContractInvocationType.SEND",
       signingCredential: {


### PR DESCRIPTION
docs(examples/cbdc): fix mismatch of Fabric identities in GET, POST requests

The state keys were not being generated correctly for some reason
It was working before without code changes so my best guess is that
the Fabric ledger/SDK versions were changed and that's what tripped it
up somehow.

Fixes #2739

[skip ci]

Co-authored-by: Peter Somogyvari <peter.somogyvari@accenture.com>

Signed-off-by: André Augusto <andre.augusto@tecnico.ulisboa.pt>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

cc: @petermetz @Anusha-Padmanabhan