### PR TITLE
feat(weaver): add build script and fix minor issues

### DIFF
--- a/tools/weaver-build-local.sh
+++ b/tools/weaver-build-local.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+THIS_SCRIPT_DIR="$(dirname "$0")"
+WEAVER_DIR="$THIS_SCRIPT_DIR/../weaver"
+
+echo -e "\n######################################"
+echo "Remove weaver node_modules..."
+echo -e "######################################\n"
+
+echo "Cacti configure process interferes with weaver packages, clean it for fresh start"
+find "$WEAVER_DIR" -name node_modules -exec rm -rf {} \;
+
+echo -e "\n######################################"
+echo "Environment check"
+echo -e "######################################\n"
+
+set -e # Fail on error from now on
+
+echo "Weaver path: $WEAVER_DIR"
+go version
+rustc --version
+java -version
+protoc --version
+protoc-gen-go --version
+protoc-gen-go-grpc --version
+
+echo -e "\n######################################"
+echo "Build protos..."
+echo -e "######################################\n"
+
+echo "# JS"
+pushd "${WEAVER_DIR}/common/protos-js"; make build; popd
+echo "# Go"
+pushd "${WEAVER_DIR}/common/protos-go"; make build; popd
+echo "# Java"
+pushd "${WEAVER_DIR}/common/protos-java-kt"; make build; popd
+echo "# Solidity"
+pushd "${WEAVER_DIR}/common/protos-sol"; make build; popd
+echo "# Rust"
+pushd "${WEAVER_DIR}/common/protos-rs"; make build; popd
+
+echo -e "\n######################################"
+echo "Build relay..."
+echo -e "######################################\n"
+
+pushd "${WEAVER_DIR}/core/relay"
+make protos-local
+make update-pkgs
+make
+popd
+
+echo -e "\n######################################"
+echo "Build fabric components..."
+echo -e "######################################\n"
+
+echo "# Node SDK"
+pushd "${WEAVER_DIR}/sdks/fabric/interoperation-node-sdk"; make build-local; popd
+echo "# Node CLI"
+pushd "${WEAVER_DIR}/samples/fabric/fabric-cli"; make build-local; popd
+echo "# Go SDK"
+pushd "${WEAVER_DIR}/sdks/fabric/go-sdk"; make build-local; popd
+echo "# Go CLI"
+# TODO - uncomment once the build is fixed
+# pushd "${WEAVER_DIR}/samples/fabric/go-cli"; make build-local; popd
+echo "# Driver"
+pushd "${WEAVER_DIR}/core/drivers/fabric-driver"; make build-local; popd
+echo "# IIN Agent"
+pushd "${WEAVER_DIR}/core/identity-management/iin-agent"; make build-local; popd
+
+echo -e "\n######################################"
+echo "Build corda components..."
+echo -e "######################################\n"
+
+echo "# Interop App"
+pushd "${WEAVER_DIR}/core/network/corda-interop-app"; make build-local; popd
+echo "# SDK"
+pushd "${WEAVER_DIR}/sdks/corda"; make build; popd
+echo "# Simple Application"
+pushd "${WEAVER_DIR}/samples/corda/corda-simple-application"; make build-local; popd
+echo "# Driver"
+pushd "${WEAVER_DIR}/core/drivers/corda-driver"; make build-local; popd
+
+echo -e "\n######################################"
+echo "Build besu components..."
+echo -e "######################################\n"
+
+echo "# SDK"
+pushd "${WEAVER_DIR}/sdks/besu/node"; make build-local; popd
+echo "# CLI"
+pushd "${WEAVER_DIR}/samples/besu/besu-cli"; make build-local; popd
+
+echo "Done!"
+exit 0;

--- a/weaver/core/drivers/fabric-driver/package-local.json
+++ b/weaver/core/drivers/fabric-driver/package-local.json
@@ -2,22 +2,22 @@
     "name": "@hyperledger/cacti-weaver-driver-fabric",
     "version": "2.0.0-alpha.2",
     "description": "",
-    "main": "out/server.js",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "build": "npm run tsc",
-        "tsc": "tsc",
-        "start": "node out/server.js",
-        "watch": "tsc --watch",
-        "dev": "nodemon out/server.js",
-        "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/hyperledger/cacti.git"
     },
-    "author": "",
     "license": "Apache-2.0",
+    "author": "",
+    "main": "out/server.js",
+    "scripts": {
+        "build": "npm run tsc",
+        "dev": "nodemon out/server.js",
+        "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
+        "start": "node out/server.js",
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "tsc": "tsc",
+        "watch": "tsc --watch"
+    },
     "dependencies": {
         "@fidm/x509": "1.2.1",
         "@grpc/grpc-js": "1.9.5",
@@ -26,10 +26,12 @@
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
         "dotenv": "8.6.0",
-        "eslint-config-prettier": "8.10.0",
-        "eslint-plugin-prettier": "3.4.1",
+        "eslint-config-prettier": "8.9.0",
+        "eslint-plugin-prettier": "5.0.0",
         "fabric-ca-client": "2.2.19",
+        "fabric-common": "2.2.19",
         "fabric-network": "2.2.19",
+        "fabric-protos": "2.2.19",
         "level": "8.0.0",
         "winston": "3.10.0"
     },
@@ -39,5 +41,9 @@
         "patch-package": "6.5.1",
         "typedoc": "0.24.8",
         "typescript": "4.9.5"
+    },
+    "engines": {
+        "node": ">=18",
+        "npm": ">=8"
     }
 }

--- a/weaver/core/identity-management/iin-agent/package-local.json
+++ b/weaver/core/identity-management/iin-agent/package-local.json
@@ -1,51 +1,59 @@
 {
-    "name": "@hyperledger/cacti-weaver-iin-agent",
-    "version": "2.0.0-alpha.2",
-    "description": "",
-    "main": "index.js",
-    "scripts": {
-        "test": "nyc mocha -r ts-node/register --exclude 'test/data/**/*.js' --recursive  -t 10000",
-        "build": "npm run tsc",
-        "tsc": "tsc",
-        "start": "node out/server.js",
-        "watch": "tsc --watch",
-        "dev": "nodemon out/server.js",
-        "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/hyperledger/cacti.git"
-    },
-    "author": "",
-    "license": "Apache-2.0",
-    "dependencies": {
-        "@fidm/x509": "1.2.1",
-        "@grpc/grpc-js": "1.9.5",
-        "@hyperledger/cacti-weaver-protos-js": "file:./protos-js",
-        "@hyperledger/cacti-weaver-sdk-fabric": "file:./cacti-weaver-sdk-fabric",
-        "@typescript-eslint/eslint-plugin": "3.10.1",
-        "@typescript-eslint/parser": "3.10.1",
-        "dotenv": "8.6.0",
-        "eslint-config-prettier": "6.15.0",
-        "eslint-plugin-prettier": "3.4.1",
-        "fabric-ca-client": "2.2.19",
-        "fabric-common": "2.2.19",
-        "fabric-network": "2.2.19"
-    },
-    "devDependencies": {
-        "@types/node": "16.18.41",
-        "chai": "4.3.7",
-        "chai-as-promised": "7.1.1",
-        "mocha": "5.2.0",
-        "nodemon": "2.0.22",
-        "nyc": "12.0.2",
-        "patch-package": "6.5.1",
-        "proto3-json-serializer": "1.1.1",
-        "rewire": "4.0.1",
-        "sinon": "6.3.5",
-        "sinon-chai": "3.7.0",
-        "ts-node": "10.9.1",
-        "typedoc": "0.24.8",
-        "typescript": "4.9.5"
-    }
+  "name": "@hyperledger/cacti-weaver-iin-agent",
+  "version": "2.0.0-alpha.2",
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hyperledger/cacti.git"
+  },
+  "license": "Apache-2.0",
+  "author": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "npm run tsc",
+    "dev": "nodemon out/server.js",
+    "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
+    "start": "node out/server.js",
+    "test": "nyc mocha -r ts-node/register --exclude 'test/data/**/*.js' --recursive  -t 10000",
+    "tsc": "tsc",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "@fidm/x509": "1.2.1",
+    "@grpc/grpc-js": "1.9.5",
+    "@hyperledger/cacti-weaver-protos-js": "file:./protos-js",
+    "@hyperledger/cacti-weaver-sdk-fabric": "file:./cacti-weaver-sdk-fabric",
+    "@typescript-eslint/eslint-plugin": "3.10.1",
+    "@typescript-eslint/parser": "3.10.1",
+    "dotenv": "8.6.0",
+    "eslint-config-prettier": "6.15.0",
+    "eslint-plugin-prettier": "3.4.1",
+    "fabric-ca-client": "2.2.19",
+    "fabric-common": "2.2.19",
+    "fabric-network": "2.2.19",
+    "uuid": "9.0.1"
+  },
+  "devDependencies": {
+    "@types/jsrsasign": "10.5.11",
+    "@types/node": "16.18.41",
+    "@types/uuid": "9.0.6",
+    "chai": "4.3.7",
+    "chai-as-promised": "7.1.1",
+    "jsrsasign": "10.8.6",
+    "mocha": "5.2.0",
+    "nodemon": "2.0.22",
+    "nyc": "12.0.2",
+    "patch-package": "6.5.1",
+    "proto3-json-serializer": "1.1.1",
+    "rewire": "4.0.1",
+    "sinon": "6.3.5",
+    "sinon-chai": "3.7.0",
+    "ts-node": "10.9.1",
+    "typedoc": "0.24.8",
+    "typescript": "4.9.5"
+  },
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  }
 }

--- a/weaver/samples/besu/besu-cli/package-local.json
+++ b/weaver/samples/besu/besu-cli/package-local.json
@@ -1,24 +1,11 @@
 {
   "name": "@hyperledger/cacti-weaver-besu-cli",
-  "version": "0.0.1",
+  "version": "2.0.0-alpha.2",
   "description": "besu-cli CLI",
-  "private": true,
+  "license": "Apache-2.0",
   "types": "build/types/types.d.ts",
   "bin": {
     "besu-cli": "bin/besu-cli"
-  },
-  "scripts": {
-    "format": "prettier --write **/*.{js,ts,tsx,json}",
-    "lint": "tslint -p .",
-    "clean-build": "rm -rf ./build",
-    "compile": "tsc -p .",
-    "copy-templates": "if [ -e ./src/templates ]; then cp -a ./src/templates ./build/; fi",
-    "build": "yarn format && yarn lint && yarn clean-build && yarn compile && yarn copy-templates",
-    "prepublishOnly": "yarn build",
-    "test": "jest",
-    "watch": "jest --watch",
-    "snapupdate": "jest --updateSnapshot",
-    "coverage": "jest --coverage"
   },
   "files": [
     "tsconfig.json",
@@ -29,13 +16,34 @@
     "docs",
     "bin"
   ],
-  "license": "Apache-2.0",
+  "scripts": {
+    "build": "yarn format && yarn lint && yarn clean-build && yarn compile && yarn copy-templates",
+    "clean-build": "rm -rf ./build",
+    "compile": "tsc -p .",
+    "copy-templates": "if [ -e ./src/templates ]; then cp -a ./src/templates ./build/; fi",
+    "coverage": "jest --coverage",
+    "format": "prettier --write **/*.{js,ts,tsx,json}",
+    "lint": "tslint -p .",
+    "prepublishOnly": "yarn build",
+    "snapupdate": "jest --updateSnapshot",
+    "test": "jest",
+    "watch": "jest --watch"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  },
   "dependencies": {
     "@hyperledger/cacti-weaver-sdk-besu": "file:../../../sdks/besu/node",
     "@hyperledger/cacti-weaver-protos-js": "file:../../../common/protos-js",
-    "@truffle/contract": "4.2.14",
+    "@truffle/contract": "4.6.28",
     "gluegun": "5.1.6",
-    "winston": "3.3.3"
+    "web3": "1.10.0",
+    "winston": "3.10.0"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",
@@ -44,17 +52,13 @@
     "prettier": "1.19.1",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
-    "tslint": "5.12.0",
-    "tslint-config-prettier": "1.17.0",
+    "tslint": "5.20.1",
+    "tslint-config-prettier": "1.18.0",
     "tslint-config-standard": "8.0.1",
     "typescript": "4.9.5"
   },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "node"
-  },
-  "prettier": {
-    "semi": false,
-    "singleQuote": true
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
   }
 }

--- a/weaver/samples/fabric/fabric-cli/package-local.json
+++ b/weaver/samples/fabric/fabric-cli/package-local.json
@@ -1,26 +1,11 @@
 {
   "name": "@hyperledger/cacti-weaver-fabric-cli",
-  "version": "1.2.1",
+  "version": "2.0.0-alpha.2",
   "description": "fabric-cli CLI",
+  "license": "Apache-2.0",
   "types": "build/types/types.d.ts",
   "bin": {
     "fabric-cli": "bin/fabric-cli"
-  },
-  "scripts": {
-    "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
-    "clean-build": "rm -rf ./build",
-    "compile": "tsc -p .",
-    "copy-templates": "if [ -e ./src/templates ]; then cp -a ./src/templates ./build/; fi",
-    "copy-basic-wallets": "cp -a ./src/wallet-network1 ./build/ && cp -a ./src/wallet-network2 ./build/",
-    "copy-data": "if [ -e ./src/data ]; then cp -a ./src/data ./build/; fi",
-    "copy-credentials": "if [ -e ./src/credentials ]; then cp -a ./src/credentials ./build/; fi",
-    "copy-config": "if [ -f ./config.json ]; then cp ./config.json ./build/; fi",
-    "build": "yarn clean-build && yarn compile && yarn copy-templates && yarn copy-data && yarn copy-basic-wallets && yarn copy-credentials",
-    "prepublishOnly": "yarn build",
-    "test": "jest",
-    "watch": "jest --watch",
-    "snapupdate": "jest --updateSnapshot",
-    "coverage": "jest --coverage"
   },
   "files": [
     "tsconfig.json",
@@ -30,7 +15,30 @@
     "docs",
     "bin"
   ],
-  "license": "Apache-2.0",
+  "scripts": {
+    "build": "yarn clean-build && yarn compile && yarn copy-templates && yarn copy-data && yarn copy-basic-wallets && yarn copy-credentials",
+    "clean-build": "rm -rf ./build",
+    "compile": "tsc -p .",
+    "copy-basic-wallets": "cp -a ./src/wallet-network1 ./build/ && cp -a ./src/wallet-network2 ./build/",
+    "copy-config": "if [ -f ./config.json ]; then cp ./config.json ./build/; fi",
+    "copy-credentials": "if [ -e ./src/credentials ]; then cp -a ./src/credentials ./build/; fi",
+    "copy-data": "if [ -e ./src/data ]; then cp -a ./src/data ./build/; fi",
+    "copy-templates": "if [ -e ./src/templates ]; then cp -a ./src/templates ./build/; fi",
+    "coverage": "jest --coverage",
+    "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
+    "prepublishOnly": "yarn build",
+    "snapupdate": "jest --updateSnapshot",
+    "test": "jest",
+    "watch": "jest --watch"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  },
   "dependencies": {
     "@fidm/x509": "1.2.1",
     "@hyperledger/cacti-weaver-protos-js": "file:../../../common/protos-js",
@@ -41,6 +49,7 @@
     "elliptic": "6.5.4",
     "express": "4.18.2",
     "fabric-ca-client": "2.2.19",
+    "fabric-common": "2.2.19",
     "fabric-network": "2.2.19",
     "gluegun": "5.1.6",
     "grpc-tools": "1.12.4",
@@ -70,13 +79,9 @@
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
   },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "node"
-  },
-  "prettier": {
-    "semi": false,
-    "singleQuote": true
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/hyperledger-labs"

--- a/weaver/sdks/besu/node/package-local.json
+++ b/weaver/sdks/besu/node/package-local.json
@@ -1,23 +1,23 @@
 {
   "name": "@hyperledger/cacti-weaver-sdk-besu",
-  "description": "Supplemental library for Web3JS based Besu client applications to enable interoperability using Weaver",
   "version": "2.0.0-alpha.2",
-  "main": "build/index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc"
-  },
-  "author": "",
-  "tag": "latest",
+  "description": "Supplemental library for Web3JS based Besu client applications to enable interoperability using Weaver",
   "repository": {
     "type": "git",
     "url": "https://github.com/hyperledger/cacti.git"
   },
   "license": "Apache-2.0",
+  "author": "",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
   "dependencies": {
     "@hyperledger/cacti-weaver-protos-js": "file:./protos-js",
     "log4js": "6.9.1",
-    "web3": "1.10.0"
+    "web3": "1.10.0",
+    "web3-utils": "1.10.0"
   },
   "devDependencies": {
     "@types/node": "16.18.41",
@@ -41,7 +41,12 @@
     "typedoc": "0.24.8",
     "typescript": "4.9.5"
   },
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/hyperledger-labs"
-  }
+    "registry": "https://npm.pkg.github.com/hyperledger"
+  },
+  "tag": "latest"
 }

--- a/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
+++ b/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
@@ -1,30 +1,41 @@
 {
   "name": "@hyperledger/cacti-weaver-sdk-fabric",
+  "version": "2.0.0-alpha.2",
   "description": "Supplemental library to 'fabric-client' with functions for relay-based cross-network interactions",
   "keywords": [
     "hyperledger",
     "blockchain",
     "interoperability"
   ],
-  "version": "2.0.0-alpha.2",
-  "author": "V. Ramakrishna",
-  "tag": "latest",
-  "main": "build/index.js",
-  "types": "./types/index.d.ts",
-  "scripts": {
-    "test": "nyc mocha -r ts-node/register --exclude 'test/data/**/*.js' --recursive  -t 10000",
-    "build": "tsc",
-    "prepublishOnly": "npm test",
-    "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
-    "docs": "typedoc --out docs/ src/"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/hyperledger/cacti.git"
   },
-  "engines": {
-    "node": ">=10.15.3 <=16.17.1",
-    "npm": ">=6.0.0 <=8.15.0"
+  "license": "Apache-2.0",
+  "author": "V. Ramakrishna",
+  "main": "build/index.js",
+  "types": "./types/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "docs": "typedoc --out docs/ src/",
+    "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
+    "prepublishOnly": "npm test",
+    "test": "nyc mocha -r ts-node/register --exclude 'test/data/**/*.js' --recursive  -t 10000"
+  },
+  "nyc": {
+    "all": true,
+    "exclude": [
+      "index.js",
+      "coverage/**",
+      "lib/impl",
+      "lib/msp",
+      "lib/protos",
+      "test/**"
+    ],
+    "reporter": [
+      "text-summary",
+      "html"
+    ]
   },
   "dependencies": {
     "@grpc/grpc-js": "1.9.5",
@@ -64,29 +75,18 @@
     "typedoc": "0.24.8",
     "typescript": "4.9.5"
   },
-  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18",
+    "npm": ">=8"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/hyperledger"
+  },
   "licenses": [
     {
       "type": "Apache-2.0",
       "url": "https://github.com/hyperledger/cacti/blob/main/weaver/LICENSE"
     }
   ],
-  "nyc": {
-    "exclude": [
-      "index.js",
-      "coverage/**",
-      "lib/impl",
-      "lib/msp",
-      "lib/protos",
-      "test/**"
-    ],
-    "reporter": [
-      "text-summary",
-      "html"
-    ],
-    "all": true
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/hyperledger"
-  }
+  "tag": "latest"
 }

--- a/weaver/sdks/fabric/interoperation-node-sdk/src/MembershipManager.ts
+++ b/weaver/sdks/fabric/interoperation-node-sdk/src/MembershipManager.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
- 
+
 import { Gateway, Network } from 'fabric-network';
 import { Channel } from 'fabric-common';
 import * as path from 'path';
@@ -91,10 +91,10 @@ function getMembershipUnit(channel: Channel, mspId: string): membership_pb.Membe
     member.setType("certificate");
     member.setValue("");
     member.setChainList(certs);
-    
+
     return member;
 }
- 
+
 function getMSPConfigurations(
     network: Network,
     memberMspIds: Array<string>
@@ -144,14 +144,14 @@ async function syncMembershipFromIINAgent(
     try {
         const foreignSecurityDomain = new agent_pb.SecurityDomainMemberIdentity();
         foreignSecurityDomain.setSecurityDomain(securityDomain);
-        
+
         const iinAgentClient = getIINAgentClient(iinAgentEndpoint, useTls, tlsCACertPath)
         const {
             syncExternalState,
         }: {
             syncExternalState: (request: agent_pb.SecurityDomainMemberIdentity) => Promise<common_ack_pb.Ack>;
         } = promisifyAll(iinAgentClient);
-        
+
         if (typeof syncExternalState === "function") {
             const [resp, error] = await handlePromise(syncExternalState(foreignSecurityDomain));
             if (error) {
@@ -205,6 +205,7 @@ export {
     deleteLocalMembership,
     readMembership,
     getMembershipUnit,
+    getMSPConfigurations,
     getAllMSPConfigurations,
     syncMembershipFromIINAgent
 }

--- a/weaver/tests/network-setups/corda/scripts/check-nodes-status.sh
+++ b/weaver/tests/network-setups/corda/scripts/check-nodes-status.sh
@@ -1,8 +1,7 @@
+#!/usr/bin/env bash
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-
-#!/bin/bash
 
 MAX_SLEEP_COUNT=40
 PROFILE=$1
@@ -61,7 +60,7 @@ if [ "$NW" = "Corda_Network" ]; then
         done
         echo "PartyC node services started for network "$NW
     fi
-    
+
     # Wait for Notary services in container to start
     while [[ $(docker logs corda_notary_1 | tail -n 1) != "Running P2PMessaging loop" ]]
     do
@@ -75,9 +74,9 @@ if [ "$NW" = "Corda_Network" ]; then
         fi
     done
     echo "Notary node services started for network "$NW
-    
+
 elif [ "$NW" = "Corda_Network2" ]; then
-    
+
     echo "Waiting for network $NW node services to start"
 
     if [ "$PROFILE" = "1-node" ] || [ "$PROFILE" = "2-nodes" ] || [ "$PROFILE" = "3-nodes" ]; then
@@ -130,7 +129,7 @@ elif [ "$NW" = "Corda_Network2" ]; then
         done
         echo "PartyC node services started for network "$NW
     fi
-    
+
     # Wait for Notary services in container to start
     while [[ $(docker logs corda_network2_notary_1 | tail -n 1) != "Running P2PMessaging loop" ]]
     do
@@ -144,7 +143,7 @@ elif [ "$NW" = "Corda_Network2" ]; then
         fi
     done
     echo "Notary node services started for network "$NW
-  
+
 else
     echo "Network $NW not found."
 fi


### PR DESCRIPTION
- Add a bash script in tools to build all the weaver packages in single command.
- Export `getMSPConfigurations` from fabric interop sdk (is imported in fabric cli, was causing compilation error on node 20)
- Move bash shebang to the top of `check-nodes-status`. On ubuntu 20 having this below was causing the file to be interpreted as sh (resulting in error)
- Update `package-local.json` files to be more inline with `package.json`.

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.