### PR TITLE
fix(connector-besu): toBuffer only supports 0x-prefixed hex

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/private-deploy-contract-from-json-web3-eea.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/private-deploy-contract-from-json-web3-eea.test.ts
@@ -109,7 +109,7 @@ test(testCase, async (t: Test) => {
         keys.tessera.member2.publicKey,
       ],
       privateKey: keys.besu.member1.privateKey,
-      gasLimit: "3000000",
+      gasLimit: "0x2DC6C0",
     });
 
   t.ok(commitmentHash, "commitmentHash truthy OK");


### PR DESCRIPTION
Commit to be reviewed
---------------

fix(connector-besu): toBuffer only supports 0x-prefixed hex

```
Primary Changes
---------------
1. Updated private-deploy-contract-from-json-web3-eea.test.ts gaslimit from
3000000 to its hex equivalent
```

fixes: #2791

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.