### PR TITLE
build(devcontainer): upgrade rust compiler to v1.74 (current latest stable)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
 			"version": "18.19.0"
 		},
 		"ghcr.io/devcontainers/features/rust:1": {
-			"version": "1.63",
+			"version": "1.74",
 			"profile": "complete"
 		},
 		"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},


### PR DESCRIPTION
1. This was forced through the domino effect of webpki related security
vulnerabilities that made it important for us to upgrade some dependencies
which on the other hand did not work with the slightly older rust compiler
that the dev container had had.

Relevant links for the vulnerabilities (this is not a fix yet)
- https://github.com/hyperledger/cacti/security/dependabot/762
- https://github.com/advisories/GHSA-8qv2-5vq6-g2g7

Skipping the CI because it's just a development environment change.

[skip ci]

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

---

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.