### PR TITLE
ci(github): loosen up file matching when selecting tests to run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,106 +40,106 @@ jobs:
         with:
           filters: |
             cmd-api-server-changed:
-              - './packages/cactus-cmd-api-server/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-cmd-api-server/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core-api/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-keychain-vault/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './packages/cactus-cmd-api-server/**'
+              - './packages/cactus-test-cmd-api-server/**'
+              - './packages/cactus-common/**'
+              - './packages/cactus-core/**'
+              - './packages/cactus-core-api/**'
+              - './packages/cactus-test-tooling/**'
+              - './packages/cactus-plugin-keychain-vault/**'
               # - './.github/workflows/ci.yaml'
 
             plugin-ledger-connector-aries-changed:
-              - './packages/cactus-plugin-ledger-connector-aries/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core-api/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './packages/cactus-plugin-ledger-connector-aries/**'
+              - './packages/cactus-common/**'
+              - './packages/cactus-core/**'
+              - './packages/cactus-core-api/**'
+              - './packages/cactus-test-tooling/**'
               # - './.github/workflows/ci.yaml'
 
             plugin-ledger-connector-besu-changed:
-              - './packages/cactus-plugin-ledger-connector-besu/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-plugin-ledger-connector-besu/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core-api/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-keychain-memory/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './packages/cactus-plugin-ledger-connector-besu/**'
+              - './packages/cactus-test-plugin-ledger-connector-besu/**'
+              - './packages/cactus-common/**'
+              - './packages/cactus-core/**'
+              - './packages/cactus-core-api/**'
+              - './packages/cactus-test-tooling/**'
+              - './packages/cactus-plugin-keychain-memory/**'
               # - './.github/workflows/ci.yaml''
 
             plugin-ledger-connector-corda-changed:
-              - './packages/cactus-plugin-ledger-connector-corda/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core-api/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './packages/cactus-plugin-ledger-connector-corda/**'
+              - './packages/cactus-common/**'
+              - './packages/cactus-core/**'
+              - './packages/cactus-core-api/**'
+              - './packages/cactus-test-tooling/**'
               # - './.github/workflows/ci.yaml'
 
             plugin-ledger-connector-fabric-changed:
-              - './packages/cactus-plugin-ledger-connector-fabric/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core-api/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-keychain-memory/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './packages/cactus-plugin-ledger-connector-fabric/**'
+              - './packages/cactus-common/**'
+              - './packages/cactus-core/**'
+              - './packages/cactus-core-api/**'
+              - './packages/cactus-test-tooling/**'
+              - './packages/cactus-plugin-keychain-memory/**'
               # - './.github/workflows/ci.yaml'
 
             plugin-ledger-connector-ethereum-changed:
-              - './packages/cactus-plugin-ledger-connector-ethereum/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core-api/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-geth-ledger/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-keychain-memory/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './packages/cactus-plugin-ledger-connector-ethereum/**'
+              - './packages/cactus-common/**'
+              - './packages/cactus-core/**'
+              - './packages/cactus-core-api/**'
+              - './packages/cactus-test-tooling/**'
+              - './packages/cactus-test-geth-ledger/**'
+              - './packages/cactus-plugin-keychain-memory/**'
               # - './.github/workflows/ci.yaml'
 
             plugin-ledger-connector-iroha2-changed:
-              - './packages/cactus-plugin-ledger-connector-iroha2/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core-api/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-keychain-memory/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './packages/cactus-plugin-ledger-connector-iroha2/**'
+              - './packages/cactus-common/**'
+              - './packages/cactus-core/**'
+              - './packages/cactus-core-api/**'
+              - './packages/cactus-test-tooling/**'
+              - './packages/cactus-plugin-keychain-memory/**'
               # - './.github/workflows/ci.yaml'
 
             plugin-ledger-connector-quorum-changed:
-              - './packages/cactus-plugin-ledger-connector-quorum/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-plugin-ledger-connector-quorum/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core-api/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-keychain-memory/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './packages/cactus-plugin-ledger-connector-quorum/**'
+              - './packages/cactus-test-plugin-ledger-connector-quorum/**'
+              - './packages/cactus-common/**'
+              - './packages/cactus-core/**'
+              - './packages/cactus-core-api/**'
+              - './packages/cactus-test-tooling/**'
+              - './packages/cactus-plugin-keychain-memory/**'
               # - './.github/workflows/ci.yaml'
 
             test-tooling-changed:
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './packages/cactus-test-tooling/**'
+              - './packages/cactus-common/**'
               # - './.github/workflows/ci.yaml'
 
             ghcr-corda-all-in-one-obligation-changed:
-              - './tools/docker/corda-all-in-one/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './tools/docker/corda-all-in-one/**'
               # - './.github/workflows/ci.yaml'
 
             ghcr-corda-all-in-one-changed:
-            - './tools/docker/corda-all-in-one/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+            - './tools/docker/corda-all-in-one/**'
             # - './.github/workflows/ci.yaml'
 
             ghcr-dev-container-vscode-changed:
-              - './.devcontainer/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './.devcontainer/**'
 
             plugin-htlc-coordinator-besu-changed:
-              - './extensions/cactus-plugin-htlc-coordinator-besu/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-htlc-eth-besu/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-htlc-eth-besu-erc20/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-ledger-connector-besu/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-plugin-htlc-eth-besu-erc20/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-common/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-core-api/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-test-tooling/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './packages/cactus-plugin-keychain-memory/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './extensions/cactus-plugin-htlc-coordinator-besu/**'
+              - './packages/cactus-plugin-htlc-eth-besu/**'
+              - './packages/cactus-plugin-htlc-eth-besu-erc20/**'
+              - './packages/cactus-plugin-ledger-connector-besu/**'
+              - './packages/cactus-test-plugin-htlc-eth-besu-erc20/**'
+              - './packages/cactus-common/**'
+              - './packages/cactus-core/**'
+              - './packages/cactus-core-api/**'
+              - './packages/cactus-test-tooling/**'
+              - './packages/cactus-plugin-keychain-memory/**'
               # - './.github/workflows/ci.yaml'
 
   build-dev:
@@ -407,11 +407,11 @@ jobs:
           tool: 'benchmarkjs'
           output-file-path: .tmp/benchmark-results/cmd-api-server/run-cmd-api-server-benchmark.ts.log
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          
+
           # Only push the benchmark results to gh-pages website if we are running on the main branch
           # We do not want to clutter the benchmark results with intermediate results from PRs that could be drafts
           auto-push: ${{ github.ref == 'refs/heads/main' }}
-          
+
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '5%'
           comment-on-alert: true

--- a/.github/workflows/test_weaver-asset-exchange-besu.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-besu.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           filters: |
             weaver_code_changed:
-              - './weaver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/**'
               - '.github/workflows/test_weaver-asset-exchange-besu.yaml'
 
   asset-exchange-besu:

--- a/.github/workflows/test_weaver-asset-exchange-corda.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-corda.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           filters: |
             weaver_code_changed:
-              - './weaver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/**'
               - '.github/workflows/test_weaver-asset-exchange-corda.yaml'
 
   asset-exchange-corda:
@@ -247,7 +247,7 @@ jobs:
         with:
           filters: |
             weaver_code_changed:
-              - './weaver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/**'
               - '.github/workflows/test_weaver-asset-exchange-corda.yaml'
 
       - name: Set up JDK 8

--- a/.github/workflows/test_weaver-asset-exchange-fabric.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-fabric.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           filters: |
             weaver_code_changed:
-              - './weaver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/**'
               - '.github/workflows/test_weaver-asset-exchange-fabric.yaml'
 
   asset-exchange-fabric:

--- a/.github/workflows/test_weaver-asset-transfer.yaml
+++ b/.github/workflows/test_weaver-asset-transfer.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           filters: |
             weaver_code_changed:
-              - './weaver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/**'
               - '.github/workflows/test_weaver-asset-transfer.yaml'
 
   asset-transfer:

--- a/.github/workflows/test_weaver-corda-interop-app.yaml
+++ b/.github/workflows/test_weaver-corda-interop-app.yaml
@@ -30,8 +30,8 @@ jobs:
         with:
           filters: |
             interop_cordapp_changed:
-              - './weaver/common/protos-java-kt/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/core/network/corda-interop-app/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/common/protos-java-kt/**'
+              - './weaver/core/network/corda-interop-app/**'
               - '.github/workflows/test_weaver-corda-interop-app.yaml'
 
   unit_test_interop_cordapp:
@@ -46,15 +46,15 @@ jobs:
       with:
         java-version: '8'
         distribution: 'adopt'
-  
+
     - name: Build Protos (Local)
       run: make build
       working-directory: weaver/common/protos-java-kt
-      
+
     - name: Build Corda Interop App (Local)
       run: make build-local
       working-directory: weaver/core/network/corda-interop-app
-      
+
     - name: Run Tests (Local)
       run: make test
       working-directory: weaver/core/network/corda-interop-app

--- a/.github/workflows/test_weaver-data-sharing.yaml
+++ b/.github/workflows/test_weaver-data-sharing.yaml
@@ -38,9 +38,9 @@ jobs:
         with:
           filters: |
             weaver_code_changed:
-              - './weaver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/**'
               - '.github/workflows/test_weaver-data-sharing.yaml'
-    
+
   data-sharing:
     needs: check_code_changed
     if: ${{ false && needs.check_code_changed.outputs.status == 'true' }}
@@ -425,7 +425,7 @@ jobs:
         with:
           filters: |
             weaver_code_changed:
-              - './weaver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/**'
               - '.github/workflows/test_weaver-data-sharing.yaml'
 
       - name: Set up JDK 8
@@ -850,7 +850,7 @@ jobs:
         with:
           filters: |
             weaver_code_changed:
-              - './weaver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/**'
               - '.github/workflows/test_weaver-data-sharing.yaml'
 
       - name: Set up JDK 8

--- a/.github/workflows/test_weaver-docker-build.yaml
+++ b/.github/workflows/test_weaver-docker-build.yaml
@@ -33,30 +33,30 @@ jobs:
         with:
           filters: |
             relay_changed:
-              - './weaver/common/protos-rs/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/core/relay/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/common/protos-rs/**'
+              - './weaver/core/relay/**'
               - '.github/workflows/test_weaver-docker-build.yaml'
 
             fabric_driver_changed:
-              - './weaver/common/protos/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/common/protos-js/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/sdks/fabric/interoperation-node-sdk/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/weaver/core/drivers/fabric-driver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/common/protos/**'
+              - './weaver/common/protos-js/**'
+              - './weaver/sdks/fabric/interoperation-node-sdk/**'
+              - './weaver/weaver/core/drivers/fabric-driver/**'
               - '.github/workflows/test_weaver-docker-build.yaml'
 
             corda_driver_changed:
-              - './weaver/common/protos/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/common/protos-java-kt/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/core/network/corda-interop-app/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/sdks/corda/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/core/drivers/corda-driver/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/common/protos/**'
+              - './weaver/common/protos-java-kt/**'
+              - './weaver/core/network/corda-interop-app/**'
+              - './weaver/sdks/corda/**'
+              - './weaver/core/drivers/corda-driver/**'
               - '.github/workflows/test_weaver-docker-build.yaml'
 
             iin_agent_changed:
-              - './weaver/common/protos/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/common/protos-js/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/sdks/fabric/interoperation-node-sdk/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - './weaver/core/identity-management/iin-agent/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - './weaver/common/protos/**'
+              - './weaver/common/protos-js/**'
+              - './weaver/sdks/fabric/interoperation-node-sdk/**'
+              - './weaver/core/identity-management/iin-agent/**'
               - '.github/workflows/test_weaver-docker-build.yaml'
 
   build_docker_relay:

--- a/.github/workflows/test_weaver-go.yaml
+++ b/.github/workflows/test_weaver-go.yaml
@@ -31,21 +31,21 @@ jobs:
         with:
           filters: |
             interopcc_changed:
-              - 'weaver/common/protos-go/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - 'weaver/core/network/fabric-interop-cc/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - 'weaver/common/protos-go/**'
+              - 'weaver/core/network/fabric-interop-cc/**'
               - '.github/workflows/test_weaver-go.yaml'
 
             simplestate_changed:
-              - 'weaver/samples/fabric/simplestate/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - 'weaver/samples/fabric/simplestate/**'
 
             simpleasset_changed:
-              - 'weaver/samples/fabric/simpleasset/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - 'weaver/samples/fabric/simpleasset/**'
 
             simpleassetandinterop_changed:
-              - 'weaver/samples/fabric/simpleassetandinterop/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - 'weaver/samples/fabric/simpleassetandinterop/**'
 
             simpleassettransfer_changed:
-              - 'weaver/samples/fabric/simpleassettransfer/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - 'weaver/samples/fabric/simpleassettransfer/**'
 
   unit_test_interopcc:
     needs: check_code_changed

--- a/.github/workflows/test_weaver-relay.yaml
+++ b/.github/workflows/test_weaver-relay.yaml
@@ -27,9 +27,9 @@ jobs:
         with:
           filters: |
             relay_changed:
-              - '.weaver/common/protos/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - '.weaver/common/protos-rs/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
-              - '.weaver/core/relay/**!(*.md|*.css|*.html|*.jpg|*.jpeg|*.png)'
+              - '.weaver/common/protos/**'
+              - '.weaver/common/protos-rs/**'
+              - '.weaver/core/relay/**'
               - .github/workflows/test_weaver-relay.yaml'
 
   unit_test_relay_local:


### PR DESCRIPTION
- Current file match glob is incorrect and never matches a file.
- I didn't find a way to filter files by extension (as it was attempted now) so I propose to loose up the rules and run the test if any file in a package has changed.

## More context
- I've noticed in another PR (https://github.com/hyperledger/cacti/pull/3018) that most tests didn't run, even though this PR changes most ts files, from all packages I think.
- I've digged a little bit in dorny/paths-filter sources, found out the file matching string is passed to `picomatch` for actual filtering.
- `picomatch` is very simple (but fast), and does not support any advanced globbing techniques. I've done some tests locally, and the best solution I found is to use less strict matching rules.

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.