### PR TITLE
fix(connector-ethereum): cannot serialize bigint

### DIFF
--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/plugin-ledger-connector-ethereum.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/plugin-ledger-connector-ethereum.ts
@@ -304,6 +304,9 @@ export class PluginLedgerConnectorEthereum
     app: Express,
     wsApi: SocketIoServer,
   ): Promise<IWebServiceEndpoint[]> {
+    // Add custom replacer to handle bigint responses correctly
+    app.set("json replacer", this.stringifyBigIntReplacer);
+
     const { logLevel } = this.options;
     const webServices = await this.getOrCreateWebServices();
     await Promise.all(webServices.map((ws) => ws.registerExpress(app)));
@@ -1182,5 +1185,15 @@ export class PluginLedgerConnectorEthereum
     return methodRef(...contractMethodArgs)[args.invocationType](
       args.invocationParams,
     );
+  }
+
+  stringifyBigIntReplacer(
+    _key: string,
+    value: bigint | unknown,
+  ): string | unknown {
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+    return value;
   }
 }

--- a/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/web-services/invoke-raw-web3eth-method-v1-endpoint.ts
+++ b/packages/cactus-plugin-ledger-connector-ethereum/src/main/typescript/web-services/invoke-raw-web3eth-method-v1-endpoint.ts
@@ -88,6 +88,7 @@ export class InvokeRawWeb3EthMethodEndpoint implements IWebServiceEndpoint {
     try {
       const methodResponse =
         await this.options.connector.invokeRawWeb3EthMethod(req.body);
+
       const response: InvokeRawWeb3EthMethodV1Response = {
         status: 200,
         data: methodResponse,


### PR DESCRIPTION
I came across an issue working with the  ledger-connector-ethereum.
Description: In the endpoint InvokeRawWeb3EthMethodV1 , some web3.eth functions are returning objects with BigInt attributes, which causes express Response.json() method to break when stringuifying those objects "TypeError: Do not know how to serialize a BigInt".

My fix was to include code in the endpoint file, to substitute BigInt attributes for their toString() value. 

How to reproduce:
 - checkout to this branch [connector-ethereum-bug](https://github.com/eduv09/blockchain-integration-framework/tree/connector-ethereum-bug);
 - run 'geth-contract-deploy-and-invoke-using-keychain-v1.test.ts'. I've added code (few lines, check last commit in that branch) in this test file that reproduces the error 

@petermetz @outSH would you have a look please? If you think there is a more suitable fix, let me know.