### PR TITLE
ci: mitigate script injection attack in test_weaver-pre-release.yaml

### DIFF
--- a/.github/workflows/test_weaver-pre-release.yaml
+++ b/.github/workflows/test_weaver-pre-release.yaml
@@ -23,9 +23,11 @@ jobs:
       
       - name: Ignore if not a release PR
         id: early
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run : |
           status="skip"
-          if echo "${{ github.event.pull_request.title }}" | grep -q "chore(release)"; then
+          if echo ${TITLE} | grep -q "chore(release)"; then
             status="continue"
           fi
           echo "status=$status" >> $GITHUB_OUTPUT
@@ -39,10 +41,12 @@ jobs:
       - uses: actions/checkout@v4.1.1
       
       - name: Get release verison from PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Assuming release PR follows pattern: chore(release): publish vA.B.C
           # Split PR title by space, and take 3rd word
-          VERSION=$(echo "${{ github.event.pull_request.title }}" | cut -d ' ' -f 3)
+          VERSION=$(echo "${TITLE}" | cut -d ' ' -f 3)
           # Strip "v" from version
           VERSION=$(echo $VERSION | sed -e 's/^v//')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
@@ -146,10 +150,12 @@ jobs:
       - uses: actions/checkout@v4.1.1
       
       - name: Get release verison from PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Assuming release PR follows pattern: chore(release): publish vA.B.C
           # Split PR title by space, and take 3rd word
-          VERSION=$(echo "${{ github.event.pull_request.title }}" | cut -d ' ' -f 3)
+          VERSION=$(echo "${TITLE}" | cut -d ' ' -f 3)
           # Strip "v" from version
           VERSION=$(echo $VERSION | sed -e 's/^v//')
           echo "VERSION=$VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
Fixes the script injection attack mentioned here: https://hackerone.com/reports/2471956

Check sample attack run here: https://github.com/sandeepnRES/cacti/actions/runs/8830394750/job/24243428274?pr=23
from PR on my fork: https://github.com/sandeepnRES/cacti/pull/23

Source for the solution: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#example-of-a-script-injection-attack