### PR TITLE
build(release-management): fix checklist and OpenAPI spec version bumps

### DIFF
--- a/RELEASE_MANAGEMENT.md
+++ b/RELEASE_MANAGEMENT.md
@@ -30,9 +30,10 @@ git rebase upstream/main
 git push --force-with-lease
 git checkout -b release-v1.1.3
 yarn run configure
-yarn lerna version 1.1.3 --ignore-scripts --conventional-commits --exact --git-remote upstream --message="chore(release): publish %s" --no-push --no-git-tag-version --no-ignore-changes --force-publish
-yarn tools:bump-openapi-spec-dep-versions
+yarn lerna version 1.1.3 --ignore-scripts --conventional-commits --exact --git-remote upstream --message="chore(release): publish %s" --no-push --no-git-tag-version --no-ignore-changes
+yarn tools:bump-openapi-spec-dep-versions --target-version=1.1.3
 yarn codegen
+yarn build:dev
 ./tools/weaver-update-version.sh 1.1.3 .
 ./tools/go-gen-checksum.sh 1.1.3 .
 ```

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint": "yarn run format && yarn run spellcheck",
     "format": "eslint '**/*.{js,ts}' --quiet --fix",
     "spellcheck": "cspell lint --no-progress \"*/*/src/**/*.{js,ts}\"",
-    "tsc": "tsc --build --verbose",
+    "tsc": "NODE_OPTIONS=\"--max_old_space_size=3072\" tsc --build --verbose",
     "codegen": "run-s 'codegen:warmup-*' codegen:lerna codegen:cleanup",
     "codegen:cleanup": "rm --force --verbose ./openapitools.json",
     "codegen:lerna": "lerna run codegen",


### PR DESCRIPTION
1. After this change the steps within the release management documentation should
work without issues.
2. Currently the process is (was) broken due to our reliance on URL references
within the OpenAPI specifications which created a chicken-egg problem with the
release tag issuance and the building of the source code to be released.

This change depends on the other pull requests that are refactoring the cross-package
OpenAPI specification references:

Depends on #3288
Depends on #3315

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.