### PR TITLE
build(deps): upgrade pkg openapi-types to v12.1.3 project-wide

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/package.json
+++ b/examples/cactus-example-carbon-accounting-backend/package.json
@@ -67,7 +67,7 @@
     "async-exit-hook": "2.0.1",
     "fabric-network": "2.2.20",
     "fs-extra": "10.1.0",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "typescript-optional": "2.0.1",
     "uuid": "8.3.2",
     "web3-core": "1.6.1",

--- a/examples/cactus-example-carbon-accounting-business-logic-plugin/package.json
+++ b/examples/cactus-example-carbon-accounting-business-logic-plugin/package.json
@@ -66,7 +66,7 @@
     "async-exit-hook": "2.0.1",
     "axios": "1.6.0",
     "express": "4.18.2",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "typescript-optional": "2.0.1",
     "uuid": "8.3.2"
   },

--- a/examples/cactus-example-cbdc-bridging-backend/package.json
+++ b/examples/cactus-example-cbdc-bridging-backend/package.json
@@ -78,7 +78,7 @@
     "knex": "2.5.1",
     "kubo-rpc-client": "3.0.1",
     "nyc": "13.1.0",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "sqlite3": "5.1.5",
     "typescript-optional": "2.0.1",
     "uuid": "8.3.2",

--- a/examples/cactus-example-supply-chain-backend/package.json
+++ b/examples/cactus-example-supply-chain-backend/package.json
@@ -72,7 +72,7 @@
     "express-jwt": "8.4.1",
     "fabric-network": "2.2.20",
     "jose": "4.9.2",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "solc": "0.8.6",
     "typescript-optional": "2.0.1",
     "uuid": "8.3.2",

--- a/examples/cactus-example-supply-chain-business-logic-plugin/package.json
+++ b/examples/cactus-example-supply-chain-business-logic-plugin/package.json
@@ -67,7 +67,7 @@
     "async-exit-hook": "2.0.1",
     "axios": "1.6.0",
     "express": "4.18.2",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "run-time-error-cjs": "1.4.0",
     "typescript-optional": "2.0.1",
     "uuid": "8.3.2"

--- a/extensions/cactus-plugin-htlc-coordinator-besu/package.json
+++ b/extensions/cactus-plugin-htlc-coordinator-besu/package.json
@@ -68,7 +68,7 @@
     "body-parser": "1.20.2",
     "fast-safe-stringify": "2.1.1",
     "joi": "14.3.1",
-    "openapi-types": "7.0.1",
+    "openapi-types": "12.1.3",
     "prom-client": "13.1.0",
     "run-time-error-cjs": "1.4.0",
     "socket.io-client-fixed-types": "4.5.4",

--- a/packages/cactus-plugin-htlc-eth-besu-erc20/package.json
+++ b/packages/cactus-plugin-htlc-eth-besu-erc20/package.json
@@ -67,7 +67,7 @@
     "axios": "1.6.0",
     "express": "4.18.2",
     "joi": "17.9.1",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "typescript-optional": "2.0.1"
   },
   "devDependencies": {

--- a/packages/cactus-plugin-htlc-eth-besu/package.json
+++ b/packages/cactus-plugin-htlc-eth-besu/package.json
@@ -78,7 +78,7 @@
     "ethers": "6.3.0",
     "express": "4.18.2",
     "joi": "17.9.1",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "typescript-optional": "2.0.1",
     "web3js-quorum": "22.4.0"
   },

--- a/packages/cactus-plugin-keychain-aws-sm/package.json
+++ b/packages/cactus-plugin-keychain-aws-sm/package.json
@@ -73,7 +73,7 @@
     "body-parser": "1.20.2",
     "express": "4.18.2",
     "internal-ip": "6.2.0",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "uuid": "9.0.1"
   },
   "engines": {

--- a/packages/cactus-plugin-keychain-azure-kv/package.json
+++ b/packages/cactus-plugin-keychain-azure-kv/package.json
@@ -77,7 +77,7 @@
     "body-parser": "1.20.2",
     "express": "4.18.2",
     "internal-ip": "6.2.0",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "uuid": "9.0.1"
   },
   "engines": {

--- a/packages/cactus-plugin-keychain-google-sm/package.json
+++ b/packages/cactus-plugin-keychain-google-sm/package.json
@@ -74,7 +74,7 @@
     "express": "4.18.2",
     "google-gax": "4.0.5",
     "internal-ip": "6.2.0",
-    "openapi-types": "9.1.0"
+    "openapi-types": "12.1.3"
   },
   "engines": {
     "node": ">=18",

--- a/packages/cactus-plugin-keychain-vault/package.json
+++ b/packages/cactus-plugin-keychain-vault/package.json
@@ -75,7 +75,7 @@
     "body-parser": "1.20.2",
     "express": "4.18.2",
     "internal-ip": "6.2.0",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "uuid": "9.0.1"
   },
   "engines": {

--- a/packages/cactus-plugin-ledger-connector-besu/package.json
+++ b/packages/cactus-plugin-ledger-connector-besu/package.json
@@ -61,7 +61,7 @@
     "express": "4.18.2",
     "http-errors": "2.0.0",
     "joi": "17.9.1",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "prom-client": "13.2.0",
     "run-time-error-cjs": "1.4.0",
     "rxjs": "7.8.1",

--- a/packages/cactus-plugin-ledger-connector-fabric/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/package.json
@@ -76,7 +76,7 @@
     "ngo": "2.7.0",
     "node-ssh": "13.1.0",
     "node-vault": "0.9.22",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "prom-client": "13.2.0",
     "run-time-error-cjs": "1.4.0",
     "rxjs": "7.8.1",

--- a/packages/cactus-plugin-ledger-connector-iroha/package.json
+++ b/packages/cactus-plugin-ledger-connector-iroha/package.json
@@ -65,7 +65,7 @@
     "fast-safe-stringify": "2.1.1",
     "iroha-helpers": "1.5.0",
     "key-encoder": "2.0.3",
-    "openapi-types": "7.0.1",
+    "openapi-types": "12.1.3",
     "prom-client": "13.1.0",
     "run-time-error-cjs": "1.4.0",
     "rxjs": "7.8.1",

--- a/packages/cactus-plugin-ledger-connector-polkadot/package.json
+++ b/packages/cactus-plugin-ledger-connector-polkadot/package.json
@@ -82,7 +82,7 @@
     "joi": "14.3.1",
     "multer": "1.4.2",
     "ngo": "2.6.2",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "prom-client": "13.2.0",
     "run-time-error": "1.4.0",
     "temp": "0.9.1",

--- a/packages/cactus-plugin-ledger-connector-xdai/package.json
+++ b/packages/cactus-plugin-ledger-connector-xdai/package.json
@@ -60,7 +60,7 @@
     "axios": "1.6.0",
     "express": "4.18.2",
     "joi": "17.9.1",
-    "openapi-types": "9.1.0",
+    "openapi-types": "12.1.3",
     "prom-client": "13.2.0",
     "run-time-error-cjs": "1.4.0",
     "typescript-optional": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7825,7 +7825,7 @@ __metadata:
     http-status-codes: 2.1.4
     jose: 4.9.2
     json-stable-stringify: 1.0.2
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     typescript-optional: 2.0.1
     uuid: 8.3.2
     web3-core: 1.6.1
@@ -7851,7 +7851,7 @@ __metadata:
     async-exit-hook: 2.0.1
     axios: 1.6.0
     express: 4.18.2
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     typescript-optional: 2.0.1
     uuid: 8.3.2
   languageName: unknown
@@ -7935,7 +7935,7 @@ __metadata:
     knex: 2.5.1
     kubo-rpc-client: 3.0.1
     nyc: 13.1.0
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     remix-tests: 0.1.34
     sqlite3: 5.1.5
     ts-node: 7.0.1
@@ -8085,7 +8085,7 @@ __metadata:
     express-jwt: 8.4.1
     fabric-network: 2.2.20
     jose: 4.9.2
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     solc: 0.8.6
     typescript-optional: 2.0.1
     uuid: 8.3.2
@@ -8112,7 +8112,7 @@ __metadata:
     async-exit-hook: 2.0.1
     axios: 1.6.0
     express: 4.18.2
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     run-time-error-cjs: 1.4.0
     typescript-optional: 2.0.1
     uuid: 8.3.2
@@ -8246,7 +8246,7 @@ __metadata:
     express: 4.18.2
     fast-safe-stringify: 2.1.1
     joi: 14.3.1
-    openapi-types: 7.0.1
+    openapi-types: 12.1.3
     prom-client: 13.1.0
     run-time-error-cjs: 1.4.0
     socket.io: 4.5.4
@@ -8270,7 +8270,7 @@ __metadata:
     axios: 1.6.0
     express: 4.18.2
     joi: 17.9.1
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     typescript-optional: 2.0.1
   languageName: unknown
   linkType: soft
@@ -8294,7 +8294,7 @@ __metadata:
     express: 4.18.2
     forge-std: "https://github.com/foundry-rs/forge-std.git#66bf4e2c92cf507531599845e8d5a08cc2e3b5bb"
     joi: 17.9.1
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     typescript-optional: 2.0.1
     web3js-quorum: 22.4.0
   languageName: unknown
@@ -8318,7 +8318,7 @@ __metadata:
     express: 4.18.2
     http-status-codes: 2.1.4
     internal-ip: 6.2.0
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     prom-client: 13.2.0
     typescript-optional: 2.0.1
     uuid: 9.0.1
@@ -8343,7 +8343,7 @@ __metadata:
     express: 4.18.2
     http-status-codes: 2.1.4
     internal-ip: 6.2.0
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     typescript-optional: 2.0.1
     uuid: 9.0.1
   languageName: unknown
@@ -8368,7 +8368,7 @@ __metadata:
     google-gax: 4.0.5
     http-status-codes: 2.1.4
     internal-ip: 6.2.0
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     typescript-optional: 2.0.1
     uuid: 9.0.1
   languageName: unknown
@@ -8430,7 +8430,7 @@ __metadata:
     http-status-codes: 2.1.4
     internal-ip: 6.2.0
     node-vault: 0.9.22
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     prom-client: 13.2.0
     typescript-optional: 2.0.1
     uuid: 9.0.1
@@ -8488,7 +8488,7 @@ __metadata:
     http-errors: 2.0.0
     joi: 17.9.1
     key-encoder: 2.0.3
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     prom-client: 13.2.0
     run-time-error-cjs: 1.4.0
     rxjs: 7.8.1
@@ -8636,7 +8636,7 @@ __metadata:
     ngo: 2.7.0
     node-ssh: 13.1.0
     node-vault: 0.9.22
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     prom-client: 13.2.0
     run-time-error-cjs: 1.4.0
     rxjs: 7.8.1
@@ -8742,7 +8742,7 @@ __metadata:
     internal-ip: 6.2.0
     iroha-helpers: 1.5.0
     key-encoder: 2.0.3
-    openapi-types: 7.0.1
+    openapi-types: 12.1.3
     prom-client: 13.1.0
     run-time-error-cjs: 1.4.0
     rxjs: 7.8.1
@@ -8788,7 +8788,7 @@ __metadata:
     joi: 14.3.1
     multer: 1.4.2
     ngo: 2.6.2
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     prom-client: 13.2.0
     run-time-error: 1.4.0
     supertest: 6.1.6
@@ -8924,7 +8924,7 @@ __metadata:
     body-parser: 1.20.2
     express: 4.18.2
     joi: 17.9.1
-    openapi-types: 9.1.0
+    openapi-types: 12.1.3
     prom-client: 13.2.0
     run-time-error-cjs: 1.4.0
     typescript-optional: 2.0.1
@@ -39975,20 +39975,6 @@ __metadata:
   version: 12.1.3
   resolution: "openapi-types@npm:12.1.3"
   checksum: 7fa5547f87a58d2aa0eba6e91d396f42d7d31bc3ae140e61b5d60b47d2fd068b48776f42407d5a8da7280cf31195aa128c2fc285e8bb871d1105edee5647a0bb
-  languageName: node
-  linkType: hard
-
-"openapi-types@npm:7.0.1":
-  version: 7.0.1
-  resolution: "openapi-types@npm:7.0.1"
-  checksum: c513edcb14c5d41e6b8ec63011cace8d13d2308b680784aac7fea4071ca958a576cee0b4f004b9cded8b31fe5c097ecc3802aa13c9ea03124b3545f37835dd0c
-  languageName: node
-  linkType: hard
-
-"openapi-types@npm:9.1.0":
-  version: 9.1.0
-  resolution: "openapi-types@npm:9.1.0"
-  checksum: 8ae57949c00ff70bc98b45d688fcdf848b9f2a44a3f70869d1cbd892dbac1d05f5f72350394ba1e254245090900722ce0fd305aadca0e9168cbfbf3a20b9df72
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The command used to perform this upgrade was:

`yarn up openapi-types --exact`

Simple quality of life improvement. The openapi-types package is used
mainly as a helper for dealing with Open API spec related logic in a
cleaner manner. It doesn't really affect the runtime behavior of the
code that much.
With all that said, it is worthwhile to consolidate the versions we use
because strange/hard to debug compiler bugs can (and do) emerge from
time to time just on account of us juggling multiple different versions
of certain libraries.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.