### PR TITLE
test(plugin-consortium-manual): fix port binding - multiple API servers

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -756,13 +756,13 @@ export class ApiServer {
 
     log.debug("%s Registering %o CRPC routes handler(s).", fn, svcCount);
 
-    const registration = await this.crpcServer.register(fastifyConnectPlugin, {
+    await this.crpcServer.register(fastifyConnectPlugin, {
       routes: crpcRoutesHandler,
       shutdownTimeoutMs: 5000,
       grpc: true,
       grpcWeb: true,
     });
-    log.debug("%s Fastify registration OK=%o", fn, registration);
+    log.debug("%s Fastify CRPC service registration OK", fn);
 
     const crpcUrl = await this.crpcServer.listen({
       host: crpcHost,

--- a/packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts
+++ b/packages/cactus-test-api-client/src/test/typescript/integration/api-client-routing-node-to-node.test.ts
@@ -204,6 +204,7 @@ describe(testCase, () => {
       apiServerOptions.cockpitPort = 0;
       apiServerOptions.grpcPort = 0;
       apiServerOptions.apiTlsEnabled = false;
+      apiServerOptions.crpcPort = 0;
       const config =
         await configService.newExampleConfigConvict(apiServerOptions);
 
@@ -250,6 +251,7 @@ describe(testCase, () => {
       apiServerOptions.grpcPort = 0;
       apiServerOptions.apiTlsEnabled = false;
       apiServerOptions.plugins = [];
+      apiServerOptions.crpcPort = 0;
       const config =
         await configService.newExampleConfigConvict(apiServerOptions);
 

--- a/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/get-consortium-jws-endpoint.test.ts
+++ b/packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/get-consortium-jws-endpoint.test.ts
@@ -218,6 +218,7 @@ describe(testCase, () => {
       apiServerOptions.cockpitPort = 0;
       apiServerOptions.grpcPort = 0;
       apiServerOptions.apiTlsEnabled = false;
+      apiServerOptions.crpcPort = 0;
       const config =
         await configService.newExampleConfigConvict(apiServerOptions);
 
@@ -266,6 +267,7 @@ describe(testCase, () => {
       apiServerOptions.grpcPort = 0;
       apiServerOptions.apiTlsEnabled = false;
       apiServerOptions.plugins = [];
+      apiServerOptions.crpcPort = 0;
       const config =
         await configService.newExampleConfigConvict(apiServerOptions);
 
@@ -317,6 +319,7 @@ describe(testCase, () => {
       apiServerOptions.grpcPort = 0;
       apiServerOptions.apiTlsEnabled = false;
       apiServerOptions.plugins = [];
+      apiServerOptions.crpcPort = 0;
       const config =
         await configService.newExampleConfigConvict(apiServerOptions);
       pluginRegistry.add(pluginConsortiumManual);


### PR DESCRIPTION
1. The ConnectRPC port defaults to 6000 in the API server so for test cases where multiple
instances of the API server are created and started, we need to specify the ports
explicitly in the API server config so that they don't clash with each other casusing the
test to fail.
2. The fix here was to simply bind to port 0 for all the ConnectRPC listeners which
eliminated the possibility of a clash and the test is passing once again.
3. I also snuck in a quality of life improvement for contributors: the API server will no
longer log the entire details of the fastify server that is being used for CRPC thereby
reducing the verbosity of the logs by a wide margin.

Crash logs that revealed the bug in the test case:

```sh
024-05-31T20:14:00.9554919Z [2024-05-31T20:14:00.953Z] ERROR (api-server):
Failed to start ApiServer Error: listen EADDRINUSE: address already in use 127.0.0.1:6000
2024-05-31T20:14:00.9556755Z     at Http2Server.setupListenHandle [as _listen2] (node:net:1817:16)
2024-05-31T20:14:00.9557720Z     at listenInCluster (node:net:1865:12)
2024-05-31T20:14:00.9558408Z     at doListen (node:net:2014:7)
2024-05-31T20:14:00.9559355Z     at processTicksAndRejections (node:internal/process/task_queues:83:21)
2024-05-31T20:14:00.9560500Z     at runNextTicks (node:internal/process/task_queues:64:3)
2024-05-31T20:14:00.9561451Z     at processImmediate (node:internal/timers:447:9) {
2024-05-31T20:14:00.9562333Z   code: 'EADDRINUSE',
2024-05-31T20:14:00.9562857Z   errno: -98,
2024-05-31T20:14:00.9563533Z   syscall: 'listen',
2024-05-31T20:14:00.9564068Z   address: '127.0.0.1',
2024-05-31T20:14:00.9564540Z   port: 6000
2024-05-31T20:14:00.9564959Z }
```

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.