### PR TITLE
test(cactus-core): fix false negative test results

### DIFF
--- a/packages/cactus-core/src/main/typescript/web-services/handle-rest-endpoint-exception.ts
+++ b/packages/cactus-core/src/main/typescript/web-services/handle-rest-endpoint-exception.ts
@@ -1,10 +1,16 @@
+import type { Response } from "express";
+import createHttpError from "http-errors";
+
+import {
+  identifierByCodes,
+  INTERNAL_SERVER_ERROR,
+} from "http-errors-enhanced-cjs";
+
 import {
   Logger,
   createRuntimeErrorWithCause,
   safeStringifyException,
 } from "@hyperledger/cactus-common";
-import type { Response } from "express";
-import createHttpError from "http-errors";
 
 /**
  * An interface describing the object containing the contextual information needed by the
@@ -40,10 +46,6 @@ export async function handleRestEndpointException(
   ctx: Readonly<IHandleRestEndpointExceptionOptions>,
 ): Promise<void> {
   const errorAsSanitizedJson = safeStringifyException(ctx.error);
-
-  const { identifierByCodes, INTERNAL_SERVER_ERROR } = await import(
-    "http-errors-enhanced-cjs"
-  );
 
   if (createHttpError.isHttpError(ctx.error)) {
     ctx.res.status(ctx.error.statusCode);


### PR DESCRIPTION
The fix was to start statically importing the http helper library we use
in `packages/cactus-core/src/main/typescript/web-services/handle-rest-endpoint-exception.ts`
instead of how it was (dynamic imports at runtime).

1. There have been reports of dynamic imports causing segmentation
faults in the NodeJS process when Jest is involved.
2. It is looking like this bug was another instance of that manifesting
but slightly differently because this time around Jest decided to hide
the stack trace of it as well.
3. Because of `2)` we have no specific evidence of the theory. We can only
say that the change in this commit made the problem go away, but since
there never was any crash logs or stack traces on the CI environment,
this remains a conjecture.
4. Trying to reproduce the issue locally failed even when using the
exact same versions of NodeJS and npm (and all the dependencies of course).
5. Based on `4)` it is likely that the segmentation fault is due to a
race condition in the lower level (C/C++) code of NodeJS and/or Jest.

Fixes #2966

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.