### PR TITLE
build(package.json): set JS heap to 3 GB for typescript compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "build:prod": "npm-run-all build:prod:frontend",
     "build:prod:frontend": "lerna run build:prod:frontend",
     "build:dev": "npm-run-all build:dev:backend webpack:dev:web build:dev:frontend",
-    "build:dev:backend": "npm-run-all tsc build:dev:backend:postbuild",
+    "build:dev:backend": "NODE_OPTIONS=\"--max_old_space_size=3072\" npm-run-all tsc build:dev:backend:postbuild",
     "build:dev:frontend": "lerna run build:dev:frontend --scope='@hyperledger/cactus-example-*-frontend' --scope='@hyperledger/cacti-ledger-browser'",
     "build:dev:common": "lerna exec --stream --scope '*/*common' -- 'del-cli dist/** && tsc --project ./tsconfig.json && webpack --env=dev --target=node --config ../../webpack.config.js'",
     "build:dev:backend:postbuild": "lerna run build:dev:backend:postbuild",


### PR DESCRIPTION
On a laptop with 16 GB RAM the default JS heap size is not enough anymore
to do a full typescript build of the project from scratch.

The size of the heap for NodeJS processes gets determined at runtime by
an algorithm that (most likely) depends on the total RAM in your computer:
https://stackoverflow.com/a/75555120

For laptops with 16 GB RAM or less, the heap ends up being calculated to
an amount that is too low at this size of the project so we have to give
it a little nudge by specifying the parameter for heap size explicitly to
be 3 GB instead of the default.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.