### PR TITLE
ci(github): add --ignore-scripts to lerna publish - some are failing

### DIFF
--- a/.github/workflows/all-nodejs-packages-publish.yaml
+++ b/.github/workflows/all-nodejs-packages-publish.yaml
@@ -40,4 +40,4 @@ jobs:
         git config --global user.email "npm-ci@hyperledger.org"
         git config --global user.name "hyperledger-ghci"
         npm whoami
-        yarn lerna publish from-git --yes --loglevel=debug
+        yarn lerna publish from-git --yes --loglevel=debug --ignore-scripts


### PR DESCRIPTION
1. Longer term we'll just fix the scripts that are crashing, but right now
as a short term solution I disabled the script execution.
2. It might even be more secure for us to use this ignore scripts flag
permanently because some of the attack vectors are in those scripts which
new versions of the dependencies can execute arbitrary code.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.