### PR TITLE
build(tools): codegen clean script now removes corda kotlin-spring src

### DIFF
--- a/tools/clear-openapi-codegen-folders.js
+++ b/tools/clear-openapi-codegen-folders.js
@@ -13,6 +13,8 @@ const PROJECT_DIR = path.join(SCRIPT_DIR, "../");
 const OPENAPI_CODEGEN_PATHS = [
   "src/main/kotlin/generated/openapi/**",
   "src/main/typescript/generated/openapi/typescript-axios/**",
+  "src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/**/server/(api|model|!impl)/**",
+  "src/main-server/kotlin/gen/kotlin-spring/src/test/kotlin/**/server/(api|model|!impl)/**",
 ];
 const lernaJsonStr = await readFile(PROJECT_DIR + LERNA_JSON, "utf-8");
 const lernaJson = JSON.parse(lernaJsonStr);


### PR DESCRIPTION
Extended the existing globs in the clean script to include the back-end
code generated via the `kotlin-spring` template as well.

1. Previously only the generated client code was removed and regenerated
but with this change we now have the generated corda connector backend
API kotlin code removed as well.
2. The build files such as the build.gradle.kts and pom.xml files are not
deleted for now just the files under the `api` and the `model` directories
within the src/main and src/test code folders.
3. Running the delete script and then the code generation results in no
git index changes which is what we strive for.
4. The reason why we needed a slightly more complicated glob pattern
for achieving this is because the back-end code requires hand-written
implementation for the endpoints which are all placed within the `impl`
directory within the `src/main` and `src/test` folders and these need to
be ignored.
5. This change is setting the stage for an upcoming upgrade in the configuration
of the open api generator where we'll set it up to use spring boot 3 instead
of the current legacy version. The reason why this is needed is because
the legacy version has a large amount of security vulnerabilities that need
to be taken care of by upgrading our dependencies.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.