### PR TITLE
build(yarn): update the lock file because it got out of sync 2023-nov-22

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7812,7 +7812,7 @@ __metadata:
     "@hyperledger/cactus-test-tooling": 2.0.0-alpha.2
     "@types/express": 4.17.20
     "@types/uuid": 9.0.6
-    axios: 1.5.1
+    axios: 1.6.0
     body-parser: 1.20.2
     cbor: 9.0.1
     express: 4.18.2


### PR DESCRIPTION
Run of the mill lock file out of sync issue that happens every now and
then by mistake when we forget to run yarn install before committing our
changes for a PR.

Could've been avoided if we had the `build-dev` CI action set to
required but for now it gives us a better chance of reaching 2.0.0
if it's disabled temporarily.

[skip ci]

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.