### PR TITLE
style(docs/examples/cbdc): applied auto-formatting to CBDC example code

### DIFF
--- a/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/besu-gateway.steps.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/besu-gateway.steps.ts
@@ -9,7 +9,12 @@ import {
 } from "../besu-helper";
 import AssetReferenceContractJson from "../../../../solidity/asset-reference-contract/AssetReferenceContract.json";
 import CBDCcontractJson from "../../../../solidity/cbdc-erc-20/CBDCcontract.json";
-import { getEthAddress, getPrvKey, assertEqual, assertStringContains } from "./common";
+import {
+  getEthAddress,
+  getPrvKey,
+  assertEqual,
+  assertStringContains,
+} from "./common";
 
 const BESU_CONTRACT_CBDC_ERC20_NAME = CBDCcontractJson.contractName;
 const BESU_CONTRACT_ASSET_REF_NAME = AssetReferenceContractJson.contractName;
@@ -156,7 +161,8 @@ Then(
       getPrvKey(user),
       assetRefID,
     ).catch((err) => {
-      assertStringContains(err.response.data.error,
+      assertStringContains(
+        err.response.data.error,
         `Transaction has been reverted by the EVM`,
       );
     });

--- a/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/bridge-back.steps.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/bridge-back.steps.ts
@@ -70,11 +70,7 @@ Then(
 Then(
   "{string} fails to initiate bridge back of {int} CBDC referenced by id {string}",
   { timeout: 60 * 1000 },
-  async function (
-    user: string,
-    amount: number,
-    assetRefID: string,
-  ) {
+  async function (user: string, amount: number, assetRefID: string) {
     const address = getEthAddress(user);
     const fabricID = getFabricId(user);
 

--- a/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/bridge-out.steps.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/bridge-out.steps.ts
@@ -1,7 +1,13 @@
 import { When, Then } from "cucumber";
 import axios from "axios";
 import CryptoMaterial from "../../../../crypto-material/crypto-material.json";
-import { getUserFromPseudonim, getFabricId, getEthAddress, assertEqual, assertStringContains } from "./common";
+import {
+  getUserFromPseudonim,
+  getFabricId,
+  getEthAddress,
+  assertEqual,
+  assertStringContains,
+} from "./common";
 
 const MAX_RETRIES = 5;
 const MAX_TIMEOUT = 5000;
@@ -87,7 +93,7 @@ When(
         recipientLedgerAssetID: "FABRIC_ASSET_ID",
       },
     );
-    
+
     assertEqual(response.status, 200);
   },
 );

--- a/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/common.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/common.ts
@@ -52,10 +52,7 @@ export function getPrvKey(user: string): string {
   }
 }
 
-export function assertEqual(
-  value_1: unknown,
-  value_2: unknown,
-) {
+export function assertEqual(value_1: unknown, value_2: unknown) {
   if (value_1 !== value_2) {
     throw Error(`Expected ${value_1} to be equal to ${value_2}`);
   }
@@ -66,7 +63,7 @@ export function assertStringContains(
   subString: string,
 ): void {
   if (!mainString.includes(subString)) {
-      throw new Error(`String "${mainString}" does not contain "${subString}"`);
+    throw new Error(`String "${mainString}" does not contain "${subString}"`);
   }
 }
 

--- a/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/fabric-gateway.steps.ts
+++ b/examples/cactus-example-cbdc-bridging-backend/src/test/typescript/cucumber/steps/fabric-gateway.steps.ts
@@ -7,7 +7,7 @@ import {
   getUserFromPseudonim,
   assertEqual,
   assertNonNullish,
-  assertStringContains
+  assertStringContains,
 } from "./common";
 import {
   deleteFabricAssetReference,
@@ -94,7 +94,7 @@ When(
 
 When(
   "bob refunds {int} CBDC to {string} in the source chain",
-    { timeout: 10 * 1000 },
+  { timeout: 10 * 1000 },
   async function (amount: number, userTo: string) {
     const finalUserFabricID = getFabricId(userTo);
     const finalUserEthAddress = getEthAddress(userTo);
@@ -123,14 +123,17 @@ Then(
         },
       )
       .catch((err) => {
-        assertStringContains(err.response.data.error, `client is not authorized to perform the operation`);
+        assertStringContains(
+          err.response.data.error,
+          `client is not authorized to perform the operation`,
+        );
       });
   },
 );
 
 Then(
   "{string} fails to transfer {int} CBDC to {string}",
-    { timeout: 10 * 1000 },
+  { timeout: 10 * 1000 },
   async function (userFrom: string, amount: number, userTo: string) {
     const recipient = getFabricId(userTo);
 
@@ -157,32 +160,32 @@ Then(
 
 Then(
   "{string} has {int} CBDC available in the source chain",
-    { timeout: 10 * 1000 },
+  { timeout: 10 * 1000 },
   async function (user: string, amount: number) {
-    assertEqual((await getFabricBalance(getFabricId(user))), amount)
+    assertEqual(await getFabricBalance(getFabricId(user)), amount);
   },
 );
 
 Then(
   "the asset reference chaincode has an asset reference with id {string}",
-    { timeout: 10 * 1000 },
+  { timeout: 10 * 1000 },
   async function (assetRefID: string) {
-    assertNonNullish((await readFabricAssetReference(assetRefID)));
+    assertNonNullish(await readFabricAssetReference(assetRefID));
   },
 );
 
 Then(
   "the asset reference with id {string} is locked in the source chain",
-    { timeout: 10 * 1000 },
+  { timeout: 10 * 1000 },
   async function (assetRefID: string) {
-    assertEqual((await readFabricAssetReference(assetRefID)).isLocked, true)
+    assertEqual((await readFabricAssetReference(assetRefID)).isLocked, true);
   },
 );
 
 Then(
   "the asset reference chaincode has no asset reference with id {string}",
-    { timeout: 10 * 1000 },
+  { timeout: 10 * 1000 },
   async function (assetRefID: string) {
-    assertEqual(await fabricAssetReferenceExists(assetRefID), "false")
+    assertEqual(await fabricAssetReferenceExists(assetRefID), "false");
   },
 );


### PR DESCRIPTION
Just ran `yarn lint` on `main` and it applied these formatting changes
so I'm applying the changes to make sure others don't have to deal with
the auto-formatter littering their commits with automated changes like
these.

The bigger story here is that this somehow passed the CI which makes me
suspect that we forgot to add a check to the lint action that would
verify that post-lint there are no files changed compared to the git
revision that is being linted, so figuring this out is a to-do still and
should go into it's own pull request later on.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.