### PR TITLE
build: upgrade & consolidate @types/node at v18.11.9 - NodeJS typings

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/src/utility-emissions-channel/typescript/package.json
+++ b/examples/cactus-example-carbon-accounting-backend/src/utility-emissions-channel/typescript/package.json
@@ -16,7 +16,7 @@
     "@types/chai": "4.3.5",
     "@types/crypto-js": "4.1.1",
     "@types/mocha": "8.2.2",
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "@types/rewire": "2.5.28",
     "chai": "4.3.7",
     "mocha": "8.4.0",

--- a/examples/cactus-example-cbdc-bridging-backend/package.json
+++ b/examples/cactus-example-cbdc-bridging-backend/package.json
@@ -91,7 +91,7 @@
     "@types/express": "4.17.19",
     "@types/express-jwt": "6.0.2",
     "@types/fs-extra": "9.0.13",
-    "@types/node": "10.17.60",
+    "@types/node": "18.11.9",
     "@types/uuid": "9.0.8",
     "cucumber": "5.0.3",
     "hardhat": "2.17.2",

--- a/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/asset-reference/typescript/package.json
+++ b/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/asset-reference/typescript/package.json
@@ -27,7 +27,7 @@
         "@types/chai": "^4.2.11",
         "@types/chai-as-promised": "^7.1.2",
         "@types/mocha": "^7.0.2",
-        "@types/node": "^13.13.52",
+        "@types/node": "18.11.9",
         "@types/sinon": "^7.5.2",
         "@types/sinon-chai": "^3.2.3",
         "chai": "^4.2.0",

--- a/examples/cactus-example-cbdc-bridging-frontend/package.json
+++ b/examples/cactus-example-cbdc-bridging-frontend/package.json
@@ -30,7 +30,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
-    "@types/node": "^16.18.66",
+    "@types/node": "18.11.9",
     "@types/react": "^18.2.39",
     "@types/react-dom": "^18.2.17",
     "axios": "1.6.0",

--- a/examples/cactus-example-discounted-asset-trade/package.json
+++ b/examples/cactus-example-discounted-asset-trade/package.json
@@ -22,7 +22,7 @@
     "@hyperledger/cactus-plugin-ledger-connector-aries": "2.0.0-alpha.2",
     "@hyperledger/cactus-plugin-ledger-connector-ethereum": "2.0.0-alpha.2",
     "@hyperledger/cactus-plugin-ledger-connector-fabric": "2.0.0-alpha.2",
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "axios": "1.6.0",
     "body-parser": "1.20.2",
     "cookie-parser": "1.4.6",

--- a/examples/cactus-example-electricity-trade/package.json
+++ b/examples/cactus-example-electricity-trade/package.json
@@ -21,7 +21,7 @@
     "@hyperledger/cactus-plugin-keychain-memory": "2.0.0-alpha.2",
     "@hyperledger/cactus-plugin-ledger-connector-ethereum": "2.0.0-alpha.2",
     "@hyperledger/cactus-plugin-ledger-connector-sawtooth": "2.0.0-alpha.2",
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "body-parser": "1.20.2",
     "cookie-parser": "1.4.6",
     "debug": "3.1.0",

--- a/examples/cactus-example-electricity-trade/tools/transferNumericAsset/package.json
+++ b/examples/cactus-example-electricity-trade/tools/transferNumericAsset/package.json
@@ -10,7 +10,7 @@
     "copy-static-assets": "ts-node copyStaticAssets.ts"
   },
   "dependencies": {
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "config": "1.31.0",
     "ethereumjs-common": "1.5.2",
     "ethereumjs-tx": "2.1.2",

--- a/examples/cactus-example-tcs-huawei/package.json
+++ b/examples/cactus-example-tcs-huawei/package.json
@@ -15,7 +15,7 @@
     "@hyperledger/cactus-cmd-socketio-server": "2.0.0-alpha.2",
     "@hyperledger/cactus-core-api": "2.0.0-alpha.2",
     "@hyperledger/cactus-verifier-client": "2.0.0-alpha.2",
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "@types/uuid": "9.0.8",
     "body-parser": "1.20.2",
     "cookie-parser": "1.4.6",

--- a/examples/cactus-example-tcs-huawei/tools/periodicExecuter/package.json
+++ b/examples/cactus-example-tcs-huawei/tools/periodicExecuter/package.json
@@ -9,7 +9,7 @@
     "tslint": "tslint -c tslint.json -p tsconfig.json"
   },
   "dependencies": {
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "ts-node": "9.1.1"
   },
   "devDependencies": {

--- a/examples/cactus-example-tcs-huawei/tools/transferNumericAsset/package.json
+++ b/examples/cactus-example-tcs-huawei/tools/transferNumericAsset/package.json
@@ -10,7 +10,7 @@
     "copy-static-assets": "ts-node copyStaticAssets.ts"
   },
   "dependencies": {
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "config": "1.31.0",
     "ethereumjs-common": "1.5.2",
     "ethereumjs-tx": "2.1.2",

--- a/examples/test-run-transaction/package.json
+++ b/examples/test-run-transaction/package.json
@@ -14,7 +14,7 @@
     "init-test-run-transaction": "ln -s ../examples/test-run-transaction/node_modules ../../dist/node_modules"
   },
   "dependencies": {
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "body-parser": "1.20.2",
     "cookie-parser": "1.4.6",
     "debug": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@types/benchmark": "2.1.5",
     "@types/fs-extra": "9.0.13",
     "@types/jest": "29.5.3",
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "@types/node-fetch": "2.6.4",
     "@types/tape": "4.13.4",
     "@types/tape-promise": "4.0.1",

--- a/packages/cactus-api-client/package.json
+++ b/packages/cactus-api-client/package.json
@@ -62,7 +62,7 @@
     "@hyperledger/cactus-test-tooling": "2.0.0-alpha.2",
     "@types/jsonwebtoken": "9.0.0",
     "@types/lodash": "4.14.195",
-    "@types/node": "20.8.10",
+    "@types/node": "18.11.9",
     "lodash": "4.17.21"
   },
   "engines": {

--- a/packages/cactus-cmd-socketio-server/package.json
+++ b/packages/cactus-cmd-socketio-server/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@hyperledger/cactus-common": "2.0.0-alpha.2",
     "@hyperledger/cactus-core-api": "2.0.0-alpha.2",
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "body-parser": "1.20.2",
     "config": "3.3.7",
     "cookie-parser": "1.4.5",
@@ -77,7 +77,7 @@
     "@types/jsonwebtoken": "9.0.0",
     "@types/lodash": "4.14.195",
     "@types/morgan": "1.9.1",
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "@types/shelljs": "0.8.11",
     "http-terminator": "3.2.0",
     "lodash": "4.17.21",

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/basic-asset-transfer/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/basic-asset-transfer/chaincode-typescript/package.json
@@ -27,7 +27,7 @@
     "devDependencies": {
         "@types/chai": "4.3.0",
         "@types/mocha": "5.2.7",
-        "@types/node": "10.17.60",
+        "@types/node": "18.11.9",
         "@types/sinon": "5.0.7",
         "@types/sinon-chai": "3.2.8",
         "chai": "4.3.6",

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/lock-asset/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/lock-asset/chaincode-typescript/package.json
@@ -27,7 +27,7 @@
     "devDependencies": {
         "@types/chai": "4.3.0",
         "@types/mocha": "5.2.7",
-        "@types/node": "10.17.60",
+        "@types/node": "18.11.9",
         "@types/sinon": "5.0.7",
         "@types/sinon-chai": "3.2.8",
         "chai": "4.3.6",

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@hyperledger/cactus-cmd-socketio-server": "2.0.0-alpha.2",
     "@hyperledger/cactus-common": "2.0.0-alpha.2",
-    "@types/node": "15.14.9",
+    "@types/node": "18.11.9",
     "body-parser": "1.20.2",
     "config": "3.3.9",
     "cookie-parser": "1.4.6",
@@ -74,7 +74,7 @@
     "@types/cookie-parser": "1.4.5",
     "@types/express": "4.17.19",
     "@types/http-errors": "2.0.1",
-    "@types/node": "15.14.9",
+    "@types/node": "18.11.9",
     "@types/shelljs": "0.8.12",
     "shelljs": "0.8.5",
     "socket.io-client-fixed-types": "4.5.4"

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/package.json
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/package.json
@@ -10,7 +10,7 @@
     "copy-static-assets": "ts-node copyStaticAssets.ts"
   },
   "dependencies": {
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "config": "1.31.0",
     "ethereumjs-common": "1.5.2",
     "ethereumjs-tx": "2.1.2",

--- a/packages/cactus-plugin-ledger-connector-tcs-huawei-socketio/package.json
+++ b/packages/cactus-plugin-ledger-connector-tcs-huawei-socketio/package.json
@@ -46,7 +46,7 @@
     "start": "cd ./dist && node common/core/bin/www.js"
   },
   "dependencies": {
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "body-parser": "1.20.2",
     "cbor": "6.0.1",
     "config": "3.3.7",

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/fabric-contracts/lock-asset/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/fabric-contracts/lock-asset/chaincode-typescript/package.json
@@ -27,7 +27,7 @@
     "devDependencies": {
         "@types/chai": "4.3.0",
         "@types/mocha": "5.2.7",
-        "@types/node": "10.17.60",
+        "@types/node": "18.11.9",
         "@types/sinon": "5.0.7",
         "@types/sinon-chai": "3.2.8",
         "chai": "4.3.6",

--- a/packages/cactus-test-verifier-client/package.json
+++ b/packages/cactus-test-verifier-client/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@types/body-parser": "1.19.4",
     "@types/express": "4.17.19",
-    "@types/node": "14.18.54",
+    "@types/node": "18.11.9",
     "@types/uuid": "9.0.8",
     "uuid": "9.0.1",
     "web3-eth-accounts": "4.0.3"

--- a/weaver/core/drivers/fabric-driver/package-local.json
+++ b/weaver/core/drivers/fabric-driver/package-local.json
@@ -31,7 +31,7 @@
         "winston": "3.10.0"
     },
     "devDependencies": {
-        "@types/node": "16.18.41",
+        "@types/node": "18.11.9",
         "nodemon": "2.0.22",
         "patch-package": "6.5.1",
         "typedoc": "0.25.6",

--- a/weaver/core/drivers/fabric-driver/package.json
+++ b/weaver/core/drivers/fabric-driver/package.json
@@ -31,7 +31,7 @@
     "winston": "3.10.0"
   },
   "devDependencies": {
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "nodemon": "2.0.22",
     "patch-package": "6.5.1",
     "typedoc": "0.25.6",

--- a/weaver/core/identity-management/iin-agent/package-local.json
+++ b/weaver/core/identity-management/iin-agent/package-local.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jsrsasign": "10.5.11",
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "@types/uuid": "9.0.6",
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",

--- a/weaver/core/identity-management/iin-agent/package.json
+++ b/weaver/core/identity-management/iin-agent/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jsrsasign": "10.5.11",
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "@types/uuid": "9.0.8",
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",

--- a/weaver/samples/besu/besu-cli/package-local.json
+++ b/weaver/samples/besu/besu-cli/package-local.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.3",
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "jest": "29.6.2",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",

--- a/weaver/samples/besu/besu-cli/package.json
+++ b/weaver/samples/besu/besu-cli/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.3",
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "jest": "29.6.2",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",

--- a/weaver/samples/fabric/fabric-cli/package-local.json
+++ b/weaver/samples/fabric/fabric-cli/package-local.json
@@ -59,7 +59,7 @@
     "@grpc/proto-loader": "0.7.8",
     "@types/express": "4.17.19",
     "@types/jest": "29.5.3",
-    "@types/node": "12.20.55",
+    "@types/node": "18.11.9",
     "google-protobuf": "3.21.2",
     "jest": "29.6.2",
     "pkg": "4.5.1",

--- a/weaver/samples/fabric/fabric-cli/package.json
+++ b/weaver/samples/fabric/fabric-cli/package.json
@@ -59,7 +59,7 @@
     "@grpc/proto-loader": "0.7.8",
     "@types/express": "4.17.19",
     "@types/jest": "29.5.3",
-    "@types/node": "12.20.55",
+    "@types/node": "18.11.9",
     "google-protobuf": "3.21.2",
     "jest": "29.6.2",
     "pkg": "4.5.1",

--- a/weaver/sdks/besu/node/package-local.json
+++ b/weaver/sdks/besu/node/package-local.json
@@ -20,7 +20,7 @@
     "web3-utils": "1.10.0"
   },
   "devDependencies": {
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
     "mocha": "5.2.0",

--- a/weaver/sdks/besu/node/package.json
+++ b/weaver/sdks/besu/node/package.json
@@ -20,7 +20,7 @@
     "web3-utils": "1.10.0"
   },
   "devDependencies": {
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
     "mocha": "5.2.0",

--- a/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
+++ b/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
@@ -53,7 +53,7 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
     "mocha": "5.2.0",

--- a/weaver/sdks/fabric/interoperation-node-sdk/package.json
+++ b/weaver/sdks/fabric/interoperation-node-sdk/package.json
@@ -53,7 +53,7 @@
     "uuid": "9.0.1"
   },
   "devDependencies": {
-    "@types/node": "16.18.41",
+    "@types/node": "18.11.9",
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
     "mocha": "5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7233,7 +7233,7 @@ __metadata:
     "@testing-library/react": "npm:^13.4.0"
     "@testing-library/user-event": "npm:^13.5.0"
     "@types/jest": "npm:^27.5.2"
-    "@types/node": "npm:^16.18.66"
+    "@types/node": "npm:18.11.9"
     "@types/react": "npm:^18.2.39"
     "@types/react-dom": "npm:^18.2.17"
     "@types/uuid": "npm:9.0.8"
@@ -7305,7 +7305,7 @@ __metadata:
     "@hyperledger/cacti-weaver-sdk-besu": "npm:2.0.0-alpha.2"
     "@truffle/contract": "npm:4.6.28"
     "@types/jest": "npm:29.5.3"
-    "@types/node": "npm:16.18.41"
+    "@types/node": "npm:18.11.9"
     gluegun: "npm:5.1.6"
     jest: "npm:29.6.2"
     ts-jest: "npm:29.1.1"
@@ -7358,7 +7358,7 @@ __metadata:
     "@grpc/grpc-js": "npm:1.9.5"
     "@hyperledger/cacti-weaver-protos-js": "npm:2.0.0-alpha.2"
     "@hyperledger/cacti-weaver-sdk-fabric": "npm:2.0.0-alpha.2"
-    "@types/node": "npm:16.18.41"
+    "@types/node": "npm:18.11.9"
     dotenv: "npm:8.6.0"
     fabric-ca-client: "npm:2.2.20"
     fabric-common: "npm:2.2.20"
@@ -7384,7 +7384,7 @@ __metadata:
     "@hyperledger/cacti-weaver-sdk-fabric": "npm:2.0.0-alpha.2"
     "@types/express": "npm:4.17.19"
     "@types/jest": "npm:29.5.3"
-    "@types/node": "npm:12.20.55"
+    "@types/node": "npm:18.11.9"
     body-parser: "npm:1.20.2"
     crypto: "npm:1.0.1"
     dotenv: "npm:8.6.0"
@@ -7421,7 +7421,7 @@ __metadata:
     "@hyperledger/cacti-weaver-protos-js": "npm:2.0.0-alpha.2"
     "@hyperledger/cacti-weaver-sdk-fabric": "npm:2.0.0-alpha.2"
     "@types/jsrsasign": "npm:10.5.11"
-    "@types/node": "npm:16.18.41"
+    "@types/node": "npm:18.11.9"
     "@types/uuid": "npm:9.0.8"
     chai: "npm:4.3.7"
     chai-as-promised: "npm:7.1.1"
@@ -7462,7 +7462,7 @@ __metadata:
   resolution: "@hyperledger/cacti-weaver-sdk-besu@workspace:weaver/sdks/besu/node"
   dependencies:
     "@hyperledger/cacti-weaver-protos-js": "npm:2.0.0-alpha.2"
-    "@types/node": "npm:16.18.41"
+    "@types/node": "npm:18.11.9"
     chai: "npm:4.3.7"
     chai-as-promised: "npm:7.1.1"
     log4js: "npm:6.9.1"
@@ -7486,7 +7486,7 @@ __metadata:
     "@grpc/grpc-js": "npm:1.9.5"
     "@grpc/proto-loader": "npm:0.7.8"
     "@hyperledger/cacti-weaver-protos-js": "npm:2.0.0-alpha.2"
-    "@types/node": "npm:16.18.41"
+    "@types/node": "npm:18.11.9"
     chai: "npm:4.3.7"
     chai-as-promised: "npm:7.1.1"
     elliptic: "npm:6.5.4"
@@ -7522,7 +7522,7 @@ __metadata:
     "@hyperledger/cactus-test-tooling": "npm:2.0.0-alpha.2"
     "@types/jsonwebtoken": "npm:9.0.0"
     "@types/lodash": "npm:4.14.195"
-    "@types/node": "npm:20.8.10"
+    "@types/node": "npm:18.11.9"
     jsonwebtoken: "npm:9.0.0"
     lodash: "npm:4.17.21"
     rxjs: "npm:7.8.1"
@@ -7615,7 +7615,7 @@ __metadata:
     "@types/jsonwebtoken": "npm:9.0.0"
     "@types/lodash": "npm:4.14.195"
     "@types/morgan": "npm:1.9.1"
-    "@types/node": "npm:14.18.54"
+    "@types/node": "npm:18.11.9"
     "@types/shelljs": "npm:0.8.11"
     body-parser: "npm:1.20.2"
     config: "npm:3.3.7"
@@ -7842,7 +7842,7 @@ __metadata:
     "@types/express": "npm:4.17.19"
     "@types/express-jwt": "npm:6.0.2"
     "@types/fs-extra": "npm:9.0.13"
-    "@types/node": "npm:10.17.60"
+    "@types/node": "npm:18.11.9"
     "@types/uuid": "npm:9.0.8"
     async-exit-hook: "npm:2.0.1"
     axios: "npm:1.6.0"
@@ -7909,7 +7909,7 @@ __metadata:
     "@types/express": "npm:4.17.19"
     "@types/jsonwebtoken": "npm:9.0.2"
     "@types/jsrsasign": "npm:10.5.8"
-    "@types/node": "npm:14.18.54"
+    "@types/node": "npm:18.11.9"
     "@types/uuid": "npm:9.0.8"
     axios: "npm:1.6.0"
     body-parser: "npm:1.20.2"
@@ -7950,7 +7950,7 @@ __metadata:
     "@hyperledger/cactus-plugin-ledger-connector-sawtooth": "npm:2.0.0-alpha.2"
     "@types/escape-html": "npm:1.0.1"
     "@types/express": "npm:4.17.19"
-    "@types/node": "npm:14.18.54"
+    "@types/node": "npm:18.11.9"
     "@types/uuid": "npm:9.0.8"
     body-parser: "npm:1.20.2"
     cookie-parser: "npm:1.4.6"
@@ -8090,7 +8090,7 @@ __metadata:
     "@types/cookie-parser": "npm:1.4.2"
     "@types/escape-html": "npm:1.0.1"
     "@types/express": "npm:4.17.19"
-    "@types/node": "npm:14.18.54"
+    "@types/node": "npm:18.11.9"
     "@types/uuid": "npm:9.0.8"
     body-parser: "npm:1.20.2"
     cookie-parser: "npm:1.4.6"
@@ -8575,7 +8575,7 @@ __metadata:
     "@types/cookie-parser": "npm:1.4.5"
     "@types/express": "npm:4.17.19"
     "@types/http-errors": "npm:2.0.1"
-    "@types/node": "npm:15.14.9"
+    "@types/node": "npm:18.11.9"
     "@types/shelljs": "npm:0.8.12"
     body-parser: "npm:1.20.2"
     config: "npm:3.3.9"
@@ -8780,7 +8780,7 @@ __metadata:
     "@types/cookie-parser": "npm:1.4.5"
     "@types/express": "npm:4.17.19"
     "@types/http-errors": "npm:2.0.1"
-    "@types/node": "npm:14.18.54"
+    "@types/node": "npm:18.11.9"
     body-parser: "npm:1.20.2"
     cbor: "npm:6.0.1"
     config: "npm:3.3.7"
@@ -9222,7 +9222,7 @@ __metadata:
     "@hyperledger/cactus-verifier-client": "npm:2.0.0-alpha.2"
     "@types/body-parser": "npm:1.19.4"
     "@types/express": "npm:4.17.19"
-    "@types/node": "npm:14.18.54"
+    "@types/node": "npm:18.11.9"
     "@types/uuid": "npm:9.0.8"
     body-parser: "npm:1.20.2"
     express: "npm:4.18.2"
@@ -9315,7 +9315,7 @@ __metadata:
     "@types/benchmark": "npm:2.1.5"
     "@types/fs-extra": "npm:9.0.13"
     "@types/jest": "npm:29.5.3"
-    "@types/node": "npm:16.18.41"
+    "@types/node": "npm:18.11.9"
     "@types/node-fetch": "npm:2.6.4"
     "@types/tape": "npm:4.13.4"
     "@types/tape-promise": "npm:4.0.1"
@@ -15250,41 +15250,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:10.17.60, @types/node@npm:^10.1.0":
-  version: 10.17.60
-  resolution: "@types/node@npm:10.17.60"
-  checksum: 10/f9161493b3284b1d41d5d594c2768625acdd9e33f992f71ccde47861916e662e2ae438d2cc5f1b285053391a31b52a7564ecedc22d485610d236bfad9c7e6a1c
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:12.20.55, @types/node@npm:^12.12.6":
-  version: 12.20.55
-  resolution: "@types/node@npm:12.20.55"
-  checksum: 10/1f916a06fff02faadb09a16ed6e31820ce170798b202ef0b14fc244bfbd721938c54a3a99836e185e4414ca461fe96c5bb5c67c3d248f153555b7e6347f061dd
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:14.18.54":
-  version: 14.18.54
-  resolution: "@types/node@npm:14.18.54"
-  checksum: 10/097e1f786813d7f55288b3b4cf81d831c2e43c4217eb366ece0deb2544324e9c0054f5e47605f74890d0d880bfc67e1a1d606abc481a4e409a999b21af2f8a46
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:15.14.9":
-  version: 15.14.9
-  resolution: "@types/node@npm:15.14.9"
-  checksum: 10/5c9cc5346ca0c565e02f11ae605911aa0892134099a5c730f49b4662635e5fbbbbeb24b2b56752ee14f092d1ca90837a35de428b9e243d7ab63c5907bfb07d89
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:16.18.41":
-  version: 16.18.41
-  resolution: "@types/node@npm:16.18.41"
-  checksum: 10/2dd7b16b39b6f8c00a2ee388f7a8e4d8408f4ddd080fd8c322f5284f9f17ee5aeaa4c021ae5148f80fe7def2967c92816c24e73a86d6d018fc6b98b79eb2b723
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:18.11.9":
   version: 18.11.9
   resolution: "@types/node@npm:18.11.9"
@@ -15306,19 +15271,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:20.8.10":
-  version: 20.8.10
-  resolution: "@types/node@npm:20.8.10"
-  dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10/8930039077c8ad74de74c724909412bea8110c3f8892bcef8dda3e9629073bed65632ee755f94b252bcdae8ca71cf83e89a4a440a105e2b1b7c9797b43483049
+"@types/node@npm:^10.1.0":
+  version: 10.17.60
+  resolution: "@types/node@npm:10.17.60"
+  checksum: 10/f9161493b3284b1d41d5d594c2768625acdd9e33f992f71ccde47861916e662e2ae438d2cc5f1b285053391a31b52a7564ecedc22d485610d236bfad9c7e6a1c
   languageName: node
   linkType: hard
 
-"@types/node@npm:^16.18.66":
-  version: 16.18.66
-  resolution: "@types/node@npm:16.18.66"
-  checksum: 10/992b264562c11de1332f8fe637c4b5d3df986348b972a57d09eca33db7b7d9abf5d348e70c37a4f05e42a717820bb7d5120b9a5a956fd0f975296a8fd910f2b5
+"@types/node@npm:^12.12.6":
+  version: 12.20.55
+  resolution: "@types/node@npm:12.20.55"
+  checksum: 10/1f916a06fff02faadb09a16ed6e31820ce170798b202ef0b14fc244bfbd721938c54a3a99836e185e4414ca461fe96c5bb5c67c3d248f153555b7e6347f061dd
   languageName: node
   linkType: hard
 
@@ -49607,13 +49570,6 @@ __metadata:
   version: 2.0.5
   resolution: "undefsafe@npm:2.0.5"
   checksum: 10/f42ab3b5770fedd4ada175fc1b2eb775b78f609156f7c389106aafd231bfc210813ee49f54483d7191d7b76e483bc7f537b5d92d19ded27156baf57592eb02cc
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~5.26.4":
-  version: 5.26.5
-  resolution: "undici-types@npm:5.26.5"
-  checksum: 10/0097779d94bc0fd26f0418b3a05472410408877279141ded2bd449167be1aed7ea5b76f756562cb3586a07f251b90799bab22d9019ceba49c037c76445f7cddd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. The default/suggested NodeJS version we use and recommend is v18 LTS
but there were a lot of places in the code that still declared v14 and
v16 both of which are now EOL.
2. This was/is working fine but eventually we'll hit some compiler issue
where the upgrade will be forced so it's most likely wiser to do this little
quality of life/housekeeping change now when it's not urgent.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.