### PR TITLE
tools: fix scripts - use run-time-error instead of run-time-error-cjs

### DIFF
--- a/tools/bump-openapi-spec-dep-versions.ts
+++ b/tools/bump-openapi-spec-dep-versions.ts
@@ -5,7 +5,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import fs from "fs-extra";
 import { globby, Options as GlobbyOptions } from "globby";
-import { RuntimeError } from "run-time-error-cjs";
+import { RuntimeError } from "run-time-error";
 import prettier from "prettier";
 import { OpenAPIV3_1 } from "openapi-types";
 import { isValidSemVer } from "semver-parser";

--- a/tools/create-production-only-archive.ts
+++ b/tools/create-production-only-archive.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "url";
 import { deleteAsync } from "del";
 import fs from "fs-extra";
 import { globby, Options as GlobbyOptions } from "globby";
-import { RuntimeError } from "run-time-error-cjs";
+import { RuntimeError } from "run-time-error";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { simpleGit, SimpleGit, SimpleGitOptions } from "simple-git";

--- a/tools/generate-sbom.ts
+++ b/tools/generate-sbom.ts
@@ -5,7 +5,7 @@ import { promisify } from "util";
 import { exec, ExecOptions } from "child_process";
 import fs from "fs-extra";
 import { globby, Options as GlobbyOptions } from "globby";
-import { RuntimeError } from "run-time-error-cjs";
+import { RuntimeError } from "run-time-error";
 import fastSafeStringify from "fast-safe-stringify";
 import { INpmListDependencyV1, npmList } from "./npm-list";
 

--- a/tools/get-latest-sem-ver-git-tag.ts
+++ b/tools/get-latest-sem-ver-git-tag.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { fileURLToPath } from "url"
 import { simpleGit, SimpleGit, SimpleGitOptions } from "simple-git";
 import { compareSemVer, isValidSemVer } from "semver-parser";
-import { RuntimeError } from "run-time-error-cjs";
+import { RuntimeError } from "run-time-error";
 
 const TAG = "[tools/get-latest-sem-ver-git-tag.ts]";
 

--- a/tools/npm-list.ts
+++ b/tools/npm-list.ts
@@ -2,7 +2,7 @@ import { ExecOptions, exec } from "child_process";
 import { promisify } from "util";
 
 import fastSafeStringify from "fast-safe-stringify";
-import { RuntimeError } from "run-time-error-cjs";
+import { RuntimeError } from "run-time-error";
 import { hasKey } from "./has-key";
 
 const execAsync = promisify(exec);

--- a/tools/sync-npm-deps-to-tsc-projects.ts
+++ b/tools/sync-npm-deps-to-tsc-projects.ts
@@ -4,7 +4,7 @@ import path from "path";
 import JSON5 from "json5";
 import fs from "fs-extra";
 import { globby, Options as GlobbyOptions } from "globby";
-import { RuntimeError } from "run-time-error-cjs";
+import { RuntimeError } from "run-time-error";
 import { readFile } from "fs/promises";
 
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
1. The `-cjs` version of the package was put into place because in the
production packages we needed it to be able to import the dependency
despite us not using ESM just yet.
2. We did a blanket search and replace at the time which seemed like a
good idea but turns out it wasn't because there are some tooling scripts
(the ones in this diff) that are already using ESM and for those the
-cjs flavored package started breaking the code.
3. So this change is just a partial/selective/surgical revert of the
earlier project-wide migratin from run-time-error to run-time-error-cjs.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.