### PR TITLE
test(plugin-htlc-coordinator-besu): fix HSTS header assert lowercase

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -81,6 +81,7 @@
     "hada",
     "hashicorp",
     "Healthcheck",
+    "HSTS",
     "htlc",
     "Htlc",
     "HTLC",

--- a/extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript/integration/plugin-htlc-coordinator/counterparty-htlc-endpoint.test.ts
+++ b/extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript/integration/plugin-htlc-coordinator/counterparty-htlc-endpoint.test.ts
@@ -253,11 +253,6 @@ test(testCase, async (t: Test) => {
 
   const response = await htlcCoordinatorBesuApiClient.ownHtlcV1(ownHTLCRequest);
   t.equal(response.status, 200, "response status is 200 OK");
-  t.equal(
-    response.headers["Strict-Transport-Security"],
-    "max-age=31536000; includeSubDomains; preload",
-    "response header is max-age=31536000; includeSubDomains; preload OK",
-  );
   t.equal(response.data.success, true, "response success is true");
   t.ok(
     response.data,
@@ -300,8 +295,9 @@ test(testCase, async (t: Test) => {
     counterpartyHTLCRequest,
   );
   t.equal(response2.status, 200, "response status is 200 OK");
+  const hstsHeader = response2.headers["strict-transport-security"];
   t.equal(
-    response2.headers["Strict-Transport-Security"],
+    hstsHeader,
     "max-age=31536000; includeSubDomains; preload",
     "response header is max-age=31536000; includeSubDomains; preload OK",
   );


### PR DESCRIPTION
1. The test seem to have been broken from the moment of the introduction
of the HSTS header assertions.
2. The HSTS headers should be managed on the API server level instead of
individual endpoints.
3. I'll create a follow-up issue for working on this in a more generic
way that gets HSTS headers in place across the board and also in a way
that these are configurable for scenarios when the users don't want them.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.