### PR TITLE
perf(ci): only publish artifacts on git version tags of main 

### DIFF
--- a/.github/workflows/all-nodejs-packages-publish.yaml
+++ b/.github/workflows/all-nodejs-packages-publish.yaml
@@ -5,8 +5,6 @@ env:
 
 on:
   push:
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/besu-all-in-one-publish.yaml
+++ b/.github/workflows/besu-all-in-one-publish.yaml
@@ -1,12 +1,8 @@
 name: besu-all-in-one-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/cmd-api-server-publish.yaml
+++ b/.github/workflows/cmd-api-server-publish.yaml
@@ -1,12 +1,8 @@
 name: cmd-api-server-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/connector-besu-publish.yaml
+++ b/.github/workflows/connector-besu-publish.yaml
@@ -1,12 +1,8 @@
 name: connector-fabric-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/connector-corda-server-publish.yaml
+++ b/.github/workflows/connector-corda-server-publish.yaml
@@ -1,12 +1,8 @@
 name: connector-corda-server-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/connector-fabric-publish.yaml
+++ b/.github/workflows/connector-fabric-publish.yaml
@@ -1,12 +1,8 @@
 name: connector-besu-publish
 
 on:
-  push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
     # Publish `v1.2.3` tags as releases.
+  push:
     tags:
       - v*
 

--- a/.github/workflows/corda-4-6-all-in-one-obligation-publish.yaml
+++ b/.github/workflows/corda-4-6-all-in-one-obligation-publish.yaml
@@ -1,12 +1,8 @@
 name: corda-4-6-all-in-one-obligation-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/corda-4-7-all-in-one-obligation-publish.yaml
+++ b/.github/workflows/corda-4-7-all-in-one-obligation-publish.yaml
@@ -1,12 +1,8 @@
 name: corda-4-7-all-in-one-obligation-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/corda-4-8-all-in-one-obligation-publish.yaml
+++ b/.github/workflows/corda-4-8-all-in-one-obligation-publish.yaml
@@ -1,12 +1,8 @@
 name: corda-4-8-all-in-one-obligation-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/dev-container-vscode-publish.yaml
+++ b/.github/workflows/dev-container-vscode-publish.yaml
@@ -1,12 +1,8 @@
 name: dev-container-vscode-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/example-carbon-accounting-publish.yaml
+++ b/.github/workflows/example-carbon-accounting-publish.yaml
@@ -1,12 +1,8 @@
 name: example-carbon-accounting-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/example-supply-chain-app-publish.yaml
+++ b/.github/workflows/example-supply-chain-app-publish.yaml
@@ -1,12 +1,8 @@
 name: example-supply-chain-app-publish
 
-on:
+on:    
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/fabric2-all-in-one-publish.yaml
+++ b/.github/workflows/fabric2-all-in-one-publish.yaml
@@ -1,12 +1,8 @@
 name: fabric2-all-in-one-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/geth-all-in-one-publish.yaml
+++ b/.github/workflows/geth-all-in-one-publish.yaml
@@ -1,12 +1,8 @@
 name: geth-all-in-one-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/ghpkg-all-kotlin-api-clients-publish.yaml
+++ b/.github/workflows/ghpkg-all-kotlin-api-clients-publish.yaml
@@ -4,11 +4,10 @@ env:
   NODEJS_VERSION: v18.18.2
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    branches: [main, dev]
-
-  pull_request:
-    branches: [main, dev]
+    tags:
+      - v*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/iroha2-all-in-one-publish.yaml
+++ b/.github/workflows/iroha2-all-in-one-publish.yaml
@@ -1,12 +1,8 @@
 name: iroha2-all-in-one-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/keychain-vault-server-publish.yaml
+++ b/.github/workflows/keychain-vault-server-publish.yaml
@@ -1,12 +1,8 @@
 name: keychain-vault-server-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/quorum-all-in-one-publish.yaml
+++ b/.github/workflows/quorum-all-in-one-publish.yaml
@@ -1,12 +1,8 @@
 name: quorum-all-in-one-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/quorum-multi-party-all-in-one-publish.yaml
+++ b/.github/workflows/quorum-multi-party-all-in-one-publish.yaml
@@ -1,12 +1,8 @@
 name: quorum-multi-party-all-in-one-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/sawtooth-all-in-one-publish.yaml
+++ b/.github/workflows/sawtooth-all-in-one-publish.yaml
@@ -1,12 +1,8 @@
 name: sawtooth-all-in-one-publish
 
 on:
+  # Publish `v1.2.3` tags as releases.
   push:
-    # Publish `main` as Docker `latest` image.
-    branches:
-      - main
-
-    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 


### PR DESCRIPTION
### **Commit** to be reviewed
---
perf(ci): only publish artifacts on git version tags of main 
```
Primary Changes 
----------------
1. Remove auto publishing of container images in all **publish.yaml upon push and maintain automation runs during pull requests
```
Fixes #2360

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.