### PR TITLE
build(weaver/corda-driver): add Trivy scanning capability and steps

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -50,6 +50,7 @@
         "dids",
         "Dids",
         "DockerOde",
+        "dokka",
         "ealen",
         "ecparams",
         "embeddable",
@@ -158,6 +159,7 @@
         "thream",
         "tlsca",
         "tlscacerts",
+        "Trivy",
         "txid",
         "txqueue",
         "Uisrs",
@@ -166,6 +168,7 @@
         "Unmarshal",
         "uuidv",
         "vscc",
+        "vuln",
         "wasm",
         "Xdai"
     ],

--- a/weaver/core/drivers/corda-driver/README.md
+++ b/weaver/core/drivers/corda-driver/README.md
@@ -148,6 +148,41 @@ The docs are then located in `build/dokka/driver-corda`. Opening
 `index.html` in your browser will allow you to navigate through the project
 structure.
 
+## Trivy Security Audit of Dependencies
+
+> Note you either need to be using the VSCode Dev Container or having installed
+> Trivy yourself prior to running these steps.
+
+[Trivy Documentation & Install Guide](https://github.com/aquasecurity/trivy)
+
+The following command generates a `pom.xml` file with the same exact dependencies
+declared as they are in the build.gradle file.
+
+The reason why we need this step is because Trivy does not yet support build.gradle
+files, only pom.xml files.
+
+```sh
+./gradlew generatePomFileForPublication
+```
+
+After this step, we now have a pom.xml file, but with the wrong name because
+Trivy will only accept these if the file is called exactly `pom.xml` but the
+script above will name it as `pom-default.xml` which Trivy ignores, so we rename:
+
+```sh
+mv ./build/publications/maven/pom-default.xml ./build/publications/maven/pom.xml
+```
+
+Finally, we are ready to point Trivy to the directory where the `pom.xml` file
+is located and actually run the scan:
+
+```sh
+trivy fs --scanners=vuln ./build/publications/maven/
+```
+
+More information about the Maven Publish Plugin can be found here:
+https://docs.gradle.org/current/userguide/publishing_maven.html
+
 ## TODO
 
 1. Create an Error class

--- a/weaver/core/drivers/corda-driver/build.gradle
+++ b/weaver/core/drivers/corda-driver/build.gradle
@@ -33,6 +33,18 @@ plugins {
     id "application"
     id "com.google.protobuf" version "0.8.12"
     id 'org.jetbrains.dokka' version '0.10.1'
+    id 'maven-publish'
+}
+
+// Can be used to generate a pom.xml file which in turn can be used to run a 
+// trivy security audit of the dependencies to check for vulnerable versions.
+// Check the package README.md file for an example to do it via bash commands.
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
 }
 
 Properties constants = new Properties()


### PR DESCRIPTION
1. The build.gradle file now has the maven publish plugin pulled which
can be used to generate pom.xml files that we don't really plan on using
for publishing but are still necessary to have in a temporary fashion
because the scanning tool (Trivy) only suports scanning dependencies
for vulnerabilities via pom.xml files of the Maven tool but not through
`build.gradle` files of the Gradle tool.
2. The `README.md` file was updated with detailed steps on how to run a
scan that includes generating the pom file, renaming it according to the
requirements of Trivy itself and then running the actual scan.
3. Some of the cspell issues have been rectified by adding new words to
the config.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.