### PR TITLE
refactor(test-tooling): fix types of streams: use NodeJS.ReadableStream

### DIFF
--- a/packages/cactus-test-tooling/package.json
+++ b/packages/cactus-test-tooling/package.json
@@ -101,6 +101,7 @@
     "@types/fs-extra": "9.0.13",
     "@types/js-yaml": "4.0.3",
     "@types/lodash": "4.14.172",
+    "@types/node": "18.11.9",
     "@types/node-forge": "1.3.0",
     "@types/ssh2": "0.5.47",
     "@types/ssh2-streams": "0.1.9",

--- a/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/common/containers.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { Duplex, Stream } from "stream";
+import { Duplex } from "stream";
 import { IncomingMessage } from "http";
 import throttle from "lodash/throttle";
 import { Container, ContainerInfo } from "dockerode";
@@ -443,7 +443,10 @@ export class Containers {
         log.debug(JSON.stringify(msg.progress || msg.status));
       }, 1000);
 
-      const pullStreamStartedHandler = (pullError: unknown, stream: Stream) => {
+      const pullStreamStartedHandler = (
+        pullError: unknown,
+        stream: NodeJS.ReadableStream,
+      ) => {
         if (pullError) {
           log.error(`Could not even start ${imageFqn} pull:`, pullError);
           reject(pullError);

--- a/packages/cactus-test-tooling/src/main/typescript/postgres/postgres-test-container.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/postgres/postgres-test-container.ts
@@ -11,7 +11,6 @@ import {
 import { ITestLedger } from "../i-test-ledger";
 import { Streams } from "../common/streams";
 import { Containers } from "../common/containers";
-import { Stream } from "stream";
 
 /*
  * Contains options for Postgres container
@@ -287,22 +286,25 @@ export class PostgresTestContainer implements ITestLedger {
   private pullContainerImage(containerNameAndTag: string): Promise<unknown[]> {
     return new Promise((resolve, reject) => {
       const docker = new Docker();
-      docker.pull(containerNameAndTag, (pullError: unknown, stream: Stream) => {
-        if (pullError) {
-          reject(pullError);
-        } else {
-          docker.modem.followProgress(
-            stream,
-            (progressError: unknown, output: unknown[]) => {
-              if (progressError) {
-                reject(progressError);
-              } else {
-                resolve(output);
-              }
-            },
-          );
-        }
-      });
+      docker.pull(
+        containerNameAndTag,
+        (pullError: unknown, stream: NodeJS.ReadableStream) => {
+          if (pullError) {
+            reject(pullError);
+          } else {
+            docker.modem.followProgress(
+              stream,
+              (progressError: unknown, output: unknown[]) => {
+                if (progressError) {
+                  reject(progressError);
+                } else {
+                  resolve(output);
+                }
+              },
+            );
+          }
+        },
+      );
     });
   }
 

--- a/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/quorum/quorum-test-ledger.ts
@@ -1,4 +1,3 @@
-import { Stream } from "stream";
 import { EventEmitter } from "events";
 import axios from "axios";
 import { v4 as uuidv4 } from "uuid";
@@ -415,22 +414,25 @@ export class QuorumTestLedger implements ITestLedger {
   private pullContainerImage(containerNameAndTag: string): Promise<unknown[]> {
     return new Promise((resolve, reject) => {
       const docker = new Docker();
-      docker.pull(containerNameAndTag, (pullError: unknown, stream: Stream) => {
-        if (pullError) {
-          reject(pullError);
-        } else {
-          docker.modem.followProgress(
-            stream,
-            (progressError: unknown, output: unknown[]) => {
-              if (progressError) {
-                reject(progressError);
-              } else {
-                resolve(output);
-              }
-            },
-          );
-        }
-      });
+      docker.pull(
+        containerNameAndTag,
+        (pullError: unknown, stream: NodeJS.ReadableStream) => {
+          if (pullError) {
+            reject(pullError);
+          } else {
+            docker.modem.followProgress(
+              stream,
+              (progressError: unknown, output: unknown[]) => {
+                if (progressError) {
+                  reject(progressError);
+                } else {
+                  resolve(output);
+                }
+              },
+            );
+          }
+        },
+      );
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9270,6 +9270,7 @@ __metadata:
     "@types/fs-extra": "npm:9.0.13"
     "@types/js-yaml": "npm:4.0.3"
     "@types/lodash": "npm:4.14.172"
+    "@types/node": "npm:18.11.9"
     "@types/node-forge": "npm:1.3.0"
     "@types/ssh2": "npm:0.5.47"
     "@types/ssh2-streams": "npm:0.1.9"


### PR DESCRIPTION
1. The container management library that we use in the test infrastructure
(called dockerode) is expecting streams that are defined in the global
namespace of the `@types/node` library, e.g. the standard library of NodeJS
itself.
2. Previously we were using the "streams" package to provide type information
to the streams that we were passing around to dockerode and it was working
fine, but after some changes that seem unrelated this has broken the
compilation process.
3. The mentioned changes are not yet on the main branch, but we expect
them to be there soon and so this change is laying the groundwork for that
by pre-emptively fixing the broken build's root cause which is that the
test-tooling package does not declare it's typings related dependencies
correctly: It implicitly uses the NodeJS standard library's types but
so far had not declared them on the package level.
4. This change is therefore to rectify the issue of the `@types/node`
dependency missing from the test-tooling package and also the refactoring
of some of the test ledger classes which were relying on the `streams`
builtin package instead of correctly using the NodeJS.ReadableStream global.
5. Earlier the reasoning for this was that we try to avoid pulling in
types from the global scope because we try to avoid any sort of dependency
on the global scope in general. Once we have proof though that this is
causing issues with the build, then we must give up the principle for
practical reasons (and only in the minimum viable scope, e.g. this does
not change the fact that everywhere else in the codebase we should still
do our best to avoid using the global scoped classes, types, functions,
etc..).

Thank you to @AndreAugusto11 and @RafaelAPB for pointing out this issue
through the pull request of his that is currently being worked on at the
time of this writing:
https://github.com/RafaelAPB/blockchain-integration-framework/pull/72

Related to but does not address #2811

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.