### PR TITLE
docs(build): change NodeJS version in BUILD.md to v18.18.2

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -94,10 +94,10 @@ The `npm run watch` script in action:
   * Windows Only
     * WSL2 or any virtual machine running Ubuntu 20.04 LTS
   * Git
-  * NodeJS v16.14.2, npm v8.5.0 (we recommend using the Node Version Manager (nvm) if available for your OS)
+  * NodeJS v18.18.2, npm v8.5.0 (we recommend using the Node Version Manager (nvm) if available for your OS)
     ```
-    nvm install 16.14.2
-    nvm use 16.14.2
+    nvm install 18.18.2
+    nvm use 18.18.2
     ```
   * Yarn
     * `npm run enable-corepack` (from within the project directory)


### PR DESCRIPTION
- fix node version in BUILD.md what caused type error in corepack
and prevented yarn from installing packages correctly.
Error message when using node 16: Type Error: URL.canParse is not a function

Signed-off-by: Tomasz Awramski <tomasz.awramski@fujitsu.com>