### PR TITLE
fix(cmd-api-server): healthcheck broken due to missing wget binary

### DIFF
--- a/packages/cactus-cmd-api-server/Dockerfile
+++ b/packages/cactus-cmd-api-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
 
@@ -11,7 +11,7 @@ EXPOSE 3000 4000 5000
 RUN groupadd --gid 1000 appuser \
   && useradd --uid 1000 --gid appuser --shell /bin/bash --create-home ${APP_USER}
 
-RUN apt update && apt install -y curl
+RUN apt update && apt install -y curl wget
 
 RUN mkdir -p "${APP}log/"
 RUN chown -R $APP_USER:$APP_USER "${APP}log/"
@@ -22,7 +22,6 @@ COPY --chown=${APP_USER}:${APP_USER} ./packages/cactus-cmd-api-server/healthchec
 RUN chown -R $APP_USER:$APP_USER ${APP}
 
 USER $APP_USER
-ARG NPM_PKG_VERSION=latest
 
 ENV TZ=Etc/UTC
 ENV NODE_ENV=production
@@ -47,21 +46,21 @@ ENV API_PORT=4000
 ENV LOG_LEVEL=INFO
 
 ENV NVM_DIR /home/${APP_USER}/.nvm
-ENV NODE_VERSION 16.15.1
+ENV NODE_VERSION 20.9.0
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # Install nvm with node and npm
 RUN mkdir -p ${NVM_DIR}
-RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash \
+RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
   && source $NVM_DIR/nvm.sh \
   && nvm install $NODE_VERSION \
   && nvm alias default $NODE_VERSION \
   && nvm use default \
-  && npm install -g npm@8.11.0
+  && npm install -g npm@10.2.4
 
-RUN npm install -g yarn@1.22.17
-RUN yarn add @hyperledger/cactus-cmd-api-server@${NPM_PKG_VERSION} --production
+ARG NPM_PKG_VERSION=latest
+RUN npm install @hyperledger/cactus-cmd-api-server@${NPM_PKG_VERSION}
 
 COPY ./packages/cactus-cmd-api-server/docker-entrypoint.sh /usr/local/bin/
 HEALTHCHECK --interval=5s --timeout=5s --start-period=1s --retries=30 CMD /healthcheck.sh

--- a/packages/cactus-cmd-api-server/README.md
+++ b/packages/cactus-cmd-api-server/README.md
@@ -258,8 +258,8 @@ Once you've built the container, the following commands should work:
     --env AUTHORIZATION_CONFIG_JSON='{}' \
     --env GRPC_TLS_ENABLED=false \
     cas \
-      ./node_modules/.bin/cactusapi \
-      --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": { "connectionProfile": {}, "instanceId": "some-unique-instance-id"}}]'
+      node_modules/@hyperledger/cactus-cmd-api-server/dist/lib/main/typescript/cmd/cactus-api.js \
+      --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-fabric", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": { "version": "dev", "peerBinary":"/fabric-samples/bin/peer", "connectionProfile": {}, "instanceId": "some-unique-instance-id"}}]'
   ```
 
 - Launch container with plugin configuration as an **environment variable**:
@@ -271,7 +271,7 @@ Once you've built the container, the following commands should work:
     --env AUTHORIZATION_PROTOCOL='NONE' \
     --env AUTHORIZATION_CONFIG_JSON='{}' \
     --env GRPC_TLS_ENABLED=false \
-    --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
+    --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": { "rpcApiWsHost": "http://127.0.0.1:8546", "rpcApiHttpHost": "http://127.0.0.1:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
     cas
   ```
 
@@ -285,14 +285,14 @@ Once you've built the container, the following commands should work:
     --env AUTHORIZATION_CONFIG_JSON='{}' \
     --env GRPC_TLS_ENABLED=false \
     cas \
-      ./node_modules/.bin/cactusapi \
-      --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]'
+      ./node_modules/@hyperledger/cactus-cmd-api-server/dist/lib/main/typescript/cmd/cactus-api.js \
+      --plugins='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": { "rpcApiWsHost": "http://127.0.0.1:8546", "rpcApiHttpHost": "http://127.0.0.1:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]'
   ```
 
 - Launch container with **configuration file** mounted from host machine:
   ```sh
 
-  echo '[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' > cactus.json
+  echo '{"plugins": [{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": { "rpcApiWsHost": "http://127.0.0.1:8546", "rpcApiHttpHost": "http://127.0.0.1:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]}' > cactus.json
 
   docker run \
     --rm \
@@ -303,7 +303,7 @@ Once you've built the container, the following commands should work:
     --env GRPC_TLS_ENABLED=false \
     --mount type=bind,source="$(pwd)"/cactus.json,target=/cactus.json \
     cas \
-      ./node_modules/.bin/cactusapi \
+      ./node_modules/@hyperledger/cactus-cmd-api-server/dist/lib/main/typescript/cmd/cactus-api.js \
       --config-file=/cactus.json
   ```
 
@@ -313,7 +313,10 @@ Don't have a Besu network on hand to test with? Test or develop against our Besu
 
 1. Terminal Window 1 (Ledger)
     ```sh
-    docker run --publish 8545:8545 hyperledger/cactus-besu-all-in-one:latest
+    docker run \
+      --publish 8545:8545 \
+      --publish 8546:8546 \
+      ghcr.io/hyperledger/cactus-besu-all-in-one:2023-11-16-89d9b93
     ```
 
 2. Terminal Window 2 (Cactus API Server)
@@ -326,7 +329,7 @@ Don't have a Besu network on hand to test with? Test or develop against our Besu
       --env AUTHORIZATION_PROTOCOL='NONE' \
       --env AUTHORIZATION_CONFIG_JSON='{}' \
       --env GRPC_TLS_ENABLED=false \
-      --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": {"rpcApiHttpHost": "http://localhost:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
+      --env PLUGINS='[{"packageName": "@hyperledger/cactus-plugin-ledger-connector-besu", "type": "org.hyperledger.cactus.plugin_import_type.LOCAL", "action": "org.hyperledger.cactus.plugin_import_action.INSTALL",  "options": { "rpcApiWsHost": "http://127.0.0.1:8546", "rpcApiHttpHost": "http://127.0.0.1:8545", "instanceId": "some-unique-besu-connector-instance-id"}}]' \
       cas
     ```
 


### PR DESCRIPTION
1. wget now gets installed explicitly
2. upgraded to ubuntu 22.04 LTS for the base image
3. upgraded nodejs to v20 LTS and npm to v10
3. Published the container image corresponding to this commit tagged as
`ghcr.io/hyperledger/cactus-cmd-api-server:2023-11-16-issue2894`

[skip ci]

Fixes #2894

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.