### PR TITLE
feat(bungee-hermes): ability to use connectors without instanciating APIs

### DIFF
--- a/packages/cactus-plugin-bungee-hermes/package.json
+++ b/packages/cactus-plugin-bungee-hermes/package.json
@@ -35,6 +35,11 @@
       "name": "André Augusto",
       "email": "andre.augusto@tecnico.ulisboa.pt",
       "url": "https://github.com/AndreAugusto11"
+    },
+    {
+      "name": "Carlos Amaro",
+      "email": "carlosrscamaro@tecnico.ulisboa.pt",
+      "url": "https://github.com/LordKubaya"
     }
   ],
   "main": "dist/lib/main/typescript/index.js",
@@ -64,6 +69,7 @@
     "axios": "1.7.2",
     "body-parser": "1.20.2",
     "fs-extra": "11.2.0",
+    "http-errors-enhanced-cjs": "2.0.1",
     "key-encoder": "2.0.3",
     "merkletreejs": "0.3.11",
     "typescript-optional": "2.0.1",

--- a/packages/cactus-plugin-bungee-hermes/src/main/typescript/plugin-bungee-hermes.ts
+++ b/packages/cactus-plugin-bungee-hermes/src/main/typescript/plugin-bungee-hermes.ts
@@ -48,6 +48,7 @@ import { MergeViewsEndpointV1 } from "./web-services/merge-views-endpoint";
 import { ProcessViewEndpointV1 } from "./web-services/process-view-endpoint";
 
 import { PrivacyPolicies } from "./view-creation/privacy-policies";
+import { PluginRegistry } from "@hyperledger/cactus-core";
 
 export interface IKeyPair {
   publicKey: Uint8Array;
@@ -56,6 +57,7 @@ export interface IKeyPair {
 
 export interface IPluginBungeeHermesOptions extends ICactusPluginOptions {
   instanceId: string;
+  readonly pluginRegistry: PluginRegistry;
   keyPair?: IKeyPair;
 
   logLevel?: LogLevelDesc;

--- a/packages/cactus-plugin-bungee-hermes/src/main/typescript/strategy/obtain-ledger-strategy.ts
+++ b/packages/cactus-plugin-bungee-hermes/src/main/typescript/strategy/obtain-ledger-strategy.ts
@@ -1,8 +1,10 @@
 import { Logger } from "@hyperledger/cactus-common";
 import { State } from "../view-creation/state";
+import { IPluginLedgerConnector } from "@hyperledger/cactus-core-api/src/main/typescript/plugin/ledger-connector/i-plugin-ledger-connector";
 
 export interface NetworkDetails {
-  connectorApiPath: string;
+  connectorApiPath?: string;
+  connector?: IPluginLedgerConnector<unknown, unknown, unknown, unknown>;
   participant: string;
 }
 export interface ObtainLedgerStrategy {

--- a/packages/cactus-plugin-bungee-hermes/src/main/typescript/strategy/strategy-besu.ts
+++ b/packages/cactus-plugin-bungee-hermes/src/main/typescript/strategy/strategy-besu.ts
@@ -10,10 +10,12 @@ import {
   EthContractInvocationType,
   EvmBlock,
   EvmLog,
+  EvmTransaction,
   GetBlockV1Request,
   GetPastLogsV1Request,
   GetTransactionV1Request,
   InvokeContractV1Request,
+  PluginLedgerConnectorBesu,
   Web3SigningCredential,
 } from "@hyperledger/cactus-plugin-ledger-connector-besu";
 import { State } from "../view-creation/state";
@@ -23,12 +25,14 @@ import { Transaction } from "../view-creation/transaction";
 import Web3 from "web3";
 import { Proof } from "../view-creation/proof";
 import { TransactionProof } from "../view-creation/transaction-proof";
+import { BadRequestError, InternalServerError } from "http-errors-enhanced-cjs";
 export interface BesuNetworkDetails extends NetworkDetails {
   signingCredential: Web3SigningCredential;
   keychainId: string;
   contractName: string;
   contractAddress: string;
 }
+
 export class StrategyBesu implements ObtainLedgerStrategy {
   public static readonly CLASS_NAME = "StrategyBesu";
 
@@ -44,25 +48,40 @@ export class StrategyBesu implements ObtainLedgerStrategy {
     stateIds: string[],
     networkDetails: BesuNetworkDetails,
   ): Promise<Map<string, State>> {
-    const fnTag = `${StrategyBesu.CLASS_NAME}#generateLedgerStates()`;
+    const fn = `${StrategyBesu.CLASS_NAME}#generateLedgerStates()`;
     this.log.debug(`Generating ledger snapshot`);
-    Checks.truthy(networkDetails, `${fnTag} networkDetails`);
+    Checks.truthy(networkDetails, `${fn} networkDetails`);
 
-    const config = new Configuration({
-      basePath: networkDetails.connectorApiPath,
-    });
-    const besuApi = new BesuApi(config);
+    let besuApi: BesuApi | undefined;
+    let connector: PluginLedgerConnectorBesu | undefined;
+
+    if (networkDetails.connector) {
+      connector = networkDetails.connector as PluginLedgerConnectorBesu;
+    } else if (networkDetails.connectorApiPath) {
+      const config = new Configuration({
+        basePath: networkDetails.connectorApiPath,
+      });
+      besuApi = new BesuApi(config);
+    } else {
+      throw new Error(
+        `${fn} networkDetails must have either connector or connectorApiPath`,
+      );
+    }
+    const connectorOrApiClient = networkDetails.connector ? connector : besuApi;
+    if (!connectorOrApiClient) {
+      throw new InternalServerError(`${fn} got neither connector nor BesuAPI`);
+    }
     const ledgerStates = new Map<string, State>();
     const assetsKey =
       stateIds.length == 0
-        ? await this.getAllAssetsKey(networkDetails, besuApi)
+        ? await this.getAllAssetsKey(networkDetails, connectorOrApiClient)
         : stateIds;
     this.log.debug("Current assets detected to capture: " + assetsKey);
     for (const assetKey of assetsKey) {
       const { transactions, values, blocks } = await this.getAllInfoByKey(
         assetKey,
         networkDetails,
-        besuApi,
+        connectorOrApiClient,
       );
 
       const state = new State(assetKey, values, transactions);
@@ -92,7 +111,7 @@ export class StrategyBesu implements ObtainLedgerStrategy {
 
   async getAllAssetsKey(
     networkDetails: BesuNetworkDetails,
-    api: BesuApi,
+    connectorOrApiClient: PluginLedgerConnectorBesu | BesuApi,
   ): Promise<string[]> {
     const parameters = {
       contractName: networkDetails.contractName,
@@ -103,29 +122,17 @@ export class StrategyBesu implements ObtainLedgerStrategy {
       signingCredential: networkDetails.signingCredential,
       gas: 1000000,
     };
-    const response = await api.invokeContractV1(
+    const response = await this.invokeContract(
       parameters as InvokeContractV1Request,
+      connectorOrApiClient,
     );
-
-    if (response.status >= 200 && response.status < 300) {
-      if (response.data.callOutput) {
-        return response.data.callOutput as string[];
-      } else {
-        throw new Error(
-          `${StrategyBesu.CLASS_NAME}#getAllAssetsKey: contract ${networkDetails.contractName} method getAllAssetsIDs output is falsy`,
-        );
-      }
-    }
-    throw new Error(
-      `${StrategyBesu.CLASS_NAME}#getAllAssetsKey: BesuAPI error with status ${response.status}: ` +
-        response.data,
-    );
+    return response;
   }
 
   async getAllInfoByKey(
     key: string,
     networkDetails: BesuNetworkDetails,
-    api: BesuApi,
+    connectorOrApiClient: PluginLedgerConnectorBesu | BesuApi,
   ): Promise<{
     transactions: Transaction[];
     values: string[];
@@ -137,57 +144,27 @@ export class StrategyBesu implements ObtainLedgerStrategy {
       address: networkDetails.contractAddress,
       topics: [[null], [Web3.utils.keccak256(key)]], //filter logs by asset key
     };
-    const response = await api.getPastLogsV1(req as GetPastLogsV1Request);
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error(
-        `${StrategyBesu.CLASS_NAME}#getAllInfoByKey: BesuAPI getPastLogsV1 error with status ${response.status}: ` +
-          response.data,
-      );
-    }
-    if (!response.data.logs) {
-      throw new Error(
-        `${StrategyBesu.CLASS_NAME}#getAllInfoByKey: BesuAPI getPastLogsV1 API call successfull but output data is falsy`,
-      );
-    }
 
-    const decoded = response.data.logs as EvmLog[];
+    const decoded = await this.getPastLogs(req, connectorOrApiClient);
     const transactions: Transaction[] = [];
     const blocks: Map<string, EvmBlock> = new Map<string, EvmBlock>();
     const values: string[] = [];
     this.log.debug("Getting transaction logs for asset: " + key);
 
     for (const log of decoded) {
-      const txTx = await api.getTransactionV1({
-        transactionHash: log.transactionHash,
-      } as GetTransactionV1Request);
+      const txTx = await this.getTransaction(
+        {
+          transactionHash: log.transactionHash,
+        } as GetTransactionV1Request,
+        connectorOrApiClient,
+      );
 
-      if (txTx.status < 200 || txTx.status >= 300) {
-        throw new Error(
-          `${StrategyBesu.CLASS_NAME}#getAllInfoByKey: BesuAPI getTransactionV1 error with status ${txTx.status}: ` +
-            txTx.data,
-        );
-      }
-      if (!txTx.data.transaction) {
-        throw new Error(
-          `${StrategyBesu.CLASS_NAME}#getAllInfoByKey: BesuAPI getTransactionV1 call successfull but output data is falsy`,
-        );
-      }
-
-      const txBlock = await api.getBlockV1({
-        blockHashOrBlockNumber: log.blockHash,
-      } as GetBlockV1Request);
-
-      if (txBlock.status < 200 || txBlock.status >= 300) {
-        throw new Error(
-          `${StrategyBesu.CLASS_NAME}#getAllInfoByKey: BesuAPI getBlockV1 error with status ${txBlock.status}: ` +
-            txBlock.data,
-        );
-      }
-      if (!txBlock.data.block) {
-        throw new Error(
-          `${StrategyBesu.CLASS_NAME}#getAllInfoByKey: BesuAPI getBlockV1 call successfull but output data is falsy`,
-        );
-      }
+      const txBlock = await this.getBlock(
+        {
+          blockHashOrBlockNumber: log.blockHash,
+        } as GetBlockV1Request,
+        connectorOrApiClient,
+      );
 
       this.log.debug(
         "Transaction: " +
@@ -197,24 +174,256 @@ export class StrategyBesu implements ObtainLedgerStrategy {
           "\n =========== \n",
       );
       const proof = new Proof({
-        creator: txTx.data.transaction.from as string, //no sig for besu
+        creator: txTx.from as string, //no sig for besu
       });
       const transaction: Transaction = new Transaction(
         log.transactionHash,
-        txBlock.data.block.timestamp,
+        txBlock.timestamp,
         new TransactionProof(proof, log.transactionHash),
       );
       transaction.setStateId(key);
       transaction.setTarget(networkDetails.contractAddress as string);
-      transaction.setPayload(
-        txTx.data.transaction.input ? txTx.data.transaction.input : "",
-      ); //FIXME: payload = transaction input ?
+      transaction.setPayload(txTx.input ? txTx.input : ""); //FIXME: payload = transaction input ?
       transactions.push(transaction);
       values.push(JSON.stringify(log.data));
 
-      blocks.set(transaction.getId(), txBlock.data.block);
+      blocks.set(transaction.getId(), txBlock);
     }
 
     return { transactions: transactions, values: values, blocks: blocks };
+  }
+
+  async invokeContract(
+    parameters: InvokeContractV1Request,
+    connectorOrApiClient: PluginLedgerConnectorBesu | BesuApi,
+  ): Promise<string[]> {
+    const fn = `${StrategyBesu.CLASS_NAME}#invokeContract()`;
+    if (!connectorOrApiClient) {
+      // throw BadRequestError because it is not our fault that we did not get
+      // all the needed parameters, e.g. we are signaling that this is a "user error"
+      // where the "user" is the other developer who called our function.
+      throw new BadRequestError(`${fn} connectorOrApiClient is falsy`);
+    } else if (connectorOrApiClient instanceof PluginLedgerConnectorBesu) {
+      const connector: PluginLedgerConnectorBesu = connectorOrApiClient;
+      const response = await connector.invokeContract(parameters);
+      if (!response) {
+        // We throw an InternalServerError because the user is not responsible
+        // for us not being able to obtain a result from the contract invocation.
+        // They provided us parameters for the call (which we then validated and
+        // accepted) an therefore now if something goes wrong we have to throw
+        // an exception accordingly (e.g. us "admitting fault")
+        throw new InternalServerError(`${fn} response is falsy`);
+      }
+      if (!response.callOutput) {
+        throw new InternalServerError(`${fn} response.callOutput is falsy`);
+      }
+      const { callOutput } = response;
+      if (!Array.isArray(callOutput)) {
+        throw new InternalServerError(`${fn} callOutput not an array`);
+      }
+      const allItemsAreStrings = callOutput.every((x) => typeof x === "string");
+      if (!allItemsAreStrings) {
+        throw new InternalServerError(`${fn} callOutput has non-string items`);
+      }
+      return response.callOutput as string[];
+    } else if (connectorOrApiClient instanceof BesuApi) {
+      const api: BesuApi = connectorOrApiClient;
+      const response = await api.invokeContractV1(parameters);
+      if (!response) {
+        throw new InternalServerError(`${fn} response is falsy`);
+      }
+      if (!response.status) {
+        throw new InternalServerError(`${fn} response.status is falsy`);
+      }
+      const { status, data, statusText, config } = response;
+      if (response.status < 200 || response.status > 300) {
+        // We log the error here on the debug level so that later on we can inspect the contents
+        // of it in the logs if we need to. The reason that this is important is because we do not
+        // want to dump the full response onto our own error response that is going back to the caller
+        // due to that potentially being a security issue that we are exposing internal data via the
+        // error responses.
+        // With that said, we still need to make sure that we can determine the root cause of any
+        // issues after the fact and therefore we must save the error response details somewhere (the logs)
+        this.log.debug("BesuAPI non-2xx HTTP response:", data, status, config);
+
+        // For the caller/client we just send back a generic error admitting that we somehow messed up:
+        const errorMessage = `${fn} BesuAPI error status: ${status}: ${statusText}`;
+        throw new InternalServerError(errorMessage);
+      }
+      if (!data) {
+        throw new InternalServerError(`${fn} response.data is falsy`);
+      }
+      if (!data.callOutput) {
+        throw new InternalServerError(`${fn} data.callOutput is falsy`);
+      }
+      const { callOutput } = data;
+      if (!Array.isArray(callOutput)) {
+        throw new InternalServerError(`${fn} callOutput not an array`);
+      }
+      const allItemsAreStrings = callOutput.every((x) => typeof x === "string");
+      if (!allItemsAreStrings) {
+        throw new InternalServerError(`${fn} callOutput has non-string items`);
+      }
+      return response.data.callOutput;
+    }
+    throw new InternalServerError(`${fn}: neither BesuAPI nor Connector given`);
+  }
+
+  async getPastLogs(
+    req: GetPastLogsV1Request,
+    connectorOrApiClient: PluginLedgerConnectorBesu | BesuApi,
+  ): Promise<EvmLog[]> {
+    const fn = `${StrategyBesu.CLASS_NAME}#getPastLogs()`;
+    if (!connectorOrApiClient) {
+      throw new BadRequestError(`${fn} connectorOrApiClient is falsy`);
+    } else if (connectorOrApiClient instanceof PluginLedgerConnectorBesu) {
+      const connector: PluginLedgerConnectorBesu = connectorOrApiClient;
+      const response = await connector.getPastLogs(req);
+      if (!response) {
+        throw new InternalServerError(`${fn} response is falsy`);
+      }
+      if (!response.logs) {
+        throw new InternalServerError(`${fn} response.logs is falsy`);
+      }
+      const { logs } = response;
+      if (!Array.isArray(logs)) {
+        throw new InternalServerError(`${fn} logs not an array`);
+      }
+      const allItemsAreEvmLog = logs.every((x) => this.isEvmLog(x));
+      if (!allItemsAreEvmLog) {
+        throw new InternalServerError(`${fn} logs has non-EvmLog items`);
+      }
+      return response.logs as EvmLog[];
+    } else if (connectorOrApiClient instanceof BesuApi) {
+      const api: BesuApi = connectorOrApiClient;
+      const response = await api.getPastLogsV1(req);
+      if (!response) {
+        throw new InternalServerError(`${fn} response is falsy`);
+      }
+      if (!response.status) {
+        throw new InternalServerError(`${fn} response.status is falsy`);
+      }
+      const { status, data, statusText, config } = response;
+      if (response.status < 200 || response.status > 300) {
+        this.log.debug("BesuAPI non-2xx HTTP response:", data, status, config);
+        const errorMessage = `${fn} BesuAPI error status: ${status}: ${statusText}`;
+        throw new InternalServerError(errorMessage);
+      }
+      if (!data) {
+        throw new InternalServerError(`${fn} response.data is falsy`);
+      }
+      if (!data.logs) {
+        throw new InternalServerError(`${fn} data.logs is falsy`);
+      }
+      const { logs } = data;
+      if (!Array.isArray(logs)) {
+        throw new InternalServerError(`${fn} logs not an array`);
+      }
+      const allItemsAreEvmLog = logs.every((x) => this.isEvmLog(x));
+      if (!allItemsAreEvmLog) {
+        throw new InternalServerError(`${fn} logs has non-EvmLog items`);
+      }
+      return response.data.logs;
+    }
+    throw new InternalServerError(`${fn}: neither BesuAPI nor Connector given`);
+  }
+
+  isEvmLog(x: any): x is EvmLog {
+    return (
+      "address" in x &&
+      "data" in x &&
+      "blockHash" in x &&
+      "transactionHash" in x &&
+      "topics" in x &&
+      "blockNumber" in x &&
+      "logIndex" in x &&
+      "transactionIndex" in x
+    );
+  }
+
+  async getTransaction(
+    req: GetTransactionV1Request,
+    connectorOrApiClient: PluginLedgerConnectorBesu | BesuApi,
+  ): Promise<EvmTransaction> {
+    const fn = `${StrategyBesu.CLASS_NAME}#getTransaction()`;
+    if (!connectorOrApiClient) {
+    } else if (connectorOrApiClient instanceof PluginLedgerConnectorBesu) {
+      const connector: PluginLedgerConnectorBesu = connectorOrApiClient;
+      const response = await connector.getTransaction(req);
+      if (!response) {
+        throw new InternalServerError(`${fn} response is falsy`);
+      }
+      if (!response.transaction) {
+        throw new InternalServerError(`${fn} response.transaction is falsy`);
+      }
+      return response.transaction;
+    } else if (connectorOrApiClient instanceof BesuApi) {
+      const api: BesuApi = connectorOrApiClient;
+      const response = await api.getTransactionV1(req);
+      if (!response) {
+        throw new InternalServerError(`${fn} response is falsy`);
+      }
+      if (!response.status) {
+        throw new InternalServerError(`${fn} response.status is falsy`);
+      }
+      const { status, data, statusText, config } = response;
+      if (response.status < 200 || response.status > 300) {
+        this.log.debug("BesuAPI non-2xx HTTP response:", data, status, config);
+
+        const errorMessage = `${fn} BesuAPI error status: ${status}: ${statusText}`;
+        throw new InternalServerError(errorMessage);
+      }
+      if (!data) {
+        throw new InternalServerError(`${fn} response.data is falsy`);
+      }
+      if (!data.transaction) {
+        throw new InternalServerError(`${fn} data.transaction is falsy`);
+      }
+      return response.data.transaction;
+    }
+    throw new InternalServerError(`${fn}: neither BesuAPI nor Connector given`);
+  }
+
+  async getBlock(
+    req: GetBlockV1Request,
+    connectorOrApiClient: PluginLedgerConnectorBesu | BesuApi,
+  ): Promise<EvmBlock> {
+    const fn = `${StrategyBesu.CLASS_NAME}#getBlock()`;
+    if (!connectorOrApiClient) {
+    } else if (connectorOrApiClient instanceof PluginLedgerConnectorBesu) {
+      const connector: PluginLedgerConnectorBesu = connectorOrApiClient;
+      const response = await connector.getBlock(req);
+      if (!response) {
+        throw new InternalServerError(`${fn} response is falsy`);
+      }
+      if (!response.block) {
+        throw new InternalServerError(`${fn} response.block is falsy`);
+      }
+      return response.block;
+    } else if (connectorOrApiClient instanceof BesuApi) {
+      const api: BesuApi = connectorOrApiClient;
+      const response = await api.getBlockV1(req);
+      if (!response) {
+        throw new InternalServerError(`${fn} response is falsy`);
+      }
+      if (!response.status) {
+        throw new InternalServerError(`${fn} response.status is falsy`);
+      }
+      const { status, data, statusText, config } = response;
+      if (response.status < 200 || response.status > 300) {
+        this.log.debug("BesuAPI non-2xx HTTP response:", data, status, config);
+
+        const errorMessage = `${fn} BesuAPI error status: ${status}: ${statusText}`;
+        throw new InternalServerError(errorMessage);
+      }
+      if (!data) {
+        throw new InternalServerError(`${fn} response.data is falsy`);
+      }
+      if (!data.block) {
+        throw new InternalServerError(`${fn} data.block is falsy`);
+      }
+      return data.block;
+    }
+    throw new InternalServerError(`${fn}: neither BesuAPI nor Connector given`);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9931,6 +9931,7 @@ __metadata:
     express: "npm:4.19.2"
     fabric-network: "npm:2.2.20"
     fs-extra: "npm:11.2.0"
+    http-errors-enhanced-cjs: "npm:2.0.1"
     key-encoder: "npm:2.0.3"
     merkletreejs: "npm:0.3.11"
     socket.io: "npm:4.6.2"


### PR DESCRIPTION
BUNGEE-Hermes required API credentials for ledger connectors within its methods. This change enables using Bungee with the connectors themselves.

https://github.com/hyperledger/cacti/pull/3251#pullrequestreview-2077548976

Summary:
- This includes the implementation to possibilitate the usage of ledgers connectors without instaciating API's with bungee.
- Tests changed to test for both using connectos and API's.