### PR TITLE
chore(carbon-accounting): fix CVE-2022-25881 CVE-2021-39167

### DIFF
--- a/examples/cactus-example-carbon-accounting-backend/package.json
+++ b/examples/cactus-example-carbon-accounting-backend/package.json
@@ -77,12 +77,15 @@
     "@types/express": "4.17.19",
     "@types/fs-extra": "9.0.13",
     "@types/json-stable-stringify": "1.0.34",
+    "@types/qs": "6.9.14",
     "@types/uuid": "9.0.8",
     "express-jwt": "8.4.1",
     "hardhat": "2.17.2",
+    "http-cache-semantics": "4.1.1",
     "http-status-codes": "2.1.4",
     "jose": "4.15.5",
-    "json-stable-stringify": "1.0.2"
+    "json-stable-stringify": "1.0.2",
+    "qs": "6.7.3"
   },
   "engines": {
     "node": ">=18",

--- a/examples/carbon-accounting/Dockerfile
+++ b/examples/carbon-accounting/Dockerfile
@@ -1,4 +1,4 @@
-FROM cruizba/ubuntu-dind:19.03.11 as runner
+FROM cruizba/ubuntu-dind:20.10.18 as runner
 
 USER root
 
@@ -33,12 +33,14 @@ WORKDIR ${APP}
 
 SHELL ["/bin/bash", "--login", "-i", "-c"]
 # Installing Node Version Manager (nvm)
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
 RUN source ~/.bashrc && \
-    nvm install 16.15.1 && \
-    npm install -g yarn && \
-    yarn add @hyperledger/cactus-example-carbon-accounting-backend@0.9.1-ci-942.cbb849c6.35 --ignore-engines --production
-
+    nvm install 20.11.1 && \
+    npm install --location=global yarn && \
+    yarn config set nodeLinker node-modules && \
+    yarn set version 4.1.0 && \
+    yarn add @hyperledger/cactus-example-carbon-accounting-backend@2.0.0-alpha.2
+    
 SHELL ["/bin/bash", "--login", "-c"]
 
 

--- a/examples/carbon-accounting/supervisord.conf
+++ b/examples/carbon-accounting/supervisord.conf
@@ -12,7 +12,7 @@ stderr_logfile=/usr/src/app/log/dockerd.err.log
 stdout_logfile=/usr/src/app/log/dockerd.out.log
 
 [program:carbon-accounting-app]
-command=/home/appuser/.nvm/versions/node/v16.3.0/bin/node /usr/src/app/examples/cactus-example-carbon-accounting-backend/dist/lib/main/typescript/carbon-accounting-app-cli.js
+command=/home/appuser/.nvm/versions/node/v20.11.1/bin/node /usr/src/app/node_modules/@hyperledger/cactus-example-carbon-accounting-backend/dist/lib/main/typescript/carbon-accounting-app-cli.js
 autostart=true
 autorestart=unexpected
 exitcodes=0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7747,16 +7747,19 @@ __metadata:
     "@types/express": "npm:4.17.19"
     "@types/fs-extra": "npm:9.0.13"
     "@types/json-stable-stringify": "npm:1.0.34"
+    "@types/qs": "npm:6.9.14"
     "@types/uuid": "npm:9.0.8"
     async-exit-hook: "npm:2.0.1"
     express-jwt: "npm:8.4.1"
     fabric-network: "npm:2.2.20"
     fs-extra: "npm:10.1.0"
     hardhat: "npm:2.17.2"
+    http-cache-semantics: "npm:4.1.1"
     http-status-codes: "npm:2.1.4"
     jose: "npm:4.15.5"
     json-stable-stringify: "npm:1.0.2"
     openapi-types: "npm:12.1.3"
+    qs: "npm:6.7.3"
     typescript-optional: "npm:2.0.1"
     uuid: "npm:9.0.1"
     web3-core: "npm:1.6.1"
@@ -15377,6 +15380,13 @@ __metadata:
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
   checksum: 10/7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
+  languageName: node
+  linkType: hard
+
+"@types/qs@npm:6.9.14":
+  version: 6.9.14
+  resolution: "@types/qs@npm:6.9.14"
+  checksum: 10/d3b76021d36b86c0063ec4b7373e9fa470754914e486fbfe54b3a8866dad037800a2c2068ecbcaa9399ae3ed15772a26b07e67793ed2519cf2de199104014716
   languageName: node
   linkType: hard
 
@@ -41969,6 +41979,13 @@ __metadata:
   version: 6.7.0
   resolution: "qs@npm:6.7.0"
   checksum: 10/d8f4b216c6777853c17586dc17fa685fb4e14269dbf6e860add6c0c61fd12137dc7aa4bf5066a794ba9a8dbb9c11e9ef20b72db763228701be95546ea807213a
+  languageName: node
+  linkType: hard
+
+"qs@npm:6.7.3":
+  version: 6.7.3
+  resolution: "qs@npm:6.7.3"
+  checksum: 10/b299d27f4ac4e47511dc15ff5650bd7a1c07cfbe514190a479b0b3a0d5b401198ff6910371b473e70fbde8e114f1bcba9c64ea52a147053e3b0b554aeb5a41ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### **Commit** to be reviewed
---
examples(carbon-accounting):fix CVE-2022-25881 CVE-2021-39167
```
Primary Changes
----------------
1. Modified the Dockerfile to use the updated versions 
   of the packages being used
2. Modified the supervisord.conf to use the correct path
   because it has changed after updating the versions
```
Fixes #2062

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.