### PR TITLE
ci: fix weaver nodejs publish ignore local .npmrc

### DIFF
--- a/weaver/common/protos-js/Makefile
+++ b/weaver/common/protos-js/Makefile
@@ -6,7 +6,7 @@ build:
 
 .PHONY: publish
 publish: build
-	npm publish
+	npm publish --no-workspaces
 
 .PHONY: clean-build
 clean-build:

--- a/weaver/sdks/besu/node/makefile
+++ b/weaver/sdks/besu/node/makefile
@@ -28,7 +28,7 @@ build-local:
 
 .PHONE: publish
 publish: .npmrc
-	npm publish
+	npm publish --no-workspaces
 	
 
 clean:

--- a/weaver/sdks/fabric/interoperation-node-sdk/makefile
+++ b/weaver/sdks/fabric/interoperation-node-sdk/makefile
@@ -28,7 +28,7 @@ build-local:
 
 .PHONE: publish
 publish: .npmrc
-	npm publish
+	npm publish --no-workspaces
 	
 
 clean:


### PR DESCRIPTION
Fix the issue identified in previous release, here is the error log screenshot, where it was ignoring local `.npmrc` required for publishing, and then later on `npm publish` is unable to authenticate:
<img width="1154" alt="Screenshot 2024-06-21 at 1 31 25 AM" src="https://github.com/hyperledger/cacti/assets/17192099/293d76fa-2eaf-4685-8324-3109495c56bd">
<img width="933" alt="Screenshot 2024-06-21 at 1 43 51 AM" src="https://github.com/hyperledger/cacti/assets/17192099/07f870e9-efd9-416f-b6ee-8ee2d83b8ffd">


**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.