### PR TITLE
build(weaver): eliminate need for package-local.json for besu/node

### DIFF
--- a/weaver/sdks/besu/node/local/package.json
+++ b/weaver/sdks/besu/node/local/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@hyperledger/cacti-weaver-protos-js": "file:./protos-js",
+    "@hyperledger/cacti-weaver-sdk-besu": "file:..",
     "log4js": "6.9.1",
     "web3": "1.10.0",
     "web3-utils": "1.10.0"
@@ -39,5 +40,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/hyperledger"
   },
-  "tag": "latest"
+  "tag": "latest",
+  "overrides": {
+    "got": "12.4.1"
+  }
 }

--- a/weaver/sdks/besu/node/makefile
+++ b/weaver/sdks/besu/node/makefile
@@ -17,13 +17,10 @@ build-local:
 		cp -r ../../../common/protos-js/identity ./protos-js/ && \
 		cp -r ../../../common/protos-js/package.json ./protos-js/) || \
 		(rm -rf protos-js && echo "Error: Please build weaver/common/protos-js locally" && exit 1)
-	(cp package.json package-remote.json && \
-		cp package-local.json package.json && \
-		npm install --workspaces=false && \
+	(npm --prefix ./local install --workspaces=false . && \
 		cp -r protos-js build/) || \
-		(mv package-remote.json package.json && exit 1)	# Runs if failure
-	mv package-remote.json package.json	                # Runs if success
-	npm run build
+		exit 1													# Runs if failure
+	npm run build												# Runs if success
 	
 
 .PHONE: publish

--- a/weaver/sdks/besu/node/package.json
+++ b/weaver/sdks/besu/node/package.json
@@ -39,5 +39,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/hyperledger"
   },
-  "tag": "latest"
+  "tag": "latest",
+  "overrides": {
+    "got": "12.4.1"
+  }
 }


### PR DESCRIPTION
Related to #2601. 

VSCode does not recognize package-local.json files semantically as package.json manifests meaning that the convenience functionalities it offers for editing package.json files are turned off.

It has been made sure that the original package-local.json has been renamed. The corresponding build scripts updated to delete the logic that copies/moves around package.json files at build time. The package.json files that are getting used can always be looked at just based on what's stored in version control instead of having to guess what changes are being made to the files by the build at runtime.

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.