### PR TITLE
fix(persistence-fabric): hide not critical API

### DIFF
--- a/packages/cactus-plugin-persistence-fabric/README.md
+++ b/packages/cactus-plugin-persistence-fabric/README.md
@@ -37,22 +37,6 @@ yarn run configure
 
 Instantiate a new `PluginPersistenceFabrickBlock` instance:
 
-There is few ways to use this plugin:
-
-1.  Using Watch block might cause infinite loop
-    and function migrateBlockNrWithTransactions
-2.  Individually using migrateBlockNrWithTransactions
-    if you know which exactly which blocks you want to analyze
-3.  Using plugin function continueBlocksSynchronization in some periodical calls
-4.  Using plugin function continuousBlocksSynchronization in some reasonable time with changeSynchronization - which should break flow
-    this function might continue work for long period
-
-5) Best to start synchronization with initialBlocksSynchronization , which will transfer and parse into database number of blocks equal to edgeOfLedger
-
-6) If there were some issues in network connection or you think that your database might be corrupted and lost some data you might use whichBlocksAreMissingInDdSimple
-   and then showHowManyBlocksMissing if more than 0
-   then use synchronizeOnlyMissedBlocks
-
 ```typescript
 import { PluginPersistenceFabric } from "../../../main/typescript/plugin-fabric-persistence-block";
 import { v4 as uuidv4 } from "uuid";


### PR DESCRIPTION
- Make not critical connector API private. This will allow easier refactors in the future. Most of the fields were used for testing purposes anyway.
- Change naming of some methods to match persistence-ethereum plugin.

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.