### PR TITLE
refactor(connector-besu): tx poll per second not at full CPU speed

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/main/typescript/plugin-ledger-connector-besu.ts
@@ -1,5 +1,6 @@
 import { Server } from "http";
 import { Server as SecureServer } from "https";
+import { setTimeout } from "timers/promises";
 
 import type { Server as SocketIoServer } from "socket.io";
 import type { Socket as SocketIoSocket } from "socket.io";
@@ -788,8 +789,14 @@ export class PluginLedgerConnectorBesu
     const startedAt = new Date();
 
     do {
+      const now = Date.now();
+      const elapsedTime = now - startedAt.getTime();
+      timedOut = now >= startedAt.getTime() + timeoutMs;
+      this.log.debug("%s tries=%n elapsedMs=%n", fnTag, tries, elapsedTime);
+      if (tries > 0) {
+        await setTimeout(1000);
+      }
       tries++;
-      timedOut = Date.now() >= startedAt.getTime() + timeoutMs;
       if (timedOut) {
         break;
       }


### PR DESCRIPTION
1. Prior to this change the polling function that waits for transactions
to be confirmed was running in  while loop without any delay, meaning that
the code that fetches the latest block is executing thousands of times
each second (or however fast the CPU in the machine/network connection are).
2. Now there is a second delay between each execution of the loop so that
we are not hammering the node of the ledger we are connected to.
3. This also has the added benefit of the test cases using this method
using much less CPU power.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.