### PR TITLE
ci(coverage): add total typescript code coverage statistics

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -37,6 +37,7 @@
     "cids",
     "clsx",
     "cmds",
+    "Codecov",
     "commenceack",
     "configtx",
     "connectrpc",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@
 env:
   NODEJS_VERSION: v18.18.2
   RUN_TRIVY_SCAN: true 
+  RUN_CODE_COVERAGE: true
 jobs:
   ActionLint:
     uses: ./.github/workflows/actionlint.yaml
@@ -27,6 +28,16 @@ jobs:
           lint-git-repo-request: '{"cloneUrl": "${{ github.server_url }}/${{ github.repository }}.git", "fetchArgs": ["--update-head-ok", "--no-tags", "--prune", "--progress", "--no-recurse-submodules", "--depth=1", "origin" ,"+${{ github.sha }}:${{ github.ref }}"], "checkoutArgs": [ "${{ github.ref }}"], "targetPhrasePatterns": [], "configDefaultsUrl": "https://inclusivenaming.org/json/dci-lint-config-recommended-v1.json" }'
       - name: Get the output response
         run: echo "${{ steps.lint-git-repo.outputs.lint-git-repo-response }}"
+
+  check-coverage:
+    outputs:
+      run-coverage: ${{ steps.set-output.outputs.run-coverage }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Set output
+        id: set-output
+        run: echo "run-coverage=${{ env.RUN_CODE_COVERAGE }}" >> "$GITHUB_OUTPUT"
 
   compute_changed_packages:
     outputs:
@@ -383,6 +394,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-api-client/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-api-client
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: ./packages/cactus-api-client/src/test/typescript/integration/default-consortium-provider.test.ts
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
@@ -404,6 +417,13 @@ jobs:
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
 
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-1
+          path: ./code-coverage-ts/**/ 
+          
   cactus-cmd-api-server:
     continue-on-error: false
     needs:
@@ -415,6 +435,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-cmd-api-server/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-cmd-api-server
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
         --files={./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-from-github.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/integration/plugin-import-without-install.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/integration/remote-plugin-imports.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/certificates-work-for-mutual-tls.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/config/self-signed-certificate-generator/generates-working-certificates.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-js-proto-loader-client-healthcheck.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-healthcheck.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/grpc-proto-gen-ts-client-m-tls-enabled.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-consortium-manual.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-keychain-memory.test.ts,./packages/cactus-cmd-api-server/src/test/typescript/unit/plugins/install-basic-plugin-ledger-connector-fabric-0-7-0.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
@@ -436,6 +458,12 @@ jobs:
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
 
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-2
+          path: ./code-coverage-ts/**/ 
 
       - name: build_ncc_bundle
         run: yarn lerna run build:bundle --scope=@hyperledger/cactus-cmd-api-server
@@ -498,6 +526,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-cmd-socketio-server/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-cmd-socketio-server
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -518,6 +548,12 @@ jobs:
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
 
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-3
+          path: ./code-coverage-ts/**/ 
 
   cactus-common:
     continue-on-error: false
@@ -527,6 +563,8 @@ jobs:
       JEST_TEST_PATTERN: packages/cactus-common/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
       TAPE_TEST_PATTERN: './packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts'
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-common
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -547,12 +585,21 @@ jobs:
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
 
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-4
+          path: ./code-coverage-ts/**/ 
+
   cactus-core:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-core/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-core
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -572,12 +619,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-5
+          path: ./code-coverage-ts/**/ 
+
   cactus-core-api:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-core-api/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-core-api
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -597,12 +653,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+ 
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-6
+          path: ./code-coverage-ts/**/ 
+  
   ce-carbon-accounting-backend:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: examples/cactus-example-carbon-accounting-backend/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ce-carbon-accounting-backend
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: ./examples/cactus-example-carbon-accounting-backend/src/test/typescript/integration/admin-enroll-v1-endpoint.test.ts
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
@@ -623,12 +689,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-7
+          path: ./code-coverage-ts/**/ 
+
   ce-carbon-accounting-business-logic-plugin:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: examples/cactus-example-carbon-accounting-business-logic-plugin/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ce-carbon-accounting-business-logic-plugin
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -648,6 +723,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-8
+          path: ./code-coverage-ts/**/ 
+
   ce-carbon-accounting-frontend:
     continue-on-error: false
     env:
@@ -655,6 +737,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: examples/cactus-example-carbon-accounting-frontend/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: true
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ce-carbon-accounting-frontend
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -674,6 +758,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-9
+          path: ./code-coverage-ts/**/ 
   ce-supply-chain-backend:
     continue-on-error: false
     env:
@@ -682,6 +772,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: examples/cactus-example-supply-chain-backend/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ce-supply-chain-backend
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: '--files={./examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-backend-api-calls.test.ts,./examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-cli-via-npm-script.test.ts}'
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
@@ -702,12 +794,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-10
+          path: ./code-coverage-ts/**/ 
+
   ce-supply-chain-business-logic-plugin:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: examples/cactus-example-supply-chain-business-logic-plugin/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ce-supply-chain-business-logic-plugin
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -727,6 +828,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-11
+          path: ./code-coverage-ts/**/ 
+
   ce-supply-chain-frontend:
     continue-on-error: false
     env:
@@ -734,6 +842,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: examples/cactus-example-supply-chain-frontend/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: true
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ce-supply-chain-frontend
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -753,12 +863,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-12
+          path: ./code-coverage-ts/**/ 
+
   cp-consortium-manual:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-consortium-manual/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cp-consortium-manual
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -778,12 +897,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-13
+          path: ./code-coverage-ts/**/ 
+
   cp-htlc-coordinator-besu:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cp-htlc-coordinator-besu
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
+      TAPE_TEST_PATTERN: >-
+        --files={./extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript/integration/plugin-htlc-coordinator/counterparty-htlc-endpoint.test.ts,./extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript/integration/plugin-htlc-coordinator/own-htlc-endpoint.test.ts,./extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript/integration/plugin-htlc-coordinator/refund.test.ts,./extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript/integration/plugin-htlc-coordinator/withdraw-counterparty-endpoint.test.ts}
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -803,12 +933,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}  
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-14
+          path: ./code-coverage-ts/**/ 
+
   cp-htlc-eth-besu:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-htlc-eth-besu/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cp-htlc-eth-besu
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -828,12 +967,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-15
+          path: ./code-coverage-ts/**/ 
+
   cp-htlc-eth-besu-erc20:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-htlc-eth-besu-erc20/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cp-htlc-eth-besu-erc20
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -853,6 +1001,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-16
+          path: ./code-coverage-ts/**/ 
+
   cp-keychain-aws-sm:
     continue-on-error: false
     env:
@@ -860,6 +1015,8 @@ jobs:
       JEST_TEST_PATTERN: packages/cactus-plugin-keychain-aws-sm/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: true
       TAPE_TEST_PATTERN: '--files={./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts,./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts,./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-keychain-aws-sm.test.ts}'
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cp-keychain-aws-sm
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -879,12 +1036,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-17
+          path: ./code-coverage-ts/**/ 
+
   cp-keychain-azure-kv:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-keychain-azure-kv/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cp-keychain-azure-kv
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: ./packages/cactus-plugin-keychain-azure-kv/src/test/typescript/integration/plugin-keychain-azure-kv.test.ts
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
@@ -905,12 +1071,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-18
+          path: ./code-coverage-ts/**/ 
+
   cpk-google-sm:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-keychain-google-sm/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpk-google-sm
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: '--files={./packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts,./packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts,./packages/cactus-plugin-keychain-google-sm/src/test/typescript/integration/plugin-keychain-google-sm.test.ts}'
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
@@ -931,12 +1106,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-19
+          path: ./code-coverage-ts/**/ 
   cpk-memory:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-keychain-memory/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpk-memory
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -956,12 +1139,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-20
+          path: ./code-coverage-ts/**/ 
   cpk-memory-wasm:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-keychain-memory-wasm/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpk-memory-wasm
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
+      TAPE_TEST_PATTERN: ./packages/cactus-plugin-keychain-memory-wasm/src/test/typescript/unit/plugin-keychain-memory-wasm.test.ts
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -981,12 +1173,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-21
+          path: ./code-coverage-ts/**/ 
   cpk-vault:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-keychain-vault/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpk-vault
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: '--files={./packages/cactus-plugin-keychain-vault/src/test/typescript/integration/cactus-keychain-vault-server.test.ts,./packages/cactus-plugin-keychain-vault/src/test/typescript/integration/openapi/openapi-validation.test.ts,./packages/cactus-plugin-keychain-vault/src/test/typescript/integration/plugin-keychain-vault.test.ts}'
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
@@ -1007,6 +1207,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-22
+          path: ./code-coverage-ts/**/ 
   cpl-connector-aries:
     continue-on-error: false
     needs:
@@ -1017,6 +1223,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-aries/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpl-connector-aries
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     runs-on: ubuntu-22.04
     steps:
@@ -1034,6 +1242,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-23
+          path: ./code-coverage-ts/**/ 
   cpl-connector-besu:
     permissions: write-all
     continue-on-error: false
@@ -1045,6 +1259,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-besu/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpl-connector-besu
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
         --files={./packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/private-deploy-contract-from-json-web3-eea.test.ts,./packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/v21-get-record-locator.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
@@ -1065,7 +1281,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
-      
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-24
+          path: ./code-coverage-ts/**/ 
+
       - name: Ensure .tmp Directory Exists
         run: mkdir -p .tmp/benchmark-results/plugin-ledger-connector-besu/
 
@@ -1103,6 +1325,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-polkadot/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpl-connector-polkadot
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs:
       - build-dev
@@ -1125,6 +1349,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-25
+          path: ./code-coverage-ts/**/ 
   cpl-connector-corda:
     continue-on-error: false
     needs:
@@ -1136,6 +1366,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-corda/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpl-connector-corda
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
         --files={./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/flow-database-access-v4.8.test.ts,./packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/openapi/openapi-validation.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
@@ -1156,6 +1388,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-26
+          path: ./code-coverage-ts/**/ 
   
   cpl-connector-stellar:
     continue-on-error: false
@@ -1186,6 +1425,12 @@ jobs:
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
 
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-27
+          path: ./code-coverage-ts/**/ 
 
   plc-fabric-0:
     needs:
@@ -1200,6 +1445,8 @@ jobs:
       FREE_UP_GITHUB_RUNNER_DISK_SPACE_DISABLED: false
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/plc-fabric-0
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: ""
       TAPE_TEST_RUNNER_DISABLED: true
     runs-on: ubuntu-22.04
@@ -1219,6 +1466,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-28
+          path: ./code-coverage-ts/**/ 
 
   plc-fabric-1:
     needs:
@@ -1623,6 +1876,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: true
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cplc-go-ethereum-socketio
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -1642,6 +1897,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-29
+          path: ./code-coverage-ts/**/ 
   cplc-iroha2:
     continue-on-error: false
     needs:
@@ -1652,6 +1913,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-iroha2/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cplc-iroha2
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     runs-on: ubuntu-22.04
     steps:
@@ -1670,6 +1933,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-30
+          path: ./code-coverage-ts/**/ 
   cplc-ethereum:
     continue-on-error: false
     needs:
@@ -1680,6 +1949,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-ethereum/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cplc-ethereum
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     runs-on: ubuntu-22.04
     steps:
@@ -1697,12 +1968,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-31
+          path: ./code-coverage-ts/**/ 
   cplc-sawtooth:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-sawtooth/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cplc-sawtooth
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -1721,12 +2000,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-32
+          path: ./code-coverage-ts/**/ 
   cplc-xdai:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cplc-xdai
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
         --files={./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai-json-object.test.ts,./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/invoke-contract-xdai-json-object.test.ts,./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts,./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
@@ -1748,12 +2035,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-33
+          path: ./code-coverage-ts/**/ 
   cpp-ethereum:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-persistence-ethereum/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpp-ethereum
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -1773,12 +2068,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-34
+          path: ./code-coverage-ts/**/ 
   cp-object-store-ipfs:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: extensions/cactus-plugin-object-store-ipfs/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cp-object-store-ipfs
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: '--files={./extensions/cactus-plugin-object-store-ipfs/src/test/typescript/integration/plugin-object-store-ipfs.test.ts,./extensions/cactus-plugin-object-store-ipfs/src/test/typescript/unit/plugin-object-store-ipfs.test.ts}'
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
@@ -1799,6 +2102,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-35
+          path: ./code-coverage-ts/**/ 
   # cactus-plugin-satp-hermes:
   #   continue-on-error: false
   #   env:
@@ -1832,6 +2141,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_RUNNER_DISABLED: false
       JEST_TEST_PATTERN: packages/cactus-plugin-bungee-hermes/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cp-bungee-hermes
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -1851,12 +2162,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-36
+          path: ./code-coverage-ts/**/ 
   ct-api-client:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-api-client/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ct-api-client
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -1876,6 +2195,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-37
+          path: ./code-coverage-ts/**/ 
+
   ct-cmd-api-server:
     continue-on-error: false
     needs:
@@ -1886,6 +2212,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-cmd-api-server/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ct-cmd-api-server
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: ./packages/cactus-test-cmd-api-server/src/test/typescript/integration/plugin-import-with-npm-install-version-selection.test.ts
       TAPE_TEST_RUNNER_DISABLED: false
     runs-on: ubuntu-22.04
@@ -1905,12 +2233,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-38
+          path: ./code-coverage-ts/**/ 
   ct-geth-ledger:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-geth-ledger/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ct-geth-ledger
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -1930,6 +2266,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-39
+          path: ./code-coverage-ts/**/ 
   ctp-consortium-manual:
     continue-on-error: false
     env:
@@ -1956,6 +2298,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-40
+          path: ./code-coverage-ts/**/ 
   ctp-htlc-eth-besu:
     continue-on-error: false
     env:
@@ -1963,6 +2311,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ctp-htlc-eth-besu
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: '--files={./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/get-single-status-endpoint.test.ts,./packages/cactus-test-plugin-htlc-eth-besu/src/test/typescript/integration/plugin-htlc-eth-besu/openapi/openapi-validation.test.ts}'
       TAPE_TEST_RUNNER_DISABLED: false
     needs: build-dev
@@ -1983,6 +2333,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-41
+          path: ./code-coverage-ts/**/ 
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -1996,6 +2352,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ctp-htlc-eth-besu-erc20
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
         --files={./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/get-status-endpoint.test.ts,./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/openapi/openapi-validation.test.ts,./packages/cactus-test-plugin-htlc-eth-besu-erc20/src/test/typescript/integration/plugin-htlc-eth-besu-erc20/refund-endpoint.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
@@ -2017,6 +2375,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-42
+          path: ./code-coverage-ts/**/ 
   ctp-ledger-connector-besu:
     continue-on-error: false
     needs:
@@ -2027,6 +2391,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ctp-ledger-connector-besu
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
         --files={./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-balance-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-past-logs-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-transaction-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-balance-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-block-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-past-logs-endpoint.test.ts,./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-sign-transaction-endpoint.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
@@ -2047,12 +2413,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-43
+          path: ./code-coverage-ts/**/ 
   ctp-ledger-connector-ethereum:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-plugin-ledger-connector-ethereum/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/ctp-ledger-connector-ethereum
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -2071,6 +2445,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-44
+          path: ./code-coverage-ts/**/ 
   cactus-test-tooling:
     continue-on-error: false
     needs:
@@ -2081,6 +2461,8 @@ jobs:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-test-tooling/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-test-tooling
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_PATTERN: >-
         --files={./packages/cactus-test-tooling/src/test/typescript/integration/besu/besu-test-ledger/constructor-validates-options.test.ts,./packages/cactus-test-tooling/src/test/typescript/integration/fabric/fabric-test-ledger-v1/constructor-validates-options.test.ts,./packages/cactus-test-tooling/src/test/typescript/integration/postgres/postgres-test-container/constructor-validates-options.test.ts,./packages/cactus-test-tooling/src/test/typescript/integration/substrate/substrate-test-ledger-constructor.test.ts,./packages/cactus-test-tooling/src/test/typescript/integration/substrate/substrate-test-ledger-multiple-concurrent.test.ts}
       TAPE_TEST_RUNNER_DISABLED: false
@@ -2101,12 +2483,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-45
+          path: ./code-coverage-ts/**/ 
   cactus-verifier-client:
     continue-on-error: false
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-verifier-client/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-verifier-client
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
@@ -2126,6 +2516,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ hashFiles('./yarn.lock') }}
       - run: ./tools/ci.sh
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+      - name: Upload coverage reports as artifacts
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: coverage-reports-46
+          path: ./code-coverage-ts/**/ 
   ghcr-besu-all-in-one:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/coverage_ts.yaml
+++ b/.github/workflows/coverage_ts.yaml
@@ -1,0 +1,59 @@
+---
+    name: coverage_typescript
+    
+    env:
+      NODEJS_VERSION: v18.18.2
+    on:
+      workflow_run:
+        workflows: 
+         - Cactus_CI
+        types:
+          - completed
+    
+    jobs:
+      generate_coverage_report:
+        runs-on: ubuntu-22.04
+        if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'success' }}
+        steps:
+          - name: Check out repository
+            uses: actions/checkout@v4.1.1
+    
+          - name: Set up Node.js
+            uses: actions/setup-node@v4.0.2
+            with:
+              node-version: ${{ env.NODEJS_VERSION }}
+    
+          - name: Restore Yarn Cache
+            uses: actions/cache@v4.0.1
+            with:
+              path: ./.yarn/
+              key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+              restore-keys: |
+                ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+    
+          - name: Install dependencies and istanbul-merge
+            run: |
+              yarn install
+              yarn add istanbul-merge --dev
+    
+          - name: Download coverage reports
+            uses: actions/download-artifact@v4.1.1
+            with:
+              run-id: ${{ github.event.workflow_run.id }}
+              github-token: ${{ secrets.GITHUB_TOKEN }}
+              path: ./code-coverage-ts/
+    
+          - name: Merge and generate coverage reports
+            run: |
+              ls -R ./code-coverage-ts/**/**/
+              npx istanbul-merge --out coverage.json ./code-coverage-ts/coverage-reports-*/*/coverage-final.json
+              npx istanbul report --include coverage.json --dir cacti html
+              npx istanbul report --include coverage.json --dir cacti text
+              npx istanbul report --include coverage.json --dir cacti text-summary
+    
+          - name: Upload coverage reports to Codecov
+            uses: codecov/codecov-action@v4.0.1
+            with:
+              name: code-coverage-report
+              fail_ci_if_error: true
+              token: ${{ secrets.CODECOV_TOKEN }}

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -146,6 +146,8 @@ function mainTask()
 
   if [ "${JEST_TEST_RUNNER_DISABLED:-false}" = "true" ]; then
     echo "$(date +%FT%T%z) [CI] Jest test runner disabled. Skipping..."
+  elif [ "${JEST_TEST_CODE_COVERAGE_ENABLED:-true}" = "true" ]; then
+   yarn jest $JEST_TEST_PATTERN --coverage --coverageDirectory=$JEST_TEST_COVERAGE_PATH
   else
     yarn test:jest:all $JEST_TEST_PATTERN
   fi


### PR DESCRIPTION
### **Commit** to be reviewed
---
ci(coverage): add total typescript code coverage statistics
```
Primary Changes
----------------
1. Updated the ci.yaml and ci.sh to introduce total typescript code coverage statistics using jest and istanbul-merge
```
Fixes #2661

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.