### PR TITLE
feat(cmd-api-server): add gRPC plugin auto-registration support

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/grpc/grpc-credentials-factory.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/grpc/grpc-credentials-factory.ts
@@ -1,0 +1,91 @@
+import * as grpc from "@grpc/grpc-js";
+
+/**
+ * Re-exports the underlying `grpc.ServerCredentials.createInsecure()` call
+ * verbatim.
+ * Why though? This is necessary because the {grpc.Server} object does an `instanceof`
+ * validation on credential objects that are passed to it and this check comes back
+ * negative if you've constructed the credentials object with a different instance
+ * of the library, **even** if the versions of the library instances are the **same**.
+ *
+ * Therefore this is a workaround that allows callers to construct credentials
+ * objects with the same import of the `@grpc/grpc-js` library that the {ApiServer}
+ * of this package is using.
+ *
+ * @returns {grpc.ServerCredentials}
+ */
+export function createGrpcInsecureServerCredentials(): grpc.ServerCredentials {
+  return grpc.ServerCredentials.createInsecure();
+}
+
+/**
+ * Re-exports the underlying `grpc.ServerCredentials.createInsecure()` call
+ * verbatim.
+ * Why though? This is necessary because the {grpc.Server} object does an `instanceof`
+ * validation on credential objects that are passed to it and this check comes back
+ * negative if you've constructed the credentials object with a different instance
+ * of the library, **even** if the versions of the library instances are the **same**.
+ *
+ * Therefore this is a workaround that allows callers to construct credentials
+ * objects with the same import of the `@grpc/grpc-js` library that the {ApiServer}
+ * of this package is using.
+ *
+ * @returns {grpc.ServerCredentials}
+ */
+export function createGrpcSslServerCredentials(
+  rootCerts: Buffer | null,
+  keyCertPairs: grpc.KeyCertPair[],
+  checkClientCertificate?: boolean,
+): grpc.ServerCredentials {
+  return grpc.ServerCredentials.createSsl(
+    rootCerts,
+    keyCertPairs,
+    checkClientCertificate,
+  );
+}
+
+/**
+ * Re-exports the underlying `grpc.ServerCredentials.createInsecure()` call
+ * verbatim.
+ * Why though? This is necessary because the {grpc.Server} object does an `instanceof`
+ * validation on credential objects that are passed to it and this check comes back
+ * negative if you've constructed the credentials object with a different instance
+ * of the library, **even** if the versions of the library instances are the **same**.
+ *
+ * Therefore this is a workaround that allows callers to construct credentials
+ * objects with the same import of the `@grpc/grpc-js` library that the {ApiServer}
+ * of this package is using.
+ *
+ * @returns {grpc.ChannelCredentials}
+ */
+export function createGrpcInsecureChannelCredentials(): grpc.ChannelCredentials {
+  return grpc.ChannelCredentials.createInsecure();
+}
+
+/**
+ * Re-exports the underlying `grpc.ServerCredentials.createInsecure()` call
+ * verbatim.
+ * Why though? This is necessary because the {grpc.Server} object does an `instanceof`
+ * validation on credential objects that are passed to it and this check comes back
+ * negative if you've constructed the credentials object with a different instance
+ * of the library, **even** if the versions of the library instances are the **same**.
+ *
+ * Therefore this is a workaround that allows callers to construct credentials
+ * objects with the same import of the `@grpc/grpc-js` library that the {ApiServer}
+ * of this package is using.
+ *
+ * @returns {grpc.ChannelCredentials}
+ */
+export function createGrpcSslChannelCredentials(
+  rootCerts?: Buffer | null,
+  privateKey?: Buffer | null,
+  certChain?: Buffer | null,
+  verifyOptions?: grpc.VerifyOptions,
+): grpc.ChannelCredentials {
+  return grpc.ChannelCredentials.createSsl(
+    rootCerts,
+    privateKey,
+    certChain,
+    verifyOptions,
+  );
+}

--- a/packages/cactus-cmd-api-server/src/main/typescript/grpc/grpc-server-factory.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/grpc/grpc-server-factory.ts
@@ -1,0 +1,21 @@
+import * as grpc from "@grpc/grpc-js";
+
+/**
+ * Re-exports the underlying `new grpc.Server()` call verbatim.
+ *
+ * Why though? This is necessary because the {grpc.Server} object does an `instanceof`
+ * validation on credential objects that are passed to it and this check comes back
+ * negative if you've constructed the credentials object with a different instance
+ * of the library, **even** if the versions of the library instances are the **same**.
+ *
+ * Therefore this is a workaround that allows callers to construct credentials
+ * objects/servers with the same import of the `@grpc/grpc-js` library that the
+ * {ApiServer} of this package is using internally.
+ *
+ * @returns {grpc.Server}
+ */
+export function createGrpcServer(
+  options?: grpc.ServerOptions | undefined,
+): grpc.Server {
+  return new grpc.Server(options);
+}

--- a/packages/cactus-cmd-api-server/src/main/typescript/public-api.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/public-api.ts
@@ -39,3 +39,12 @@ export {
 } from "./authzn/authorizer-factory";
 export { IAuthorizationConfig } from "./authzn/i-authorization-config";
 export { AuthorizationProtocol } from "./config/authorization-protocol";
+
+export {
+  createGrpcInsecureChannelCredentials,
+  createGrpcInsecureServerCredentials,
+  createGrpcSslChannelCredentials,
+  createGrpcSslServerCredentials,
+} from "./grpc/grpc-credentials-factory";
+
+export { createGrpcServer } from "./grpc/grpc-server-factory";


### PR DESCRIPTION
1. The API server supports gRPC endpoints, but plugins are not yet able
to register their own gRPC services to be exposed the same way that was
already possible for HTTP endpoints to be registered dynamically. This
was due to an oversight when the original contribution was made by Peter
(who was the person making the oversight - good job Peter)
2. The functionality works largely the same as it does for the HTTP
endpoints but it does so for gRPC services (which is the equivalent of
endpoints in gRPC terminology, so service === endpoint in this context.)
3. There are new methods added to the public API surface of the API server
package which can be used to construct gRPC credential and server objects
using the instance of the library that is used by the API server.
This is necessary because the validation logic built into grpc-js fails
for these mentioned objects if the creds or the server was constructed
with a different instance of the library than the one used by the API
server.
4. Different instance in this context means just that the exact same
version of the library was imported from a different path for example
there could be the node_modules directory of the besu connector and also
the node_modules directory of the API server.
5. Because of the problem outlined above, the only way we can have functioning
test cases is if the API server exposes its own instance of grpc-js.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.