### PR TITLE
docs(RELEASE_MANAGEMENT): explain auto-merge for release PRs is a no-no

### DIFF
--- a/RELEASE_MANAGEMENT.md
+++ b/RELEASE_MANAGEMENT.md
@@ -80,6 +80,14 @@ git push --set-upstream upstream release-v1.1.3
 
 ### Then create a PR here - once that's merged, rebase onto upstream/main and:
 
+**IMPORTANT**: Do not enable auto-merging on GitHub for the pull request doing the release.
+The problem with auto-merging here is that it would modify the release commit's SHA as the
+rebase would happen on GitHub's servers where your git signing identity is not available to use
+given that GitHub does (should) not have access to your private key for signing.
+The way the preserve your commit signature as valid the commit SHA must remain the same and the
+way to achieve this is to perform the pull request merging with fast forward. The merging
+ensures that there is no commit SHA change and the `--ff-only` option ensures that there is no
+merge commit to throw a wrench in the process.
 
 1. Do a merge freeze
 2. Unfreeze the specific pull request that you just opened for the release issuance


### PR DESCRIPTION
The detailed explanation is here:

Do not enable auto-merging on GitHub for the pull request doing the release.
The problem with auto-merging here is that it would modify the release commit's SHA as the
rebase would happen on GitHub's servers where your git signing identity is not available to use
given that GitHub does (should) not have access to your private key for signing.
The way the preserve your commit signature as valid the commit SHA must remain the same and the
way to achieve this is to perform the pull request merging with fast forward. The merging
ensures that there is no commit SHA change and the `--ff-only` option ensures that there is no
merge commit to throw a wrench in the process.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.