### PR TITLE
test(cactus-test-verifier-client): replace socketio connector with eth openapi

### DIFF
--- a/packages/cactus-cmd-socketio-server/src/test/typescript/unit/cmd-socketio-blp-plugin.test.ts
+++ b/packages/cactus-cmd-socketio-server/src/test/typescript/unit/cmd-socketio-blp-plugin.test.ts
@@ -26,7 +26,7 @@ const mockAppConfig = {
     },
   ],
   logLevel: sutLogLevel,
-  applicationHostInfo: { hostName: "0.0.0.0", hostPort: 0 },
+  applicationHostInfo: { hostName: "127.0.0.1", hostPort: 0 },
   socketOptions: {
     rejectUnauthorized: false,
     reconnection: false,

--- a/packages/cactus-plugin-keychain-azure-kv/src/test/typescript/integration/plugin-keychain-azure-kv.test.ts
+++ b/packages/cactus-plugin-keychain-azure-kv/src/test/typescript/integration/plugin-keychain-azure-kv.test.ts
@@ -41,7 +41,7 @@ test("get,set,has,delete alters state as expected for AzureCredentialType.InMemo
   expressApp.use(bodyParser.json({ limit: "250mb" }));
   const server = http.createServer(expressApp);
   const listenOptions: IListenOptions = {
-    hostname: "0.0.0.0",
+    hostname: "127.0.0.1",
     port: 0,
     server,
   };

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/benchmark/setup/geth-benchmark-env.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/benchmark/setup/geth-benchmark-env.ts
@@ -113,7 +113,7 @@ export async function setupBenchmarkEnvironment(
     path: Constants.SocketIoConnectionPathV1,
   });
   const addressInfo = (await Servers.listen({
-    hostname: "0.0.0.0",
+    hostname: "127.0.0.1",
     port: 0,
     server: httpServer,
   })) as AddressInfo;

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-json-object-v1.test.ts
@@ -90,7 +90,7 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     await ledger.start();
 
     const listenOptions: IListenOptions = {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
       port: 0,
       server,
     };

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-contract-deploy-and-invoke-using-keychain-v1.test.ts
@@ -93,7 +93,7 @@ describe("Ethereum contract deploy and invoke using keychain tests", () => {
     await ledger.start();
 
     const listenOptions: IListenOptions = {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
       port: 0,
       server,
     };

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-method-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-invoke-web3-method-v1.test.ts
@@ -85,7 +85,7 @@ describe("invokeRawWeb3EthMethod Tests", () => {
     });
 
     const listenOptions: IListenOptions = {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
       port: 0,
       server,
     };

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-transact-and-gas-fees.test.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/integration/geth-transact-and-gas-fees.test.ts
@@ -74,7 +74,7 @@ describe("Running ethereum transactions with different gas configurations", () =
     await ledger.start();
 
     const listenOptions: IListenOptions = {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
       port: 0,
       server,
     };

--- a/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
+++ b/packages/cactus-plugin-ledger-connector-quorum/src/test/typescript/integration/plugin-ledger-connector-quorum/deploy-contract/v2.3.0-deploy-contract-from-json.test.ts
@@ -107,7 +107,7 @@ describe(testCase, () => {
     await ledger.start();
 
     const listenOptions: IListenOptions = {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
       port: 0,
       server,
     };

--- a/packages/cactus-plugin-ledger-connector-sawtooth/src/test/typescript/integration/sawtooth-monitoring-endpoints.test.ts
+++ b/packages/cactus-plugin-ledger-connector-sawtooth/src/test/typescript/integration/sawtooth-monitoring-endpoints.test.ts
@@ -171,7 +171,7 @@ describe("Sawtooth monitoring endpoints tests", () => {
 
     log.info("Setup ApiServer...");
     const listenOptions: IListenOptions = {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
       port: 0,
       server,
     };

--- a/packages/cactus-plugin-persistence-ethereum/src/test/typescript/integration/persistence-ethereum-functional.test.ts
+++ b/packages/cactus-plugin-persistence-ethereum/src/test/typescript/integration/persistence-ethereum-functional.test.ts
@@ -282,7 +282,7 @@ describe("Ethereum persistence plugin tests", () => {
     defaultAccountAddress = account.address;
 
     const addressInfo = (await Servers.listen({
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
       port: 0,
       server: connectorServer,
     })) as AddressInfo;

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/withdraw-endpoint-invalid-id.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/withdraw-endpoint-invalid-id.test.ts
@@ -97,7 +97,7 @@ describe(testCase, () => {
     await besuTestLedger.start();
 
     const listenOptions: IListenOptions = {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
       port: 0,
       server,
     };

--- a/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/withdraw-endpoint.test.ts
+++ b/packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/withdraw-endpoint.test.ts
@@ -88,7 +88,7 @@ describe(testCase, () => {
     expressApp.use(bodyParser.json({ limit: "250mb" }));
     server = http.createServer(expressApp);
     const listenOptions: IListenOptions = {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
       port: 0,
       server,
     };

--- a/packages/cactus-test-verifier-client/package.json
+++ b/packages/cactus-test-verifier-client/package.json
@@ -42,22 +42,27 @@
     "dist/*"
   ],
   "scripts": {
-    "stress-test": "node --expose-gc --no-opt dist/main/typescript/verifier-with-go-eth-stress-check.js",
-    "stress-test-inspect": "node --expose-gc --inspect-brk --no-opt dist/main/typescript/verifier-with-go-eth-stress-check.js"
+    "stress-test": "node --expose-gc --no-opt dist/lib/main/typescript/verifier-with-go-eth-stress-check.js",
+    "stress-test-inspect": "node --expose-gc --inspect-brk --no-opt dist/lib/main/typescript/verifier-with-go-eth-stress-check.js"
   },
   "dependencies": {
-    "@hyperledger/cactus-api-client": "2.0.0-alpha.2",
-    "@hyperledger/cactus-cmd-api-server": "2.0.0-alpha.2",
     "@hyperledger/cactus-common": "2.0.0-alpha.2",
-    "@hyperledger/cactus-plugin-ledger-connector-go-ethereum-socketio": "2.0.0-alpha.2",
+    "@hyperledger/cactus-core": "2.0.0-alpha.2",
+    "@hyperledger/cactus-core-api": "2.0.0-alpha.2",
+    "@hyperledger/cactus-plugin-ledger-connector-ethereum": "2.0.0-alpha.2",
+    "@hyperledger/cactus-test-geth-ledger": "2.0.0-alpha.2",
     "@hyperledger/cactus-test-tooling": "2.0.0-alpha.2",
     "@hyperledger/cactus-verifier-client": "2.0.0-alpha.2",
+    "body-parser": "1.20.2",
+    "express": "4.18.2",
     "log4js": "6.4.1",
-    "web3": "1.7.3",
-    "web3-core": "1.7.3"
+    "socket.io": "4.5.4"
   },
   "devDependencies": {
-    "@types/node": "14.18.54"
+    "@types/body-parser": "1.19.4",
+    "@types/express": "4.17.19",
+    "@types/node": "14.18.54",
+    "web3-eth-accounts": "4.0.3"
   },
   "engines": {
     "node": ">=10",

--- a/packages/cactus-test-verifier-client/tsconfig.json
+++ b/packages/cactus-test-verifier-client/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "./dist/lib",
-    "declarationDir": "dist/",
+    "declarationDir": "dist/lib",
     "resolveJsonModule": true,
     "rootDir": "./src",
     "tsBuildInfoFile": "../../.build-cache/cactus-test-verifier-client.tsbuildinfo"
@@ -12,23 +12,27 @@
     "./src"
   ],
   "references": [
+
     {
       "path": "../cactus-common/tsconfig.json"
+    },
+    {
+      "path": "../cactus-core/tsconfig.json"
+    },
+    {
+      "path": "../cactus-core-api/tsconfig.json"
+    },
+    {
+      "path": "../cactus-plugin-ledger-connector-ethereum/tsconfig.json"
+    },
+    {
+      "path": "../cactus-test-geth-ledger/tsconfig.json"
     },
     {
       "path": "../cactus-test-tooling/tsconfig.json"
     },
     {
-      "path": "../cactus-cmd-api-server/tsconfig.json"
-    },
-    {
-      "path": "../cactus-api-client/tsconfig.json"
-    },
-    {
       "path": "../cactus-verifier-client/tsconfig.json"
-    },
-    {
-      "path": "../cactus-plugin-ledger-connector-go-ethereum-socketio/tsconfig.json"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7662,7 +7662,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperledger/cactus-plugin-ledger-connector-go-ethereum-socketio@2.0.0-alpha.2, @hyperledger/cactus-plugin-ledger-connector-go-ethereum-socketio@workspace:packages/cactus-plugin-ledger-connector-go-ethereum-socketio":
+"@hyperledger/cactus-plugin-ledger-connector-go-ethereum-socketio@workspace:packages/cactus-plugin-ledger-connector-go-ethereum-socketio":
   version: 0.0.0-use.local
   resolution: "@hyperledger/cactus-plugin-ledger-connector-go-ethereum-socketio@workspace:packages/cactus-plugin-ledger-connector-go-ethereum-socketio"
   dependencies:
@@ -8258,16 +8258,21 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hyperledger/cactus-test-verifier-client@workspace:packages/cactus-test-verifier-client"
   dependencies:
-    "@hyperledger/cactus-api-client": 2.0.0-alpha.2
-    "@hyperledger/cactus-cmd-api-server": 2.0.0-alpha.2
     "@hyperledger/cactus-common": 2.0.0-alpha.2
-    "@hyperledger/cactus-plugin-ledger-connector-go-ethereum-socketio": 2.0.0-alpha.2
+    "@hyperledger/cactus-core": 2.0.0-alpha.2
+    "@hyperledger/cactus-core-api": 2.0.0-alpha.2
+    "@hyperledger/cactus-plugin-ledger-connector-ethereum": 2.0.0-alpha.2
+    "@hyperledger/cactus-test-geth-ledger": 2.0.0-alpha.2
     "@hyperledger/cactus-test-tooling": 2.0.0-alpha.2
     "@hyperledger/cactus-verifier-client": 2.0.0-alpha.2
+    "@types/body-parser": 1.19.4
+    "@types/express": 4.17.19
     "@types/node": 14.18.54
+    body-parser: 1.20.2
+    express: 4.18.2
     log4js: 6.4.1
-    web3: 1.7.3
-    web3-core: 1.7.3
+    socket.io: 4.5.4
+    web3-eth-accounts: 4.0.3
   languageName: unknown
   linkType: soft
 
@@ -47865,17 +47870,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-bzz@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-bzz@npm:1.7.3"
-  dependencies:
-    "@types/node": ^12.12.6
-    got: 9.6.0
-    swarm-js: ^0.1.40
-  checksum: cd4dddd51b445bd40d3e2fd57eba268d3cbc9d359e5b8ebd16735183135387f509923ff12ec5f0645a0faeaeed4ea7d4753385fdd289c74280cc774e89e5a56e
-  languageName: node
-  linkType: hard
-
 "web3-bzz@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-bzz@npm:1.8.1"
@@ -47934,16 +47928,6 @@ __metadata:
     web3-eth-iban: 1.7.0
     web3-utils: 1.7.0
   checksum: ca1a14a3c39a9c7acea94ed6e65c2ee7a233b8928ab0c1a1a5ebe2cf9ab6db768a5896a6b44be1c2c0a2f96ddfc81c9716d89c49b5f944dadc5dcf5d329ddaca
-  languageName: node
-  linkType: hard
-
-"web3-core-helpers@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-core-helpers@npm:1.7.3"
-  dependencies:
-    web3-eth-iban: 1.7.3
-    web3-utils: 1.7.3
-  checksum: 8c02f7fe202f74f925a18cf6f32649df5caa3221cefc493a6a4fb554d43bece1b4dc7a4cb0952c9d8669a4766dfdafb6d6100a5f68d109b89cc7cf314ed59959
   languageName: node
   linkType: hard
 
@@ -48023,19 +48007,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-core-method@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-core-method@npm:1.7.3"
-  dependencies:
-    "@ethersproject/transactions": ^5.0.0-beta.135
-    web3-core-helpers: 1.7.3
-    web3-core-promievent: 1.7.3
-    web3-core-subscriptions: 1.7.3
-    web3-utils: 1.7.3
-  checksum: cd1940676eb9ed6a28d172f9beaaccbb2021e831a19d690f9b50fa913a66be7bd8e85928c2a542c03f15ccdfb5dae63e43bcc8f04cd652b897233ae584a68d57
-  languageName: node
-  linkType: hard
-
 "web3-core-method@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-core-method@npm:1.8.1"
@@ -48091,15 +48062,6 @@ __metadata:
   dependencies:
     eventemitter3: 4.0.4
   checksum: 93774b2b954b7b60cd60ebd3bc299cfef1080c5460ddad7c0ed3ca9262ecce374253202500a63eb27a83323c0d0b7275ca7ceaa76a9c560652d0bc5fb34173ff
-  languageName: node
-  linkType: hard
-
-"web3-core-promievent@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-core-promievent@npm:1.7.3"
-  dependencies:
-    eventemitter3: 4.0.4
-  checksum: a4784709f7c581bc3d74d996c80d764e95f73ebb30a7383f1af16bfc4c67e3c9fc0524962e48241fa180bce13d489b41f87a88f717e1009299ed0562612a0ad7
   languageName: node
   linkType: hard
 
@@ -48177,19 +48139,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-core-requestmanager@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-core-requestmanager@npm:1.7.3"
-  dependencies:
-    util: ^0.12.0
-    web3-core-helpers: 1.7.3
-    web3-providers-http: 1.7.3
-    web3-providers-ipc: 1.7.3
-    web3-providers-ws: 1.7.3
-  checksum: fcee4c1280b621d9e50b339995295ece6a17b1de73b6e9acf490ea08037f3d3b39f0b2a339def4e470f5bbb2dec49634887089128cebb9b98da54e8f54b9a142
-  languageName: node
-  linkType: hard
-
 "web3-core-requestmanager@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-core-requestmanager@npm:1.8.1"
@@ -48250,16 +48199,6 @@ __metadata:
     eventemitter3: 4.0.4
     web3-core-helpers: 1.7.0
   checksum: 1f092c73f3e4255f486c21105243298f4f0dc8dce51fc6e87fa8b18bb75fb2396a2dc99795cae8f3be82ab17c3041c933ad48852211f741ee5e9fe4b59b1647b
-  languageName: node
-  linkType: hard
-
-"web3-core-subscriptions@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-core-subscriptions@npm:1.7.3"
-  dependencies:
-    eventemitter3: 4.0.4
-    web3-core-helpers: 1.7.3
-  checksum: 6b524a9df78ded17313979508564b1246cec8df99849d77d87f6c8316d276f62744ef05663cdb130bae8c9ddab56e3a267091a9051418a035c537bf90bafea28
   languageName: node
   linkType: hard
 
@@ -48345,21 +48284,6 @@ __metadata:
     web3-core-requestmanager: 1.7.0
     web3-utils: 1.7.0
   checksum: 72834bb34f8f71ed709866ed5fd386a37be6c6213eebc75a64605638d9ab026f81d51a19a07e5ad5d1a00d088401073ca2bdc370b1134855948c7cd290caa8c7
-  languageName: node
-  linkType: hard
-
-"web3-core@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-core@npm:1.7.3"
-  dependencies:
-    "@types/bn.js": ^4.11.5
-    "@types/node": ^12.12.6
-    bignumber.js: ^9.0.0
-    web3-core-helpers: 1.7.3
-    web3-core-method: 1.7.3
-    web3-core-requestmanager: 1.7.3
-    web3-utils: 1.7.3
-  checksum: 2959ea9bb018e8346ef14456a46b4ad06e68529882be1d6059876f60c9feeda6d7acf6d4e4f4c8caa1b45a216c904860c4113fd93e499af64d637cd5787a7b60
   languageName: node
   linkType: hard
 
@@ -48539,16 +48463,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-eth-abi@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-eth-abi@npm:1.7.3"
-  dependencies:
-    "@ethersproject/abi": 5.0.7
-    web3-utils: 1.7.3
-  checksum: 878ace128ce24f8deca93e4656950b4e582a2dd2aac8d2d718ddf611429266a4b6e25b0afe5000a19ef3876cc786fa165c9be7752d60f49dd4659462a0bd2e79
-  languageName: node
-  linkType: hard
-
 "web3-eth-abi@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-eth-abi@npm:1.8.1"
@@ -48698,25 +48612,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-eth-accounts@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-eth-accounts@npm:1.7.3"
-  dependencies:
-    "@ethereumjs/common": ^2.5.0
-    "@ethereumjs/tx": ^3.3.2
-    crypto-browserify: 3.12.0
-    eth-lib: 0.2.8
-    ethereumjs-util: ^7.0.10
-    scrypt-js: ^3.0.1
-    uuid: 3.3.2
-    web3-core: 1.7.3
-    web3-core-helpers: 1.7.3
-    web3-core-method: 1.7.3
-    web3-utils: 1.7.3
-  checksum: 141edccc5ac4371f610f1436ecb1340a7cb2739b6298d772c732348631e01ef2060620b3cca7d43daac647a4b6cf84157f8fae6df921896642c6aa376449860b
-  languageName: node
-  linkType: hard
-
 "web3-eth-accounts@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-eth-accounts@npm:1.8.1"
@@ -48860,22 +48755,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-eth-contract@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-eth-contract@npm:1.7.3"
-  dependencies:
-    "@types/bn.js": ^4.11.5
-    web3-core: 1.7.3
-    web3-core-helpers: 1.7.3
-    web3-core-method: 1.7.3
-    web3-core-promievent: 1.7.3
-    web3-core-subscriptions: 1.7.3
-    web3-eth-abi: 1.7.3
-    web3-utils: 1.7.3
-  checksum: e5bdb00cdff0ad5d4282de52cf8046dcfc24df8a5f338075345cc50953d2387a3b9ea6ff505334ee62a09e6d8fe533d048891df2821069f902fa519120c1a7c7
-  languageName: node
-  linkType: hard
-
 "web3-eth-contract@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-eth-contract@npm:1.8.1"
@@ -49016,22 +48895,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-eth-ens@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-eth-ens@npm:1.7.3"
-  dependencies:
-    content-hash: ^2.5.2
-    eth-ens-namehash: 2.0.8
-    web3-core: 1.7.3
-    web3-core-helpers: 1.7.3
-    web3-core-promievent: 1.7.3
-    web3-eth-abi: 1.7.3
-    web3-eth-contract: 1.7.3
-    web3-utils: 1.7.3
-  checksum: b079e72e27831a377078b9c3cccc2d30295667d03d368b10a061f8d36e445557d75dfd986ea5b170baf15964f2a1c42a77d78aebbe5d249f60f5eff3ed0efa10
-  languageName: node
-  linkType: hard
-
 "web3-eth-ens@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-eth-ens@npm:1.8.1"
@@ -49166,16 +49029,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-eth-iban@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-eth-iban@npm:1.7.3"
-  dependencies:
-    bn.js: ^4.11.9
-    web3-utils: 1.7.3
-  checksum: 0e36167c63955f3e0481b99b3e2fa89246785678644cdb42c73ee013220182d06abad91ddc32e5c726fa7a06db17aace48ffc167cb1e3411530e441a6fbaa0cc
-  languageName: node
-  linkType: hard
-
 "web3-eth-iban@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-eth-iban@npm:1.8.1"
@@ -49275,20 +49128,6 @@ __metadata:
     web3-net: 1.7.0
     web3-utils: 1.7.0
   checksum: 013e21652fb42541623e8d1cdca1504770746defc2a4e7b973e34dc71170fdeeb4fde2a3c3394f8c010399897d92fca289acf184d2c56ce17a28eb073bdecdae
-  languageName: node
-  linkType: hard
-
-"web3-eth-personal@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-eth-personal@npm:1.7.3"
-  dependencies:
-    "@types/node": ^12.12.6
-    web3-core: 1.7.3
-    web3-core-helpers: 1.7.3
-    web3-core-method: 1.7.3
-    web3-net: 1.7.3
-    web3-utils: 1.7.3
-  checksum: be938abdc281c14f8d6ef7c7e980def172ea5b28aa4c7b0d18e81452938fcc9d193bfa42006641ad13d60775af12954f98cd91c41f3aa11181386d5f551bbaec
   languageName: node
   linkType: hard
 
@@ -49442,26 +49281,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-eth@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-eth@npm:1.7.3"
-  dependencies:
-    web3-core: 1.7.3
-    web3-core-helpers: 1.7.3
-    web3-core-method: 1.7.3
-    web3-core-subscriptions: 1.7.3
-    web3-eth-abi: 1.7.3
-    web3-eth-accounts: 1.7.3
-    web3-eth-contract: 1.7.3
-    web3-eth-ens: 1.7.3
-    web3-eth-iban: 1.7.3
-    web3-eth-personal: 1.7.3
-    web3-net: 1.7.3
-    web3-utils: 1.7.3
-  checksum: 5d7d1606b484098ff7943f132ef2c805c2fd2596386917e828f7ee8dbac3497cbc0a81df240e13ffb3289b59c9f72191a02e0f2636034b846b094d927821c7b3
-  languageName: node
-  linkType: hard
-
 "web3-eth@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-eth@npm:1.8.1"
@@ -49583,17 +49402,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-net@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-net@npm:1.7.3"
-  dependencies:
-    web3-core: 1.7.3
-    web3-core-method: 1.7.3
-    web3-utils: 1.7.3
-  checksum: 09b31ab30dc59650ee83d8752b753b18862522d372d3101acc620ed188792c46e844e363c55da06f64400e587f37f609381f353a862ef14b379decf48f36173b
-  languageName: node
-  linkType: hard
-
 "web3-net@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-net@npm:1.8.1"
@@ -49695,16 +49503,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-providers-http@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-providers-http@npm:1.7.3"
-  dependencies:
-    web3-core-helpers: 1.7.3
-    xhr2-cookies: 1.1.0
-  checksum: e1539a36aec1b8f49fd79e407086c96274f4d62f33646bc95b65a94ccad8cb15bc40f6040cddc1eb018bfc3199687d6a6b7c18f11bb8423f6e24b1567e1191e2
-  languageName: node
-  linkType: hard
-
 "web3-providers-http@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-providers-http@npm:1.8.1"
@@ -49803,16 +49601,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-providers-ipc@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-providers-ipc@npm:1.7.3"
-  dependencies:
-    oboe: 2.1.5
-    web3-core-helpers: 1.7.3
-  checksum: 28e7dbc73dc6f32302d1a579c48682efa3584150042883e5e8b1774c1beab848ac16d3932c94bfb9af5aac6f1558d920c8672079e67e5aff03be9510506cb184
-  languageName: node
-  linkType: hard
-
 "web3-providers-ipc@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-providers-ipc@npm:1.8.1"
@@ -49908,17 +49696,6 @@ __metadata:
     web3-core-helpers: 1.7.0
     websocket: ^1.0.32
   checksum: d3c2084fd64fad728947e541395b17056e925f636d5ea9a6ebcca9bbb52dc88b32b5a2317a82c1fb54b4b2d6f7b56a5489468fb46394cfd3ca2bbedddc37d4c6
-  languageName: node
-  linkType: hard
-
-"web3-providers-ws@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-providers-ws@npm:1.7.3"
-  dependencies:
-    eventemitter3: 4.0.4
-    web3-core-helpers: 1.7.3
-    websocket: ^1.0.32
-  checksum: 041427c34763579ed89f16de63e811de4cb502a43b4d120fe725cf33e879a7d104fca34093a18f6bb3a0b10596543e5905875377c1fed35f56ce86c5dae3475c
   languageName: node
   linkType: hard
 
@@ -50056,18 +49833,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-shh@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-shh@npm:1.7.3"
-  dependencies:
-    web3-core: 1.7.3
-    web3-core-method: 1.7.3
-    web3-core-subscriptions: 1.7.3
-    web3-net: 1.7.3
-  checksum: c4b66aa9361d7dc2e66f88b106e1eae81587465ab85b3c31b9979c1247fa4e6cd7aa44d0e8c8411e26df51aa75ccd1c24efb11d87b5e8eef1beab241faf925a8
-  languageName: node
-  linkType: hard
-
 "web3-shh@npm:1.8.1":
   version: 1.8.1
   resolution: "web3-shh@npm:1.8.1"
@@ -50188,21 +49953,6 @@ __metadata:
     randombytes: ^2.1.0
     utf8: 3.0.0
   checksum: cd96c8cca5507714bf089eb91d513a3515b6e4a959b9d380ff543b2aa076379a4fb613a64c03a4d4332a8d7e78e5e22bb41ed0092ee634bbd336d12d80a73dc0
-  languageName: node
-  linkType: hard
-
-"web3-utils@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3-utils@npm:1.7.3"
-  dependencies:
-    bn.js: ^4.11.9
-    ethereum-bloom-filters: ^1.0.6
-    ethereumjs-util: ^7.1.0
-    ethjs-unit: 0.1.6
-    number-to-bn: 1.7.0
-    randombytes: ^2.1.0
-    utf8: 3.0.0
-  checksum: 96fd1d7310f4674ddccbd1f2f8e1ff1817b8869a67a1562ef3ce1130ae50dfec8e64fc4ce9f80855d87fa63fb6dd71b4561e5e1925be5b26f3787b0d4e5f89e7
   languageName: node
   linkType: hard
 
@@ -50363,21 +50113,6 @@ __metadata:
     web3-shh: 1.7.0
     web3-utils: 1.7.0
   checksum: 0a9e24ff02a5b914e6528e72a9aefe78944ec026fefc96130a39f51d9e07c00f528e5dff25cfada7917774298cbccd629c611672212db58835f2c0a6dadf173e
-  languageName: node
-  linkType: hard
-
-"web3@npm:1.7.3":
-  version: 1.7.3
-  resolution: "web3@npm:1.7.3"
-  dependencies:
-    web3-bzz: 1.7.3
-    web3-core: 1.7.3
-    web3-eth: 1.7.3
-    web3-eth-personal: 1.7.3
-    web3-net: 1.7.3
-    web3-shh: 1.7.3
-    web3-utils: 1.7.3
-  checksum: a944c296e75bd9c5e95687754524561ca993663d0c57ca2e8da794b9e8de57d319522fa05ec3b06d98382cc9ba59a0b8f17eb092782aa849b4e8cecc7867522a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Replace deprecated cactus-plugin-ledger-connector-go-ethereum-socketio with openapi-based cactus-plugin-ledger-connector-ethereum.

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.