### PR TITLE
build: unpin OpenAPI specs from v2.0.0-alpha.2 URL refs, use REMOTE

### DIFF
--- a/extensions/cactus-plugin-htlc-coordinator-besu/src/main/json/openapi.tpl.json
+++ b/extensions/cactus-plugin-htlc-coordinator-besu/src/main/json/openapi.tpl.json
@@ -69,7 +69,7 @@
           },
           "web3SigningCredential": {
             "description": "Web3SigningCredential",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
           "inputAmount": {
@@ -147,7 +147,7 @@
           },
           "web3SigningCredential": {
             "description": "Web3SigningCredential",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
           "gas": {
@@ -186,7 +186,7 @@
           },
           "web3SigningCredential": {
             "description": "Web3SigningCredential",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
           "htlcId": {

--- a/extensions/cactus-plugin-object-store-ipfs/src/main/json/openapi.json
+++ b/extensions/cactus-plugin-object-store-ipfs/src/main/json/openapi.json
@@ -34,6 +34,7 @@
       "GetObjectRequestV1": {
         "type": "object",
         "required": ["key"],
+        "additionalProperties": false,
         "properties": {
           "key": {
             "type": "string",
@@ -67,6 +68,7 @@
       "SetObjectRequestV1": {
         "type": "object",
         "required": ["key", "value"],
+        "additionalProperties": false,
         "properties": {
           "key": {
             "type": "string",
@@ -100,6 +102,7 @@
       "HasObjectRequestV1": {
         "type": "object",
         "required": ["key"],
+        "additionalProperties": false,
         "properties": {
           "key": {
             "type": "string",

--- a/extensions/cactus-plugin-object-store-ipfs/src/main/json/openapi.tpl.json
+++ b/extensions/cactus-plugin-object-store-ipfs/src/main/json/openapi.tpl.json
@@ -47,11 +47,11 @@
         "summary": "Retrieves an object from the object store.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/4bf8038ea4c0c341cef3a63b59f77c12cec65a46/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/object_store_get_object_v1_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/object_store_get_object_v1_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/4bf8038ea4c0c341cef3a63b59f77c12cec65a46/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/object_store_get_object_v1_response_body"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/object_store_get_object_v1_response_body"
           }
         }
       }
@@ -68,11 +68,11 @@
         "summary": "Sets an object in the object store under the specified key.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/4bf8038ea4c0c341cef3a63b59f77c12cec65a46/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/object_store_set_object_v1_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/object_store_set_object_v1_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/4bf8038ea4c0c341cef3a63b59f77c12cec65a46/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/object_store_set_object_v1_response_body"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/object_store_set_object_v1_response_body"
           }
         }
       }
@@ -89,11 +89,11 @@
         "summary": "Checks the presence of an object in the object store.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/4bf8038ea4c0c341cef3a63b59f77c12cec65a46/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/object_store_has_object_v1_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/object_store_has_object_v1_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/4bf8038ea4c0c341cef3a63b59f77c12cec65a46/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/object_store_has_object_v1_response_body"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/object_store_has_object_v1_response_body"
           }
         }
       }

--- a/packages/cactus-plugin-consortium-manual/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-consortium-manual/src/main/json/openapi.tpl.json
@@ -17,7 +17,7 @@
         "properties": {
           "jws": {
             "description": "The JSON Web Signature of the Cactus node.",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/schemas/JWSGeneral",
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/schemas/JWSGeneral",
             "nullable": false
           }
         }
@@ -28,7 +28,7 @@
         "properties": {
           "jws": {
             "description": "The JSON Web Signature of the Cactus consortium.",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/schemas/JWSGeneral",
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/schemas/JWSGeneral",
             "nullable": false,
             "format": "The general format which is a JSON object, not a string."
           }

--- a/packages/cactus-plugin-htlc-eth-besu-erc20/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-htlc-eth-besu-erc20/src/main/json/openapi.tpl.json
@@ -76,7 +76,7 @@
           },
           "web3SigningCredential": {
             "description": "Web3SigningCredentialType",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
           "connectorId": {
@@ -118,7 +118,7 @@
           },
           "web3SigningCredential": {
             "description": "Web3SigningCredentialType",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
           "connectorId": {
@@ -166,7 +166,7 @@
           },
           "web3SigningCredential": {
             "description": "Web3SigningCredentialType",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
           "connectorId": {
@@ -208,7 +208,7 @@
             }
           },
           "web3SigningCredential": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
           },
           "connectorId": {
             "type": "string"
@@ -232,7 +232,7 @@
             "type": "string"
           },
           "web3SigningCredential": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
           },
           "connectorId": {
             "type": "string"
@@ -269,7 +269,7 @@
           },
           "web3SigningCredential": {
             "description": "Web3SigningCredential",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
           "gas": {
@@ -333,7 +333,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/RunTransactionResponse"
+                  "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/RunTransactionResponse"
                 }
               }
             }
@@ -367,7 +367,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
+                  "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
                 }
               }
             }
@@ -453,7 +453,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
+                  "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
                 }
               }
             }
@@ -487,7 +487,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
+                  "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
                 }
               }
             }

--- a/packages/cactus-plugin-htlc-eth-besu/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-htlc-eth-besu/src/main/json/openapi.tpl.json
@@ -59,7 +59,7 @@
             "nullable": false
           },
           "web3SigningCredential": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
           },
           "keychainId": {
             "description": "keychainId for the keychian plugin",
@@ -94,7 +94,7 @@
             "nullable": false
           },
           "web3SigningCredential": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
           },
           "connectorId": {
             "description": "connectorId for the connector besu plugin",
@@ -141,7 +141,7 @@
           },
           "web3SigningCredential": {
             "description": "Web3SigningCredentialType",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
           "connectorId": {
@@ -193,7 +193,7 @@
           },
           "web3SigningCredential": {
             "description": "Web3SigningCredential",
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential",
             "nullable": false
           },
           "gas": {
@@ -218,7 +218,7 @@
             }
           },
           "web3SigningCredential": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
           },
           "connectorId": {
             "type": "string"
@@ -242,7 +242,7 @@
             "type": "string"
           },
           "web3SigningCredential": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
+            "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/Web3SigningCredential"
           },
           "connectorId": {
             "type": "string"
@@ -306,7 +306,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
+                  "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
                 }
               }
             }
@@ -338,7 +338,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
+                  "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
                 }
               }
             }
@@ -371,7 +371,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
+                  "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/InvokeContractV1Response"
                 }
               }
             }
@@ -455,7 +455,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/RunTransactionResponse"
+                  "$ref": "../../../../../packages/cactus-plugin-ledger-connector-besu/src/main/json/openapi.json#/components/schemas/RunTransactionResponse"
                 }
               }
             }

--- a/packages/cactus-plugin-keychain-aws-sm/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-keychain-aws-sm/src/main/json/openapi.tpl.json
@@ -39,23 +39,23 @@
         "summary": "Retrieves the contents of a keychain entry from the backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
           },
           "404": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
           }
         }
       }
@@ -72,20 +72,20 @@
         "summary": "Sets a value under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
           }
         }
       }
@@ -102,20 +102,20 @@
         "summary": "Deletes an entry under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_500"
           }
         }
       }
@@ -132,20 +132,20 @@
         "summary": "Checks that an entry exists under a key on the keychain backend",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
           }
         }
       }

--- a/packages/cactus-plugin-keychain-azure-kv/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-keychain-azure-kv/src/main/json/openapi.tpl.json
@@ -34,23 +34,23 @@
         "summary": "Retrieves the contents of a keychain entry from the backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
           },
           "404": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
           }
         }
       }
@@ -67,20 +67,20 @@
         "summary": "Sets a value under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
           }
         }
       }
@@ -97,20 +97,20 @@
         "summary": "Deletes a value under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_500"
           }
         }
       }
@@ -127,20 +127,20 @@
         "summary": "Checks that an entry exists under a key on the keychain backend",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
           }
         }
       }

--- a/packages/cactus-plugin-keychain-google-sm/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-keychain-google-sm/src/main/json/openapi.tpl.json
@@ -25,23 +25,23 @@
         "summary": "Retrieves the contents of a keychain entry from the backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
           },
           "404": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
           }
         }
       }
@@ -58,20 +58,20 @@
         "summary": "Sets a value under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
           }
         }
       }
@@ -88,11 +88,11 @@
         "summary": "Deletes an entry under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
           }
         }
       }
@@ -109,20 +109,20 @@
         "summary": "Checks that an entry exists under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
           }
         }
       }

--- a/packages/cactus-plugin-keychain-memory-wasm/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-keychain-memory-wasm/src/main/json/openapi.tpl.json
@@ -22,23 +22,23 @@
         "summary": "Retrieves the contents of a keychain entry from the backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
           },
           "404": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
           }
         }
       }
@@ -55,20 +55,20 @@
         "summary": "Sets a value under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
           }
         }
       }
@@ -85,20 +85,20 @@
         "summary": "Deletes an entry under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_500"
           }
         }
       }
@@ -115,20 +115,20 @@
         "summary": "Checks that an entry exists under a key on the keychain backend",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
           }
         }
       }

--- a/packages/cactus-plugin-keychain-memory/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-keychain-memory/src/main/json/openapi.tpl.json
@@ -30,23 +30,23 @@
         "summary": "Retrieves the contents of a keychain entry from the backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
           },
           "404": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
           }
         }
       }
@@ -63,20 +63,20 @@
         "summary": "Sets a value under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
           }
         }
       }
@@ -93,20 +93,20 @@
         "summary": "Deletes an entry under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_delete_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_delete_entry_500"
           }
         }
       }
@@ -123,20 +123,20 @@
         "summary": "Checks that an entry exists under a key on the keychain backend",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_has_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_has_entry_500"
           }
         }
       }

--- a/packages/cactus-plugin-keychain-vault/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-keychain-vault/src/main/json/openapi.tpl.json
@@ -94,23 +94,23 @@
         "summary": "Retrieves the contents of a keychain entry from the backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_get_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_401"
           },
           "404": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_404"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_get_entry_500"
           }
         }
       }
@@ -195,20 +195,20 @@
         "summary": "Sets a value under a key on the keychain backend.",
         "parameters": [],
         "requestBody": {
-          "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
+          "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/requestBodies/keychain_set_entry_request_body"
         },
         "responses": {
           "200": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_200"
           },
           "400": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_400"
           },
           "401": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_401"
           },
           "500": {
-            "$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2/packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
+            "$ref": "../../../../../packages/cactus-core-api/src/main/json/openapi.json#/components/responses/keychain_set_entry_500"
           }
         }
       }


### PR DESCRIPTION
On a high level this is a find & replace operation where the occurrences of the
first bullet point were replaced with the second bullet point:
* `"$ref": "https://raw.githubusercontent.com/hyperledger/cactus/v2.0.0-alpha.2`
* `"$ref": "../../../../..`

The firs bullet point above is called a URL reference while the second one is
called a REMOTE references (remote as in a different spec file on the file-system).

1. With this change, we unlock the release process being able to issue code that
is working on the latest OpenAPI specifications that we are cross-referencing
from one package to another.
2. Previously you had to manually update the references in about a hundred
and fifty locations to make sure that the versions are bumped but after this
change this happens automatically as the newly introduced bundling process
and the usage of the REMOTE references instead of URL references.
3. The problem so far with the release process was that with the URL references
we dependended on the existence of a pushed git tag for a successful release build.
But we cannot git push the tag before having performed a successful release build,
so this was a chicken-egg problem that had to be somehow untangled from its
circular dependency hell and this change is what makes it happen by no longer
depending on the git tags having been pushed to the upstream repository.

Related to, but does not yet fix: https://github.com/hyperledger/cacti/issues/2175

Depends on #3288

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.