### PR TITLE
test(connector-fabric): move integration tests to use Fabric v2.5.6 AIO

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/delegate-signing-methods.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/delegate-signing-methods.test.ts
@@ -7,9 +7,6 @@
 //////////////////////////////////
 
 // Ledger settings
-const imageName = "ghcr.io/hyperledger/cactus-fabric2-all-in-one";
-const imageVersion = "2021-09-02--fix-876-supervisord-retries";
-const fabricEnvVersion = "2.2.0";
 const fabricEnvCAVersion = "1.4.9";
 const ledgerChannelName = "mychannel";
 const assetTradeContractName = "copyAssetTrade";
@@ -47,6 +44,9 @@ import { PluginRegistry } from "@hyperledger/cactus-core";
 import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory";
 import {
   Containers,
+  DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -97,15 +97,20 @@ describe("Delegated signing tests", () => {
 
     // Start Ledger
     log.info("Start FabricTestLedgerV1...");
-    log.debug("Version:", fabricEnvVersion, "CA Version:", fabricEnvCAVersion);
+    log.debug(
+      "Fabric Version:",
+      FABRIC_25_LTS_AIO_FABRIC_VERSION,
+      "CA Version:",
+      fabricEnvCAVersion,
+    );
     ledger = new FabricTestLedgerV1({
       emitContainerLogs: false,
       publishAllPorts: true,
       logLevel: testLogLevel,
-      imageName,
-      imageVersion,
+      imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
+      imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
       envVars: new Map([
-        ["FABRIC_VERSION", fabricEnvVersion],
+        ["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION],
         ["CA_VERSION", fabricEnvCAVersion],
         ["CACTUS_FABRIC_TEST_LOOSE_MEMBERSHIP", "1"],
       ]),
@@ -336,7 +341,7 @@ describe("Delegated signing tests", () => {
       expect(initQueryResponse.status).toEqual(200);
       const initQueryOutput = JSON.parse(initQueryResponse.data.functionOutput);
       expect(initQueryOutput["ID"]).toEqual("asset1");
-      expect(initQueryOutput["owner"]).not.toEqual(newAssetOwner);
+      expect(initQueryOutput["Owner"]).not.toEqual(newAssetOwner);
 
       // Transfer ownership
       const sendResponse = await apiClient.runTransactionV1({
@@ -367,7 +372,7 @@ describe("Delegated signing tests", () => {
       expect(queryResponse.status).toEqual(200);
       const queryOutput = JSON.parse(queryResponse.data.functionOutput);
       expect(queryOutput["ID"]).toEqual("asset1");
-      expect(queryOutput["owner"]).toEqual(newAssetOwner);
+      expect(queryOutput["Owner"]).toEqual(newAssetOwner);
     },
     testTimeout,
   );
@@ -392,7 +397,7 @@ describe("Delegated signing tests", () => {
     expect(initQueryResponse.status).toEqual(200);
     const initQueryOutput = JSON.parse(initQueryResponse.data.functionOutput);
     expect(initQueryOutput["ID"]).toEqual("asset1");
-    expect(initQueryOutput["owner"]).not.toEqual(newAssetOwner);
+    expect(initQueryOutput["Owner"]).not.toEqual(newAssetOwner);
     checkMockSigningCallbacksAndClear(initQueryId, 2);
 
     // Transfer ownership
@@ -433,7 +438,7 @@ describe("Delegated signing tests", () => {
     expect(queryResponse.status).toEqual(200);
     const queryOutput = JSON.parse(queryResponse.data.functionOutput);
     expect(queryOutput["ID"]).toEqual("asset1");
-    expect(queryOutput["owner"]).toEqual(newAssetOwner);
+    expect(queryOutput["Owner"]).toEqual(newAssetOwner);
     checkMockSigningCallbacksAndClear(finalQueryId, 2);
   });
 

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts
@@ -11,8 +11,10 @@ import bodyParser from "body-parser";
 
 import {
   Containers,
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -42,7 +44,7 @@ import { Configuration } from "@hyperledger/cactus-core-api";
 import { DEFAULT_FABRIC_2_AIO_IMAGE_NAME } from "@hyperledger/cactus-test-tooling";
 
 const testCase = "deploys Fabric 2.x contract from go source";
-const logLevel: LogLevelDesc = "TRACE";
+const logLevel: LogLevelDesc = "INFO";
 
 test("BEFORE " + testCase, async (t: Test) => {
   const pruning = pruneDockerAllIfGithubAction({ logLevel });
@@ -62,8 +64,8 @@ test(testCase, async (t: Test) => {
     emitContainerLogs: true,
     publishAllPorts: true,
     imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-    imageVersion: DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-    envVars: new Map([["FABRIC_VERSION", DEFAULT_FABRIC_2_AIO_FABRIC_VERSION]]),
+    imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
+    envVars: new Map([["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION]]),
     logLevel,
   });
 
@@ -106,50 +108,13 @@ test(testCase, async (t: Test) => {
     asLocalhost: true,
   };
 
-  // This is the directory structure of the Fabirc 2.x CLI container (fabric-tools image)
-  // const orgCfgDir = "/fabric-samples/test-network/organizations/";
-  const orgCfgDir =
-    "/opt/gopath/src/github.com/hyperledger/fabric/peer/organizations/";
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org1Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org1MSP",
-
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt`,
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp`,
-    CORE_PEER_ADDRESS: "peer0.org1.example.com:7051",
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org2Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org2MSP",
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    CORE_PEER_ADDRESS: "peer0.org2.example.com:9051",
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp`,
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt`,
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
   const pluginOptions: IPluginLedgerConnectorFabricOptions = {
     instanceId: uuidv4(),
     dockerBinary: "/usr/local/bin/docker",
     peerBinary: "/fabric-samples/bin/peer",
     goBinary: "/usr/local/go/bin/go",
     pluginRegistry,
-    cliContainerEnv: org1Env,
+    cliContainerEnv: FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
     sshConfig,
     logLevel,
     connectionProfile,
@@ -225,8 +190,12 @@ test(testCase, async (t: Test) => {
     // constructorArgs: { Args: ["john", "99"] },
     sourceFiles: [assetTransferGo, smartContractGo, goMod, goSum],
     ccName: contractName,
-    targetOrganizations: [org1Env, org2Env],
-    caFile: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
+    targetOrganizations: [
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
+    ],
+    caFile:
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1.ORDERER_TLS_ROOTCERT_FILE,
     ccLabel: "basic-asset-transfer-2",
     ccLang: ChainCodeProgrammingLanguage.Golang,
     ccSequence: 1,
@@ -272,13 +241,6 @@ test(testCase, async (t: Test) => {
   // Checks.truthy(init, `init truthy OK`);
   Checks.truthy(packaging, `packaging truthy OK`);
   Checks.truthy(queryCommitted, `queryCommitted truthy OK`);
-
-  // FIXME - without this wait it randomly fails with an error claiming that
-  // the endorsement was impossible to be obtained. The fabric-samples script
-  // does the same thing, it just waits 10 seconds for good measure so there
-  // might not be a way for us to avoid doing this, but if there is a way we
-  // absolutely should not have timeouts like this, anywhere...
-  await new Promise((resolve) => setTimeout(resolve, 10000));
 
   const assetId = uuidv4();
   const assetOwner = uuidv4();

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
@@ -11,9 +11,11 @@ import bodyParser from "body-parser";
 
 import {
   Containers,
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -65,8 +67,8 @@ test(testCase, async (t: Test) => {
     emitContainerLogs: true,
     publishAllPorts: true,
     imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-    imageVersion: DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-    envVars: new Map([["FABRIC_VERSION", DEFAULT_FABRIC_2_AIO_FABRIC_VERSION]]),
+    imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
+    envVars: new Map([["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION]]),
     logLevel,
   });
   const tearDown = async () => {
@@ -108,50 +110,13 @@ test(testCase, async (t: Test) => {
     asLocalhost: true,
   };
 
-  // This is the directory structure of the Fabirc 2.x CLI container (fabric-tools image)
-  // const orgCfgDir = "/fabric-samples/test-network/organizations/";
-  const orgCfgDir =
-    "/opt/gopath/src/github.com/hyperledger/fabric/peer/organizations/";
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org1Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org1MSP",
-
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt`,
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp`,
-    CORE_PEER_ADDRESS: "peer0.org1.example.com:7051",
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org2Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org2MSP",
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    CORE_PEER_ADDRESS: "peer0.org2.example.com:9051",
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp`,
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt`,
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
   const pluginOptions: IPluginLedgerConnectorFabricOptions = {
     instanceId: uuidv4(),
     dockerBinary: "/usr/local/bin/docker",
     peerBinary: "/fabric-samples/bin/peer",
     goBinary: "/usr/local/go/bin/go",
     pluginRegistry,
-    cliContainerEnv: org1Env,
+    cliContainerEnv: FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
     sshConfig,
     logLevel,
     connectionProfile,
@@ -235,8 +200,12 @@ test(testCase, async (t: Test) => {
     // constructorArgs: { Args: ["john", "99"] },
     sourceFiles,
     ccName: contractName,
-    targetOrganizations: [org1Env, org2Env],
-    caFile: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
+    targetOrganizations: [
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
+    ],
+    caFile:
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1.ORDERER_TLS_ROOTCERT_FILE,
     ccLabel: "basic-asset-transfer-2",
     ccLang: ChainCodeProgrammingLanguage.Javascript,
     ccSequence: 1,
@@ -281,13 +250,6 @@ test(testCase, async (t: Test) => {
   Checks.truthy(commit, `commit truthy OK`);
   Checks.truthy(packaging, `packaging truthy OK`);
   Checks.truthy(queryCommitted, `queryCommitted truthy OK`);
-
-  // FIXME - without this wait it randomly fails with an error claiming that
-  // the endorsement was impossible to be obtained. The fabric-samples script
-  // does the same thing, it just waits 10 seconds for good measure so there
-  // might not be a way for us to avoid doing this, but if there is a way we
-  // absolutely should not have timeouts like this, anywhere...
-  await new Promise((resolve) => setTimeout(resolve, 30000));
 
   const assetId = uuidv4();
   const assetOwner = uuidv4();

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-typescript-source.test.ts
@@ -11,9 +11,11 @@ import bodyParser from "body-parser";
 
 import {
   Containers,
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -43,7 +45,7 @@ import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory
 import { Configuration } from "@hyperledger/cactus-core-api";
 
 const testCase = "deploys Fabric 2.x contract from typescript source";
-const logLevel: LogLevelDesc = "TRACE";
+const logLevel: LogLevelDesc = "INFO";
 
 test("BEFORE " + testCase, async (t: Test) => {
   const pruning = pruneDockerAllIfGithubAction({ logLevel });
@@ -63,8 +65,8 @@ test(testCase, async (t: Test) => {
     emitContainerLogs: true,
     publishAllPorts: true,
     imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-    imageVersion: DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-    envVars: new Map([["FABRIC_VERSION", DEFAULT_FABRIC_2_AIO_FABRIC_VERSION]]),
+    imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
+    envVars: new Map([["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION]]),
     logLevel,
   });
   const tearDown = async () => {
@@ -106,50 +108,13 @@ test(testCase, async (t: Test) => {
     asLocalhost: true,
   };
 
-  // This is the directory structure of the Fabirc 2.x CLI container (fabric-tools image)
-  // const orgCfgDir = "/fabric-samples/test-network/organizations/";
-  const orgCfgDir =
-    "/opt/gopath/src/github.com/hyperledger/fabric/peer/organizations/";
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org1Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org1MSP",
-
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt`,
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp`,
-    CORE_PEER_ADDRESS: "peer0.org1.example.com:7051",
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org2Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org2MSP",
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    CORE_PEER_ADDRESS: "peer0.org2.example.com:9051",
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp`,
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt`,
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
   const pluginOptions: IPluginLedgerConnectorFabricOptions = {
     instanceId: uuidv4(),
     dockerBinary: "/usr/local/bin/docker",
     peerBinary: "/fabric-samples/bin/peer",
     goBinary: "/usr/local/go/bin/go",
     pluginRegistry,
-    cliContainerEnv: org1Env,
+    cliContainerEnv: FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
     sshConfig,
     logLevel,
     connectionProfile,
@@ -268,8 +233,12 @@ test(testCase, async (t: Test) => {
     // constructorArgs: { Args: ["john", "99"] },
     sourceFiles,
     ccName: contractName,
-    targetOrganizations: [org1Env, org2Env],
-    caFile: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
+    targetOrganizations: [
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
+    ],
+    caFile:
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1.ORDERER_TLS_ROOTCERT_FILE,
     ccLabel: "basic-asset-transfer-2",
     ccLang: ChainCodeProgrammingLanguage.Typescript,
     ccSequence: 1,
@@ -314,13 +283,6 @@ test(testCase, async (t: Test) => {
   Checks.truthy(commit, `commit truthy OK`);
   Checks.truthy(packaging, `packaging truthy OK`);
   Checks.truthy(queryCommitted, `queryCommitted truthy OK`);
-
-  // FIXME - without this wait it randomly fails with an error claiming that
-  // the endorsement was impossible to be obtained. The fabric-samples script
-  // does the same thing, it just waits 10 seconds for good measure so there
-  // might not be a way for us to avoid doing this, but if there is a way we
-  // absolutely should not have timeouts like this, anywhere...
-  await new Promise((resolve) => setTimeout(resolve, 30000));
 
   const assetId = uuidv4();
   const assetOwner = uuidv4();

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-lock-asset.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-lock-asset.test.ts
@@ -11,9 +11,11 @@ import bodyParser from "body-parser";
 
 import {
   Containers,
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -45,10 +47,10 @@ import { PluginKeychainMemory } from "@hyperledger/cactus-plugin-keychain-memory
 import { Configuration } from "@hyperledger/cactus-core-api";
 
 const testCase = "deploys Fabric 2.x contract from typescript source";
-const logLevel: LogLevelDesc = "TRACE";
+const logLevel: LogLevelDesc = "INFO";
 const log: Logger = LoggerProvider.getOrCreate({
   label: "fabric-lock-asset",
-  level: "INFO",
+  level: logLevel,
 });
 test("BEFORE " + testCase, async (t: Test) => {
   const pruning = pruneDockerAllIfGithubAction({ logLevel });
@@ -68,8 +70,8 @@ test(testCase, async (t: Test) => {
     emitContainerLogs: true,
     publishAllPorts: true,
     imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-    imageVersion: DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-    envVars: new Map([["FABRIC_VERSION", DEFAULT_FABRIC_2_AIO_FABRIC_VERSION]]),
+    imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
+    envVars: new Map([["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION]]),
     logLevel,
   });
   const tearDown = async () => {
@@ -111,50 +113,13 @@ test(testCase, async (t: Test) => {
     asLocalhost: true,
   };
 
-  // This is the directory structure of the Fabirc 2.x CLI container (fabric-tools image)
-  // const orgCfgDir = "/fabric-samples/test-network/organizations/";
-  const orgCfgDir =
-    "/opt/gopath/src/github.com/hyperledger/fabric/peer/organizations/";
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org1Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org1MSP",
-
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt`,
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp`,
-    CORE_PEER_ADDRESS: "peer0.org1.example.com:7051",
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org2Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org2MSP",
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    CORE_PEER_ADDRESS: "peer0.org2.example.com:9051",
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp`,
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt`,
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
   const pluginOptions: IPluginLedgerConnectorFabricOptions = {
     instanceId: uuidv4(),
     dockerBinary: "/usr/local/bin/docker",
     peerBinary: "/fabric-samples/bin/peer",
     goBinary: "/usr/local/go/bin/go",
     pluginRegistry,
-    cliContainerEnv: org1Env,
+    cliContainerEnv: FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
     sshConfig,
     logLevel,
     connectionProfile,
@@ -260,8 +225,12 @@ test(testCase, async (t: Test) => {
     // constructorArgs: { Args: ["john", "99"] },
     sourceFiles,
     ccName: contractName,
-    targetOrganizations: [org1Env, org2Env],
-    caFile: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
+    targetOrganizations: [
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
+    ],
+    caFile:
+      FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1.ORDERER_TLS_ROOTCERT_FILE,
     ccLabel: "basic-asset-transfer-2",
     ccLang: ChainCodeProgrammingLanguage.Typescript,
     ccSequence: 1,
@@ -306,13 +275,6 @@ test(testCase, async (t: Test) => {
   Checks.truthy(commit, `commit truthy OK`);
   Checks.truthy(packaging, `packaging truthy OK`);
   Checks.truthy(queryCommitted, `queryCommitted truthy OK`);
-
-  // FIXME - without this wait it randomly fails with an error claiming that
-  // the endorsement was impossible to be obtained. The fabric-samples script
-  // does the same thing, it just waits 10 seconds for good measure so there
-  // might not be a way for us to avoid doing this, but if there is a way we
-  // absolutely should not have timeouts like this, anywhere...
-  await new Promise((resolve) => setTimeout(resolve, 10000));
 
   const assetId = uuidv4();
 

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-delegated-sign-v1-endpoint.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-delegated-sign-v1-endpoint.test.ts
@@ -11,9 +11,6 @@
 //////////////////////////////////
 
 // Ledger settings
-const imageName = "ghcr.io/hyperledger/cactus-fabric2-all-in-one";
-const imageVersion = "2021-09-02--fix-876-supervisord-retries";
-const fabricEnvVersion = "2.2.0";
 const fabricEnvCAVersion = "1.4.9";
 const ledgerChannelName = "mychannel";
 const ledgerContractName = "basic";
@@ -32,6 +29,9 @@ import { Server as SocketIoServer } from "socket.io";
 import { DiscoveryOptions, X509Identity } from "fabric-network";
 
 import {
+  DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -89,15 +89,20 @@ describe("watchBlocksDelegatedSignV1 of fabric connector tests", () => {
 
     // Start Ledger
     log.info("Start FabricTestLedgerV1...");
-    log.debug("Version:", fabricEnvVersion, "CA Version:", fabricEnvCAVersion);
+    log.debug(
+      "Version:",
+      FABRIC_25_LTS_AIO_IMAGE_VERSION,
+      "CA Version:",
+      fabricEnvCAVersion,
+    );
     ledger = new FabricTestLedgerV1({
       emitContainerLogs: false,
       publishAllPorts: true,
       logLevel: testLogLevel,
-      imageName,
-      imageVersion,
+      imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
+      imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
       envVars: new Map([
-        ["FABRIC_VERSION", fabricEnvVersion],
+        ["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION],
         ["CA_VERSION", fabricEnvCAVersion],
       ]),
     });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-v1-endpoint.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/fabric-watch-blocks-v1-endpoint.test.ts
@@ -8,9 +8,9 @@ import { Server as SocketIoServer } from "socket.io";
 import { DiscoveryOptions } from "fabric-network";
 
 import {
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -53,8 +53,8 @@ import {
 
 // Ledger settings
 const imageName = DEFAULT_FABRIC_2_AIO_IMAGE_NAME;
-const imageVersion = DEFAULT_FABRIC_2_AIO_IMAGE_VERSION;
-const fabricEnvVersion = DEFAULT_FABRIC_2_AIO_FABRIC_VERSION;
+const imageVersion = FABRIC_25_LTS_AIO_IMAGE_VERSION;
+const fabricEnvVersion = FABRIC_25_LTS_AIO_FABRIC_VERSION;
 const fabricEnvCAVersion = "1.4.9";
 const ledgerChannelName = "mychannel";
 const ledgerContractName = "basic";

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/get-block.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/get-block.test.ts
@@ -9,9 +9,9 @@ import { DiscoveryOptions } from "fabric-network";
 const { BlockDecoder } = require("fabric-common");
 
 import {
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -51,8 +51,8 @@ import {
 
 // Ledger settings
 const imageName = DEFAULT_FABRIC_2_AIO_IMAGE_NAME;
-const imageVersion = DEFAULT_FABRIC_2_AIO_IMAGE_VERSION;
-const fabricEnvVersion = DEFAULT_FABRIC_2_AIO_FABRIC_VERSION;
+const imageVersion = FABRIC_25_LTS_AIO_IMAGE_VERSION;
+const fabricEnvVersion = FABRIC_25_LTS_AIO_FABRIC_VERSION;
 const fabricEnvCAVersion = "1.4.9";
 const ledgerChannelName = "mychannel";
 const ledgerContractName = "basic";

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/obtain-profiles.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/obtain-profiles.test.ts
@@ -3,9 +3,9 @@
 import test, { Test } from "tape-promise/tape";
 
 import {
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -26,8 +26,8 @@ test(testCase, async (t: Test) => {
     emitContainerLogs: true,
     publishAllPorts: true,
     imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-    imageVersion: DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-    envVars: new Map([["FABRIC_VERSION", DEFAULT_FABRIC_2_AIO_FABRIC_VERSION]]),
+    imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
+    envVars: new Map([["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION]]),
   });
   const tearDown = async () => {
     await ledger.stop();

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts
@@ -9,9 +9,9 @@ import express from "express";
 
 import {
   Containers,
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -48,24 +48,23 @@ import { Configuration } from "@hyperledger/cactus-core-api";
  * ```
  */
 
-const testCase = "runs tx on a Fabric v2.2.0 ledger";
+const testCase = "runs tx on a Fabric v2.5.6 ledger";
 
 describe(testCase, () => {
   const expressApp = express();
   expressApp.use(bodyParser.json({ limit: "250mb" }));
   const server = http.createServer(expressApp);
-  const logLevel: LogLevelDesc = "TRACE";
-  const level = "INFO";
+  const logLevel: LogLevelDesc = "INFO";
   const label = "fabric run transaction test";
-  const log = LoggerProvider.getOrCreate({ level, label });
+  const log = LoggerProvider.getOrCreate({ level: logLevel, label });
   const ledger = new FabricTestLedgerV1({
     emitContainerLogs: true,
     publishAllPorts: true,
     logLevel,
     imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-    imageVersion: DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+    imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
     envVars: new Map([
-      ["FABRIC_VERSION", DEFAULT_FABRIC_2_AIO_FABRIC_VERSION],
+      ["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION],
       ["CA_VERSION", "1.4.9"],
     ]),
   });

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-with-identities.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-with-identities.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../../main/typescript/public-api";
 import { DiscoveryOptions } from "fabric-network";
 
-const logLevel: LogLevelDesc = "TRACE";
+const logLevel: LogLevelDesc = "INFO";
 import {
   Containers,
   VaultTestServer,
@@ -22,8 +22,8 @@ import {
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
 } from "@hyperledger/cactus-test-tooling";
 import { v4 as internalIpV4 } from "internal-ip";
 import axios from "axios";
@@ -45,8 +45,8 @@ test("run-transaction-with-identities", async (t: Test) => {
     emitContainerLogs: true,
     publishAllPorts: true,
     imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-    imageVersion: DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-    envVars: new Map([["FABRIC_VERSION", DEFAULT_FABRIC_2_AIO_FABRIC_VERSION]]),
+    imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
+    envVars: new Map([["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION]]),
     logLevel,
   });
 

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-with-ws-ids.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-with-ws-ids.test.ts
@@ -21,14 +21,14 @@ import {
   WsTestServer,
   WS_IDENTITY_HTTP_PORT,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
 } from "@hyperledger/cactus-test-tooling";
 import { v4 as internalIpV4 } from "internal-ip";
 import { WsWallet } from "ws-wallet";
 import { WsIdentityClient } from "ws-identity-client";
 
-const logLevel: LogLevelDesc = "DEBUG";
+const logLevel: LogLevelDesc = "INFO";
 
 // test scenario
 // - enroll registrar (both using default identity and webSocket(p256) identity)
@@ -47,8 +47,8 @@ test("run-transaction-with-ws-ids", async (t: Test) => {
     emitContainerLogs: true,
     publishAllPorts: true,
     imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-    imageVersion: DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-    envVars: new Map([["FABRIC_VERSION", DEFAULT_FABRIC_2_AIO_FABRIC_VERSION]]),
+    imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
+    envVars: new Map([["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION]]),
     logLevel,
   });
 

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -8,9 +8,11 @@ import express from "express";
 import bodyParser from "body-parser";
 import {
   Containers,
-  DEFAULT_FABRIC_2_AIO_FABRIC_VERSION,
   DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-  DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_AIO_FABRIC_VERSION,
+  FABRIC_25_LTS_AIO_IMAGE_VERSION,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+  FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
   FabricTestLedgerV1,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
@@ -38,8 +40,8 @@ import { Configuration } from "@hyperledger/cactus-core-api";
 import { installOpenapiValidationMiddleware } from "@hyperledger/cactus-core";
 import OAS from "../../../../main/json/openapi.json";
 
-const testCase = "deploys Fabric 2.x contract from typescript source";
-const logLevel: LogLevelDesc = "TRACE";
+const testCase = "deploys Fabric V2.5.6 contract from typescript source";
+const logLevel: LogLevelDesc = "INFO";
 
 test("BEFORE " + testCase, async (t: Test) => {
   const pruning = pruneDockerAllIfGithubAction({ logLevel });
@@ -59,8 +61,8 @@ test(testCase, async (t: Test) => {
     emitContainerLogs: true,
     publishAllPorts: true,
     imageName: DEFAULT_FABRIC_2_AIO_IMAGE_NAME,
-    imageVersion: DEFAULT_FABRIC_2_AIO_IMAGE_VERSION,
-    envVars: new Map([["FABRIC_VERSION", DEFAULT_FABRIC_2_AIO_FABRIC_VERSION]]),
+    imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
+    envVars: new Map([["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION]]),
     logLevel,
   });
   const tearDown = async () => {
@@ -101,50 +103,13 @@ test(testCase, async (t: Test) => {
     asLocalhost: true,
   };
 
-  // This is the directory structure of the Fabirc 2.x CLI container (fabric-tools image)
-  // const orgCfgDir = "/fabric-samples/test-network/organizations/";
-  const orgCfgDir =
-    "/opt/gopath/src/github.com/hyperledger/fabric/peer/organizations/";
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org1Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org1MSP",
-
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt`,
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp`,
-    CORE_PEER_ADDRESS: "peer0.org1.example.com:7051",
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
-  // these below mirror how the fabric-samples sets up the configuration
-  const org2Env = {
-    CORE_LOGGING_LEVEL: "debug",
-    FABRIC_LOGGING_SPEC: "debug",
-    CORE_PEER_LOCALMSPID: "Org2MSP",
-
-    FABRIC_CFG_PATH: "/etc/hyperledger/fabric",
-    CORE_PEER_TLS_ENABLED: "true",
-    ORDERER_CA: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-
-    CORE_PEER_ADDRESS: "peer0.org2.example.com:9051",
-    CORE_PEER_MSPCONFIGPATH: `${orgCfgDir}peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp`,
-    CORE_PEER_TLS_ROOTCERT_FILE: `${orgCfgDir}peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt`,
-    ORDERER_TLS_ROOTCERT_FILE: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
-  };
-
   const pluginOptions: IPluginLedgerConnectorFabricOptions = {
     instanceId: uuidv4(),
     dockerBinary: "/usr/local/bin/docker",
     peerBinary: "/fabric-samples/bin/peer",
     goBinary: "/usr/local/go/bin/go",
     pluginRegistry,
-    cliContainerEnv: org1Env,
+    cliContainerEnv: FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
     sshConfig,
     logLevel,
     connectionProfile,
@@ -275,8 +240,12 @@ test(testCase, async (t: Test) => {
       ccVersion: "1.0.0",
       sourceFiles,
       ccName: contractName,
-      targetOrganizations: [org1Env, org2Env],
-      caFile: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
+      targetOrganizations: [
+        FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+        FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
+      ],
+      caFile:
+        FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1.ORDERER_TLS_ROOTCERT_FILE,
       ccLabel: "basic-asset-transfer-2",
       ccLang: ChainCodeProgrammingLanguage.Typescript,
       ccSequence: 1,
@@ -303,8 +272,12 @@ test(testCase, async (t: Test) => {
       ccVersion: "1.0.0",
       sourceFiles,
       ccName: contractName,
-      targetOrganizations: [org1Env, org2Env],
-      caFile: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
+      targetOrganizations: [
+        FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+        FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
+      ],
+      caFile:
+        FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1.ORDERER_TLS_ROOTCERT_FILE,
       ccLabel: "basic-asset-transfer-2",
       ccLang: ChainCodeProgrammingLanguage.Typescript,
       ccSequence: 1,
@@ -315,7 +288,7 @@ test(testCase, async (t: Test) => {
 
     try {
       await apiClient.deployContractV1(
-        parameters as any as DeployContractV1Request,
+        parameters as unknown as DeployContractV1Request,
       );
     } catch (e) {
       t2.equal(
@@ -341,8 +314,12 @@ test(testCase, async (t: Test) => {
       ccVersion: "1.0.0",
       sourceFiles,
       ccName: contractName,
-      targetOrganizations: [org1Env, org2Env],
-      caFile: `${orgCfgDir}ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem`,
+      targetOrganizations: [
+        FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1,
+        FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_2,
+      ],
+      caFile:
+        FABRIC_25_LTS_FABRIC_SAMPLES_ENV_INFO_ORG_1.ORDERER_TLS_ROOTCERT_FILE,
       ccLabel: "basic-asset-transfer-2",
       ccLang: ChainCodeProgrammingLanguage.Typescript,
       ccSequence: 1,
@@ -353,9 +330,7 @@ test(testCase, async (t: Test) => {
     };
 
     try {
-      await apiClient.deployContractV1(
-        parameters as any as DeployContractV1Request,
-      );
+      await apiClient.deployContractV1(parameters as DeployContractV1Request);
     } catch (e) {
       t2.equal(
         e.response.status,
@@ -415,9 +390,7 @@ test(testCase, async (t: Test) => {
     };
 
     try {
-      await apiClient.runTransactionV1(
-        parameters as any as RunTransactionRequest,
-      );
+      await apiClient.runTransactionV1(parameters as RunTransactionRequest);
     } catch (e) {
       t2.equal(
         e.response.status,
@@ -454,9 +427,7 @@ test(testCase, async (t: Test) => {
     };
 
     try {
-      await apiClient.runTransactionV1(
-        parameters as any as RunTransactionRequest,
-      );
+      await apiClient.runTransactionV1(parameters as RunTransactionRequest);
     } catch (e) {
       t2.equal(
         e.response.status,


### PR DESCRIPTION
1. This fixes many flakes that we were suffering from before with the
older versions of the AIO image.
2. There could still be other flakes lurking around, but their numbers
should definitely be going down with this change due to the increased
stability of the new AIO image.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.