### PR TITLE
docs(examples/cbdc): fix mismatch of fabric identities

### DIFF
--- a/examples/cactus-example-cbdc-bridging-backend/src/crypto-material/crypto-material.json
+++ b/examples/cactus-example-cbdc-bridging-backend/src/crypto-material/crypto-material.json
@@ -1,22 +1,21 @@
-{
-  "info": {
+{ "info": {
     "description": "this file contains data to be used for testing purposes only. It should not be changed. It should remain consistent with the crypto material in the fabric chaincode"
   },
   "accounts": {
     "userA": {
       "ethAddress": "0x1A86D6f4b5D30A07D1a94bb232eF916AFe5DbDbc",
       "privateKey": "0xb47c3ba5a816dbbb2271db721e76e6c80e58fe54972d26a42f00bc97a92a2535",
-      "fabricID": "x509::/OU=client/OU=org1/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
+      "fabricID": "x509::/OU=org1/OU=client/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
     },
     "bridge": {
       "ethAddress": "0xf28d5769171bfbD2B3628d722e58129a6aE15022",
       "privateKey": "0x2917bd3b0dced512d3555f171a0979fedd37bb0593883089396d9b893aa0505d",
-      "fabricID": "x509::/OU=client/OU=org2/OU=department1/CN=bridge::/C=UK/ST=Hampshire/L=Hursley/O=org2.example.com/CN=ca.org2.example.com"
+      "fabricID": "x509::/OU=org2/OU=client/OU=department1/CN=bridge::/C=UK/ST=Hampshire/L=Hursley/O=org2.example.com/CN=ca.org2.example.com"
     },
     "userB": {
       "ethAddress": "0xB264c626D7D09789AbfD2a431A28a054366e7b63",
       "privateKey": "0xfe95d40663e60e9a8a2e1f4153c9e207ac26d928e8a5631647735d91e93be402",
-      "fabricID": "x509::/OU=client/OU=org1/OU=department1/CN=userB::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
+      "fabricID": "x509::/OU=org1/OU=client/OU=department1/CN=userB::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
     }
   },
   "gateways": {

--- a/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/asset-reference/typescript/src/asset-reference-contract.spec.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/asset-reference/typescript/src/asset-reference-contract.spec.ts
@@ -15,10 +15,10 @@ import * as sinonChai from "sinon-chai";
 const bridgedOutAmountKey = "amountBridgedOut";
 
 const USER_A_FABRIC_ID =
-  "x509::/OU=client/OU=org1/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com";
+  "x509::/OU=org1/OU=client/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com";
 
 const USER_A_ETH_ADDRESS =
-  "x509::/OU=client/OU=org1/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com";
+  "x509::/OU=org1/OU=client/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com";
 
 chai.should();
 chai.use(chaiAsPromised);

--- a/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/cbdc-erc-20/javascript/crypto-material/crypto-material.json
+++ b/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/cbdc-erc-20/javascript/crypto-material/crypto-material.json
@@ -6,17 +6,17 @@
     "userA": {
       "ethAddress": "0x1A86D6f4b5D30A07D1a94bb232eF916AFe5DbDbc",
       "privateKey": "0xb47c3ba5a816dbbb2271db721e76e6c80e58fe54972d26a42f00bc97a92a2535",
-      "fabricID": "x509::/OU=client/OU=org1/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
+      "fabricID": "x509::/OU=org1/OU=client/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
     },
     "bridge": {
       "ethAddress": "0xf28d5769171bfbD2B3628d722e58129a6aE15022",
       "privateKey": "0x2917bd3b0dced512d3555f171a0979fedd37bb0593883089396d9b893aa0505d",
-      "fabricID": "x509::/OU=client/OU=org2/OU=department1/CN=bridge::/C=UK/ST=Hampshire/L=Hursley/O=org2.example.com/CN=ca.org2.example.com"
+      "fabricID": "x509::/OU=org2/OU=client/OU=department1/CN=bridge::/C=UK/ST=Hampshire/L=Hursley/O=org2.example.com/CN=ca.org2.example.com"
     },
     "userB": {
       "ethAddress": "0xB264c626D7D09789AbfD2a431A28a054366e7b63",
       "privateKey": "0xfe95d40663e60e9a8a2e1f4153c9e207ac26d928e8a5631647735d91e93be402",
-      "fabricID": "x509::/OU=client/OU=org1/OU=department1/CN=userB::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
+      "fabricID": "x509::/OU=org1/OU=client/OU=department1/CN=userB::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
     }
   }
 }

--- a/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/cbdc-erc-20/javascript/lib/tokenERC20.js
+++ b/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/cbdc-erc-20/javascript/lib/tokenERC20.js
@@ -373,9 +373,11 @@ class TokenERC20Contract extends Contract {
    * @param {Integer} amount amount of tokens to be minted
    * @returns {Object} The balance
    */
-  async Mint(ctx, amount, minter) {
+  async Mint(ctx, amount) {
     //check contract options are already set first to execute the function
     await this.CheckInitialized(ctx);
+
+    const minter = ctx.clientIdentity.getID();
 
     // Check minter authorization - this sample assumes Org1 is the central banker with privilege to mint new tokens
     const clientMSPID = ctx.clientIdentity.getMSPID();

--- a/examples/cactus-example-cbdc-bridging-frontend/src/api-calls/fabric-api.js
+++ b/examples/cactus-example-cbdc-bridging-frontend/src/api-calls/fabric-api.js
@@ -27,14 +27,12 @@ export async function getFabricBalance(frontendUser) {
 }
 
 export async function mintTokensFabric(frontendUser, amount) {
-  const fabricID = getFabricId(frontendUser);
-
   const response = await axios.post(
     "http://localhost:4000/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/run-transaction",
     {
       contractName: FABRIC_CONTRACT_CBDC_ERC20_NAME,
       channelName: FABRIC_CHANNEL_NAME,
-      params: [amount.toString(), fabricID],
+      params: [amount.toString()],
       methodName: "Mint",
       invocationType: "FabricContractInvocationType.SEND",
       signingCredential: {

--- a/examples/cactus-example-cbdc-bridging-frontend/src/crypto-material/crypto-material.json
+++ b/examples/cactus-example-cbdc-bridging-frontend/src/crypto-material/crypto-material.json
@@ -6,17 +6,17 @@
     "userA": {
       "ethAddress": "0x1A86D6f4b5D30A07D1a94bb232eF916AFe5DbDbc",
       "privateKey": "0xb47c3ba5a816dbbb2271db721e76e6c80e58fe54972d26a42f00bc97a92a2535",
-      "fabricID": "x509::/OU=client/OU=org1/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
+      "fabricID": "x509::/OU=org1/OU=client/OU=department1/CN=userA::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
     },
     "bridge": {
       "ethAddress": "0xf28d5769171bfbD2B3628d722e58129a6aE15022",
       "privateKey": "0x2917bd3b0dced512d3555f171a0979fedd37bb0593883089396d9b893aa0505d",
-      "fabricID": "x509::/OU=client/OU=org2/OU=department1/CN=bridge::/C=UK/ST=Hampshire/L=Hursley/O=org2.example.com/CN=ca.org2.example.com"
+      "fabricID": "x509::/OU=org2/OU=client/OU=department1/CN=bridge::/C=UK/ST=Hampshire/L=Hursley/O=org2.example.com/CN=ca.org2.example.com"
     },
     "userB": {
       "ethAddress": "0xB264c626D7D09789AbfD2a431A28a054366e7b63",
       "privateKey": "0xfe95d40663e60e9a8a2e1f4153c9e207ac26d928e8a5631647735d91e93be402",
-      "fabricID": "x509::/OU=client/OU=org1/OU=department1/CN=userB::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
+      "fabricID": "x509::/OU=org1/OU=client/OU=department1/CN=userB::/C=US/ST=North Carolina/L=Durham/O=org1.example.com/CN=ca.org1.example.com"
     }
   },
   "gateways": {


### PR DESCRIPTION
* What I believe has been an update to the Fabric SDK has led the application to break due to having the Fabric identities hardcoded (for the Fabric-Ethereum ID mapping). This was first noted in #2739.
* An initial fix was deployed in #2802 but only the Mint function was changed, which caused other functions to be breaking at the moment (e.g., Escrow)
* This commit changes the crypto material files and reverts the workaround in PR #2802
* The crypto material is only used for testing and to show information in the frontend (e.g., requesting the balance of a specific user based on the identity)
* For critical operations, access control is being performed by the chaincode by using the call at the begining of the relevant methods

Fixes #2914