### PR TITLE
style(weaver): fix DCI lint errors related to gradle wrapper scripts

### DIFF
--- a/.dcilintignore
+++ b/.dcilintignore
@@ -26,3 +26,6 @@ weaver/tests/network-setups/corda/shared
 
 # Commit messages snuck disallowed terminology into the changelog files.
 CHANGELOG.md
+
+# Ignore the Gradle Wrapper scripts because they are vendored dependencies that we cannot alter
+**/gradlew


### PR DESCRIPTION
Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.