### PR TITLE
ci(github): refactor ActionLint job to use the official installer

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -3,14 +3,66 @@ on:
   workflow_call:
 
 jobs:
-  actionlint:
+  Lint_GitHub_Actions:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.6.25/scripts/download-actionlint.bash)
-        shell: bash
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
-        shell: bash
+    - name: git_clone
+      uses: actions/checkout@v4.1.1
+
+    # We need to wipe the root package.json file because the installation of actionlint fails otherwise like this:
+    #
+    # npm ERR! code ERESOLVE
+    # npm ERR! ERESOLVE could not resolve
+    # npm ERR! 
+    # npm ERR! While resolving: react-scripts@5.0.1
+    # npm ERR! Found: typescript@5.3.3
+    # npm ERR! node_modules/typescript
+    # npm ERR!   dev typescript@"5.3.3" from the root project
+    # npm ERR!   peerOptional typescript@">=3.7.2" from tap@16.3.8
+    # npm ERR!   node_modules/tap
+    # npm ERR!     dev tap@"16.3.8" from the root project
+    # npm ERR!   25 more (ts-jest, @hyperledger/cactus-plugin-satp-hermes, ...)
+    # npm ERR! 
+    # npm ERR! Could not resolve dependency:
+    # npm ERR! peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
+    # npm ERR! node_modules/react-scripts
+    # npm ERR!   react-scripts@"5.0.1" from @hyperledger/cacti-example-cbdc-bridging-frontend@2.0.0-alpha.2
+    # npm ERR!   examples/cactus-example-cbdc-bridging-frontend
+    # npm ERR!     @hyperledger/cacti-example-cbdc-bridging-frontend@2.0.0-alpha.2
+    # npm ERR!     node_modules/@hyperledger/cacti-example-cbdc-bridging-frontend
+    # npm ERR!       workspace examples/cactus-example-cbdc-bridging-frontend from the root project
+    # npm ERR! 
+    # npm ERR! Conflicting peer dependency: typescript@4.9.5
+    # npm ERR! node_modules/typescript
+    # npm ERR!   peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
+    # npm ERR!   node_modules/react-scripts
+    # npm ERR!     react-scripts@"5.0.1" from @hyperledger/cacti-example-cbdc-bridging-frontend@2.0.0-alpha.2
+    # npm ERR!     examples/cactus-example-cbdc-bridging-frontend
+    # npm ERR!       @hyperledger/cacti-example-cbdc-bridging-frontend@2.0.0-alpha.2
+    # npm ERR!       node_modules/@hyperledger/cacti-example-cbdc-bridging-frontend
+    # npm ERR!         workspace examples/cactus-example-cbdc-bridging-frontend from the root project
+    # npm ERR! 
+    # npm ERR! Fix the upstream dependency conflict, or retry
+    # npm ERR! this command with --force or --legacy-peer-deps
+    # npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
+    - name: wipe_non_yaml_sources
+      run: rm -rf packages/ examples/ extensions/ package.json
+
+    - name: actionlint
+      id: actionlint
+      uses: raven-actions/actionlint@v1.0.3
+      with:
+        version: 1.6.27
+        cache: true
+
+    - name: actionlint_summary
+      if: ${{ steps.actionlint.outputs.exit-code != 0 }} # example usage, do echo only when actionlint action failed
+      run: |
+        echo "Used actionlint version ${{ steps.actionlint.outputs.version-semver }}"
+        echo "Used actionlint release ${{ steps.actionlint.outputs.version-tag }}"
+        echo "actionlint ended with ${{ steps.actionlint.outputs.exit-code }} exit code"
+        echo "actionlint ended because '${{ steps.actionlint.outputs.exit-message }}'"
+        echo "actionlint found ${{ steps.actionlint.outputs.total-errors }} errors"
+        echo "actionlint checked ${{ steps.actionlint.outputs.total-files }} files"
+        echo "actionlint cache used: ${{ steps.actionlint.outputs.cache-hit }}"
+        exit ${{ steps.actionlint.outputs.exit-code }}


### PR DESCRIPTION
1. Previously we just winged it with a bash script downloading another
bash script to unzip the actionlint binaries.
2. From now on we'll use the GitHub action from the marketplace which
has a lot of configuration options exposed in a convenient way such as
what type of warnings to ignore, what version of actionlint to install,
etc.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.