### PR TITLE
chore(connector-quorum): fix CVEs: CVE-2023-36665, CVE-2022-21190

### DIFF
--- a/packages/cactus-plugin-ledger-connector-quorum/Dockerfile
+++ b/packages/cactus-plugin-ledger-connector-quorum/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/cactus-cmd-api-server:v1.0.0
+FROM ghcr.io/hyperledger/cactus-cmd-api-server:2024-03-18-8ddc02d
 
 ARG NPM_PKG_VERSION=latest
 


### PR DESCRIPTION
### **Commit** to be reviewed
---
chore(connector-quorum): fix CVEs: CVE-2023-36665, CVE-2022-21190
```
Primary Changes
----------------
1. Modified the Dockerfile to use the updated versions of the packages being used
```


Fixes #2865

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.