### PR TITLE
build(plugin-keychain-memory): fix local imports broken due to .js exts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,9 @@ module.exports = {
   preset: "ts-jest",
   logHeapUsage: true,
   testEnvironment: "node",
+  moduleNameMapper: {
+    "^(\\.\\.?\\/.+)\\.jsx?$": "$1",
+  },
   maxWorkers: 1,
   maxConcurrency: 1,
   setupFilesAfterEnv: ["jest-extended/all", "./jest.setup.console.logs.js"],


### PR DESCRIPTION
Found the solution and a long discussion about it here:
https://github.com/kulshekhar/ts-jest/issues/1057

TLDR: The Jest resolver needs a little extra information/tweak to the
config so that it can correctly handle the .js imports.

Specifically this comment provided the solution which I made here:
https://github.com/kulshekhar/ts-jest/issues/1057#issuecomment-1482644543

Fixes #3254

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.