### PR TITLE
ci(github): fix VSCode dev container publish job - use official builder

### DIFF
--- a/.github/workflows/dev-container-vscode-publish.yaml
+++ b/.github/workflows/dev-container-vscode-publish.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   IMAGE_NAME: cactus-dev-container-vscode
+  NODEJS_VERSION: v18.18.2
 
 jobs:
   # Push image to GitHub Packages.
@@ -31,15 +32,17 @@ jobs:
       contents: read
 
     steps:
+      - name: Use Node.js ${{ env.NODEJS_VERSION }}
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
       - uses: actions/checkout@v4.1.1
-
-      - name: Build image
-        run: docker build "$DOCKER_BUILD_DIR" --file "$DOCKERFILE_PATH" --tag "$IMAGE_NAME" --label "runnumber=${GITHUB_RUN_ID}"
-
+      - name: npm_install_@devcontainers/cli@0.44.0
+        run: npm install -g @devcontainers/cli@0.44.0
+      - name: npx_yes_devcontainers_cli_build
+        run: npx --yes @devcontainers/cli@0.44.0 build --workspace-folder="./" --log-level=trace --push=false --config="./.devcontainer/devcontainer.json" --image-name="$IMAGE_NAME"
       - name: Log in to registry
-        # This is where you will update the PAT to GITHUB_TOKEN
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
       - name: Push image
         run: |
           SHORTHASH=$(git rev-parse --short "$GITHUB_SHA")


### PR DESCRIPTION
1. We don't have a Dockerfile anymore to define the image of the dev container
instead the build's input is the `devcontainer.json` file which can be built
using the `@devcontainers/cli` npm package instead of the usual `docker build`
command on the terminal.
2. The ci.yaml job building the image was already doing the build this way but
we must've forgotten to update the publish job as well.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.