### PR TITLE
docs(examples): fix supply-chain-frontend run-time-error-cjs angular build

### DIFF
--- a/examples/cactus-example-supply-chain-frontend/package.json
+++ b/examples/cactus-example-supply-chain-frontend/package.json
@@ -67,7 +67,7 @@
     "@ionic-native/status-bar": "5.36.0",
     "@ionic/angular": "7.3.3",
     "net-browserify": "0.2.4",
-    "run-time-error-cjs": "1.4.0",
+    "run-time-error": "1.4.0",
     "rxjs": "7.8.1",
     "tls-browserify": "0.2.2",
     "tslib": "2.6.2",

--- a/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/bamboo-harvest-detail/bamboo-harvest-detail.page.ts
+++ b/examples/cactus-example-supply-chain-frontend/src/app/bamboo-harvest/bamboo-harvest-detail/bamboo-harvest-detail.page.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
-import { RuntimeError } from "run-time-error-cjs";
+import { RuntimeError } from "run-time-error";
 
 import { Component, Inject, Input, OnInit } from "@angular/core";
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7157,7 +7157,7 @@ __metadata:
     net-browserify: 0.2.4
     os-browserify: 0.3.0
     path-browserify: 1.0.1
-    run-time-error-cjs: 1.4.0
+    run-time-error: 1.4.0
     rxjs: 7.8.1
     tls-browserify: 0.2.2
     tslib: 2.6.2
@@ -7872,7 +7872,7 @@ __metadata:
     "@hyperledger/cactus-test-tooling": 2.0.0-alpha.2
     "@types/body-parser": 1.19.4
     "@types/express": 4.17.19
-    axios: 1.5.1
+    axios: 1.6.0
     body-parser: 1.20.2
     express: 4.18.2
     joi: 17.9.1


### PR DESCRIPTION
Webpack does not play nice with the `run-time-error-cjs` package's exports.
I replaced it with the vanilla `run-time-error` because the front-end
package is fine with it (does not have ESM/CJS issues like other packages)

[skip ci]

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

---

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.