### PR TITLE
fix(cmd-api-server): address CVE-2022-25881

### DIFF
--- a/packages/cactus-cmd-api-server/Dockerfile
+++ b/packages/cactus-cmd-api-server/Dockerfile
@@ -46,21 +46,21 @@ ENV API_PORT=4000
 ENV LOG_LEVEL=INFO
 
 ENV NVM_DIR /home/${APP_USER}/.nvm
-ENV NODE_VERSION 20.9.0
+ENV NODE_VERSION 20.11.1
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
+ 
 # Install nvm with node and npm
 RUN mkdir -p ${NVM_DIR}
-RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
-  && source $NVM_DIR/nvm.sh \
-  && nvm install $NODE_VERSION \
-  && nvm alias default $NODE_VERSION \
-  && nvm use default \
-  && npm install -g npm@10.2.4
-
-ARG NPM_PKG_VERSION=latest
-RUN npm install @hyperledger/cactus-cmd-api-server@${NPM_PKG_VERSION}
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
+    && source $NVM_DIR/nvm.sh \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default \
+    nvm install ${NODE_VERSION} && \
+    npm install --location=global yarn && \
+    yarn config set nodeLinker node-modules && \
+    yarn set version 4.1.0 && \
+    yarn add @hyperledger/cactus-cmd-api-server@2.0.0-alpha.2
 
 COPY ./packages/cactus-cmd-api-server/docker-entrypoint.sh /usr/local/bin/
 HEALTHCHECK --interval=5s --timeout=5s --start-period=1s --retries=30 CMD /healthcheck.sh


### PR DESCRIPTION
### Commit to be reviewed

[fix(cmd-api-server): address](https://github.com/hyperledger/cacti/pull/2899/commits/23d0bc53ffbe7caa216362604196d9b4b08d871a) https://github.com/advisories/GHSA-rc47-6667-2j5j 

Primary Changes:
	Updated the Dockerfile & https-cache-semantics inside the cmd-api-server package

Fixes: https://github.com/hyperledger/cacti/issues/2862

Signed-off-by: zondervancalvez <zondervan.v.calvez@accenture.com>
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.
