### PR TITLE
build(typescript): upgrade compiler to v5.5.x

### DIFF
--- a/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/asset-reference/typescript/package.json
+++ b/examples/cactus-example-cbdc-bridging-backend/src/fabric-contracts/asset-reference/typescript/package.json
@@ -38,7 +38,7 @@
         "sinon-chai": "^3.5.0",
         "ts-node": "^8.8.1",
         "tslint": "^6.1.0",
-        "typescript": "5.3.3",
+        "typescript": "5.5.2",
         "winston": "^3.2.1"
     },
     "nyc": {

--- a/examples/cactus-example-cbdc-bridging-frontend/package.json
+++ b/examples/cactus-example-cbdc-bridging-frontend/package.json
@@ -37,7 +37,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "typescript": "5.3.3",
+    "typescript": "5.5.2",
     "uuid": "9.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/examples/cactus-example-electricity-trade/tools/transferNumericAsset/package.json
+++ b/examples/cactus-example-electricity-trade/tools/transferNumericAsset/package.json
@@ -19,6 +19,6 @@
     "socket.io": "4.6.2"
   },
   "devDependencies": {
-    "typescript": "5.3.3"
+    "typescript": "5.5.2"
   }
 }

--- a/examples/test-run-transaction/package.json
+++ b/examples/test-run-transaction/package.json
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "@types/escape-html": "1.0.1",
-    "typescript": "5.3.3"
+    "typescript": "5.5.2"
   }
 }

--- a/examples/test-run-transaction/supply-chain-app-stub/package.json
+++ b/examples/test-run-transaction/supply-chain-app-stub/package.json
@@ -9,7 +9,7 @@
     "express": "4.19.2",
     "moment": "2.29.4",
     "ts-node": "10.9.1",
-    "typescript": "5.3.3",
+    "typescript": "5.5.2",
     "helmet": "4.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "ts-jest": "29.1.1",
     "ts-loader": "9.4.4",
     "ts-node": "10.9.1",
-    "typescript": "5.3.3",
+    "typescript": "5.5.2",
     "web3": "4.1.1",
     "web3-core": "4.1.1",
     "web3-eth": "4.1.1",

--- a/packages/cacti-ledger-browser/package.json
+++ b/packages/cacti-ledger-browser/package.json
@@ -79,7 +79,7 @@
     "@types/react": "18.2.43",
     "@types/react-dom": "18.2.17",
     "@vitejs/plugin-react": "4.2.1",
-    "typescript": "5.2.2",
+    "typescript": "5.5.2",
     "vite": "5.1.7"
   }
 }

--- a/packages/cactus-plugin-bungee-hermes/src/test/typescript/fabric-contracts/lock-asset/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-bungee-hermes/src/test/typescript/fabric-contracts/lock-asset/chaincode-typescript/package.json
@@ -25,7 +25,7 @@
         "@types/node": "10.17.60",
         "@types/sinon": "5.0.7",
         "@types/sinon-chai": "3.2.8",
-        "typescript": "3.9.10"
+        "typescript": "5.5.2"
     },
     "nyc": {
         "extension": [

--- a/packages/cactus-plugin-bungee-hermes/src/test/typescript/fabric-contracts/simple-asset/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-bungee-hermes/src/test/typescript/fabric-contracts/simple-asset/chaincode-typescript/package.json
@@ -25,7 +25,7 @@
         "@types/node": "18.11.9",
         "@types/sinon": "5.0.7",
         "@types/sinon-chai": "3.2.8",
-        "typescript": "5.3.3"
+        "typescript": "5.5.2"
     },
     "nyc": {
         "extension": [

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/basic-asset-transfer/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/basic-asset-transfer/chaincode-typescript/package.json
@@ -37,7 +37,7 @@
         "sinon-chai": "3.7.0",
         "ts-node": "7.0.1",
         "tslint": "5.20.1",
-        "typescript": "5.3.3"
+        "typescript": "5.5.2"
     },
     "nyc": {
         "extension": [

--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/lock-asset/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/fixtures/go/lock-asset/chaincode-typescript/package.json
@@ -37,7 +37,7 @@
         "sinon-chai": "3.7.0",
         "ts-node": "7.0.1",
         "tslint": "5.20.1",
-        "typescript": "5.3.3"
+        "typescript": "5.5.2"
     },
     "nyc": {
         "extension": [

--- a/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/package.json
+++ b/packages/cactus-plugin-ledger-connector-go-ethereum-socketio/src/test/typescript/unit-test/package.json
@@ -19,7 +19,7 @@
     "web3": "1.7.0"
   },
   "devDependencies": {
-    "typescript": "5.3.3",
+    "typescript": "5.5.2",
     "@types/shelljs": "^0.8.12"
   }
 }

--- a/packages/cactus-plugin-satp-hermes/package.json
+++ b/packages/cactus-plugin-satp-hermes/package.json
@@ -81,7 +81,7 @@
     "express": "4.19.2",
     "fabric-network": "2.2.20",
     "kubo-rpc-client": "3.0.1",
-    "typescript": "5.3.3"
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/fabric-contracts/lock-asset/chaincode-typescript/package.json
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/fabric-contracts/lock-asset/chaincode-typescript/package.json
@@ -37,7 +37,7 @@
         "sinon-chai": "3.7.0",
         "ts-node": "7.0.1",
         "tslint": "5.20.1",
-        "typescript": "5.3.3"
+        "typescript": "5.5.2"
     },
     "nyc": {
         "extension": [

--- a/weaver/core/drivers/fabric-driver/package-local.json
+++ b/weaver/core/drivers/fabric-driver/package-local.json
@@ -33,8 +33,8 @@
   "devDependencies": {
     "@types/node": "18.11.9",
     "nodemon": "2.0.22",
-    "typedoc": "0.25.6",
-    "typescript": "5.3.3"
+    "typedoc": "0.26.2",
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/core/drivers/fabric-driver/package.json
+++ b/weaver/core/drivers/fabric-driver/package.json
@@ -33,8 +33,8 @@
   "devDependencies": {
     "@types/node": "18.11.9",
     "nodemon": "2.0.22",
-    "typedoc": "0.25.6",
-    "typescript": "5.3.3"
+    "typedoc": "0.26.2",
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/core/identity-management/iin-agent/package-local.json
+++ b/weaver/core/identity-management/iin-agent/package-local.json
@@ -43,8 +43,8 @@
     "sinon": "6.3.5",
     "sinon-chai": "3.7.0",
     "ts-node": "10.9.1",
-    "typedoc": "0.25.6",
-    "typescript": "5.3.3"
+    "typedoc": "0.26.2",
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/core/identity-management/iin-agent/package.json
+++ b/weaver/core/identity-management/iin-agent/package.json
@@ -43,8 +43,8 @@
     "sinon": "6.3.5",
     "sinon-chai": "3.7.0",
     "ts-node": "10.9.1",
-    "typedoc": "0.25.6",
-    "typescript": "5.3.3"
+    "typedoc": "0.26.2",
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/samples/besu/besu-cli/package-local.json
+++ b/weaver/samples/besu/besu-cli/package-local.json
@@ -46,7 +46,7 @@
     "jest": "29.6.2",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
-    "typescript": "5.3.3"
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/samples/besu/besu-cli/package.json
+++ b/weaver/samples/besu/besu-cli/package.json
@@ -46,7 +46,7 @@
     "jest": "29.6.2",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
-    "typescript": "5.3.3"
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/samples/besu/simpleasset/package.json
+++ b/weaver/samples/besu/simpleasset/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "truffle": "5.11.2",
-    "typescript": "5.3.3"
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/samples/fabric/fabric-cli/package-local.json
+++ b/weaver/samples/fabric/fabric-cli/package-local.json
@@ -53,7 +53,7 @@
     "@types/node": "18.11.9",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
-    "typescript": "5.3.3"
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/samples/fabric/fabric-cli/package.json
+++ b/weaver/samples/fabric/fabric-cli/package.json
@@ -53,7 +53,7 @@
     "@types/node": "18.11.9",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
-    "typescript": "5.3.3"
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/sdks/besu/node/package-local.json
+++ b/weaver/sdks/besu/node/package-local.json
@@ -29,8 +29,8 @@
     "sinon": "6.3.5",
     "sinon-chai": "3.7.0",
     "ts-node": "10.9.1",
-    "typedoc": "0.25.6",
-    "typescript": "5.3.3"
+    "typedoc": "0.26.2",
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/sdks/besu/node/package.json
+++ b/weaver/sdks/besu/node/package.json
@@ -29,8 +29,8 @@
     "sinon": "6.3.5",
     "sinon-chai": "3.7.0",
     "ts-node": "10.9.1",
-    "typedoc": "0.25.6",
-    "typescript": "5.3.3"
+    "typedoc": "0.26.2",
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
+++ b/weaver/sdks/fabric/interoperation-node-sdk/package-local.json
@@ -62,8 +62,8 @@
     "sinon": "6.3.5",
     "sinon-chai": "3.7.0",
     "ts-node": "10.9.1",
-    "typedoc": "0.25.6",
-    "typescript": "5.3.3"
+    "typedoc": "0.26.2",
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/weaver/sdks/fabric/interoperation-node-sdk/package.json
+++ b/weaver/sdks/fabric/interoperation-node-sdk/package.json
@@ -62,8 +62,8 @@
     "sinon": "6.3.5",
     "sinon-chai": "3.7.0",
     "ts-node": "10.9.1",
-    "typedoc": "0.25.6",
-    "typescript": "5.3.3"
+    "typedoc": "0.26.2",
+    "typescript": "5.5.2"
   },
   "engines": {
     "node": ">=18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7393,7 +7393,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-scripts: "npm:5.0.1"
-    typescript: "npm:5.3.3"
+    typescript: "npm:5.5.2"
     uuid: "npm:9.0.1"
     web-vitals: "npm:^2.1.4"
   languageName: unknown
@@ -7421,7 +7421,7 @@ __metadata:
     react-apexcharts: "npm:1.4.1"
     react-dom: "npm:18.2.0"
     react-router-dom: "npm:6.21.3"
-    typescript: "npm:5.2.2"
+    typescript: "npm:5.5.2"
     vite: "npm:5.1.7"
     web3: "npm:4.1.1"
   languageName: unknown
@@ -7477,7 +7477,7 @@ __metadata:
     jest: "npm:29.6.2"
     ts-jest: "npm:29.1.1"
     ts-node: "npm:10.9.1"
-    typescript: "npm:5.3.3"
+    typescript: "npm:5.5.2"
     web3: "npm:1.10.0"
     winston: "npm:3.10.0"
   bin:
@@ -7497,7 +7497,7 @@ __metadata:
     ganache-cli: "npm:6.12.2"
     solc: "npm:0.8.21"
     truffle: "npm:5.11.2"
-    typescript: "npm:5.3.3"
+    typescript: "npm:5.5.2"
     web3: "npm:1.10.0"
   languageName: unknown
   linkType: soft
@@ -7533,8 +7533,8 @@ __metadata:
     fabric-protos: "npm:2.2.20"
     level: "npm:8.0.0"
     nodemon: "npm:2.0.22"
-    typedoc: "npm:0.25.6"
-    typescript: "npm:5.3.3"
+    typedoc: "npm:0.26.2"
+    typescript: "npm:5.5.2"
     winston: "npm:3.10.0"
   languageName: unknown
   linkType: soft
@@ -7557,7 +7557,7 @@ __metadata:
     gluegun: "npm:5.1.6"
     ts-jest: "npm:29.1.1"
     ts-node: "npm:10.9.1"
-    typescript: "npm:5.3.3"
+    typescript: "npm:5.5.2"
     uuid: "npm:9.0.1"
     winston: "npm:3.10.0"
   bin:
@@ -7591,8 +7591,8 @@ __metadata:
     sinon: "npm:6.3.5"
     sinon-chai: "npm:3.7.0"
     ts-node: "npm:10.9.1"
-    typedoc: "npm:0.25.6"
-    typescript: "npm:5.3.3"
+    typedoc: "npm:0.26.2"
+    typescript: "npm:5.5.2"
     uuid: "npm:9.0.1"
   languageName: unknown
   linkType: soft
@@ -7624,8 +7624,8 @@ __metadata:
     sinon: "npm:6.3.5"
     sinon-chai: "npm:3.7.0"
     ts-node: "npm:10.9.1"
-    typedoc: "npm:0.25.6"
-    typescript: "npm:5.3.3"
+    typedoc: "npm:0.26.2"
+    typescript: "npm:5.5.2"
     web3: "npm:1.10.0"
     web3-utils: "npm:1.10.0"
   languageName: unknown
@@ -7657,8 +7657,8 @@ __metadata:
     sjcl: "npm:1.0.8"
     sshpk: "npm:1.17.0"
     ts-node: "npm:10.9.1"
-    typedoc: "npm:0.25.6"
-    typescript: "npm:5.3.3"
+    typedoc: "npm:0.26.2"
+    typescript: "npm:5.5.2"
     uuid: "npm:9.0.1"
   languageName: unknown
   linkType: soft
@@ -9095,7 +9095,7 @@ __metadata:
     secp256k1: "npm:4.0.3"
     socket.io: "npm:4.6.2"
     sqlite3: "npm:5.1.5"
-    typescript: "npm:5.3.3"
+    typescript: "npm:5.5.2"
     typescript-optional: "npm:2.0.1"
     uuid: "npm:9.0.1"
     web3: "npm:1.6.1"
@@ -9536,7 +9536,7 @@ __metadata:
     ts-jest: "npm:29.1.1"
     ts-loader: "npm:9.4.4"
     ts-node: "npm:10.9.1"
-    typescript: "npm:5.3.3"
+    typescript: "npm:5.5.2"
     web3: "npm:4.1.1"
     web3-core: "npm:4.1.1"
     web3-eth: "npm:4.1.1"
@@ -13314,6 +13314,13 @@ __metadata:
     "@sentry/types": "npm:5.30.0"
     tslib: "npm:^1.9.3"
   checksum: 10/4aa8acf7d0d9688c927a620cbb9fd37d6d2738f701863af772be329baca2cede909dcae6c7b4b449474787245c09212909ee740b4cae143d21ddb1fed910cc3a
+  languageName: node
+  linkType: hard
+
+"@shikijs/core@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@shikijs/core@npm:1.9.0"
+  checksum: 10/ec07699742f0561ab4d2fb07715397183cbed23ca42e082b14e9e5f85eb7f8647897f69698d003d8c6a1b8682da0af77861b3a2f78d366eef7581bae4415142c
   languageName: node
   linkType: hard
 
@@ -17561,13 +17568,6 @@ __metadata:
   version: 6.0.1
   resolution: "ansi-regex@npm:6.0.1"
   checksum: 10/1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
-  languageName: node
-  linkType: hard
-
-"ansi-sequence-parser@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "ansi-sequence-parser@npm:1.1.1"
-  checksum: 10/9ce30f257badc2ef62cac8028a7e26c368d22bf26650427192e8ffd102da42e377e3affe90fae58062eecc963b0b055f510dde3b677c7e0c433c67069b5a8ee5
   languageName: node
   linkType: hard
 
@@ -34091,7 +34091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:3.2.0, jsonc-parser@npm:^3.2.0":
+"jsonc-parser@npm:3.2.0":
   version: 3.2.0
   resolution: "jsonc-parser@npm:3.2.0"
   checksum: 10/bd68b902e5f9394f01da97921f49c5084b2dc03a0c5b4fdb2a429f8d6f292686c1bf87badaeb0a8148d024192a88f5ad2e57b2918ba43fe25cf15f3371db64d4
@@ -35250,6 +35250,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkify-it@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "linkify-it@npm:5.0.0"
+  dependencies:
+    uc.micro: "npm:^2.0.0"
+  checksum: 10/ef3b7609dda6ec0c0be8a7b879cea195f0d36387b0011660cd6711bba0ad82137f59b458b7e703ec74f11d88e7c1328e2ad9b855a8500c0ded67461a8c4519e6
+  languageName: node
+  linkType: hard
+
 "lint-staged@npm:11.2.6":
   version: 11.2.6
   resolution: "lint-staged@npm:11.2.6"
@@ -36213,12 +36222,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "marked@npm:4.3.0"
+"markdown-it@npm:^14.1.0":
+  version: 14.1.0
+  resolution: "markdown-it@npm:14.1.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+    entities: "npm:^4.4.0"
+    linkify-it: "npm:^5.0.0"
+    mdurl: "npm:^2.0.0"
+    punycode.js: "npm:^2.3.1"
+    uc.micro: "npm:^2.1.0"
   bin:
-    marked: bin/marked.js
-  checksum: 10/c830bb4cb3705b754ca342b656e8a582d7428706b2678c898b856f6030c134ce2d1e19136efa3e6a1841f7330efbd24963d6bdeddc57d2938e906250f99895d0
+    markdown-it: bin/markdown-it.mjs
+  checksum: 10/f34f921be178ed0607ba9e3e27c733642be445e9bb6b1dba88da7aafe8ba1bc5d2f1c3aa8f3fc33b49a902da4e4c08c2feadfafb290b8c7dda766208bb6483a9
   languageName: node
   linkType: hard
 
@@ -36283,6 +36299,13 @@ __metadata:
   version: 2.0.4
   resolution: "mdn-data@npm:2.0.4"
   checksum: 10/2236dbec301f7e148a9cc4f91c0c45fd0271a9a5e7defc80792da2d64d823f24be51dd28d24f328896fc504d84e00d1833eeac47a55e47729ec6ed0308aa824a
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdurl@npm:2.0.0"
+  checksum: 10/1720349d4a53e401aa993241368e35c0ad13d816ad0b28388928c58ca9faa0cf755fa45f18ccbf64f4ce54a845a50ddce5c84e4016897b513096a68dac4b0158
   languageName: node
   linkType: hard
 
@@ -36793,6 +36816,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: 10/79f2ba42e638110f122e9102388fa59298c398f8cf7e587afc5877d2144dab87f528bb66478665c6b4a217d00c8c0722885754e85510b5b0c4dd10460bd3751f
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "minimatch@npm:9.0.4"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/4cdc18d112b164084513e890d6323370db14c22249d536ad1854539577a895e690a27513dc346392f61a4a50afbbd8abc88f3f25558bfbbbb862cd56508b20f5
   languageName: node
   linkType: hard
 
@@ -42150,6 +42182,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode.js@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "punycode.js@npm:2.3.1"
+  checksum: 10/f0e946d1edf063f9e3d30a32ca86d8ff90ed13ca40dad9c75d37510a04473340cfc98db23a905cc1e517b1e9deb0f6021dce6f422ace235c60d3c9ac47c5a16a
+  languageName: node
+  linkType: hard
+
 "punycode@npm:1.3.2":
   version: 1.3.2
   resolution: "punycode@npm:1.3.2"
@@ -45216,15 +45255,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shiki@npm:^0.14.7":
-  version: 0.14.7
-  resolution: "shiki@npm:0.14.7"
+"shiki@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "shiki@npm:1.9.0"
   dependencies:
-    ansi-sequence-parser: "npm:^1.1.0"
-    jsonc-parser: "npm:^3.2.0"
-    vscode-oniguruma: "npm:^1.7.0"
-    vscode-textmate: "npm:^8.0.0"
-  checksum: 10/be3f2444c65bd0c57802026f171cb42ad571d361ee885be0c292b60785f68c70f19b69310f5ffe7f7a93db4c5ef50211e0a0248794bc6bb48d242bc43fe72a62
+    "@shikijs/core": "npm:1.9.0"
+  checksum: 10/ce5648b4e1a5e5e81e54e01ec9dc94cf324530f460058f29f1e5e464dbf096fee2194fbef38b29128a747f783f9134531991316b01ed168f65d0617dabf84c33
   languageName: node
   linkType: hard
 
@@ -48884,19 +48920,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:0.25.6":
-  version: 0.25.6
-  resolution: "typedoc@npm:0.25.6"
+"typedoc@npm:0.26.2":
+  version: 0.26.2
+  resolution: "typedoc@npm:0.26.2"
   dependencies:
     lunr: "npm:^2.3.9"
-    marked: "npm:^4.3.0"
-    minimatch: "npm:^9.0.3"
-    shiki: "npm:^0.14.7"
+    markdown-it: "npm:^14.1.0"
+    minimatch: "npm:^9.0.4"
+    shiki: "npm:^1.9.0"
+    yaml: "npm:^2.4.5"
   peerDependencies:
-    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10/4d3858152859598e0a7ed34f3ed023a4ad83b4fa0c684b14752e23b59c3102d265596eb510f2ab8665e7b8e67b5a601fe3f70c9eab1b0a2fece63c33088ea848
+  checksum: 10/f7cbe3e4a7635fe8fef9aacd62eedf72ff008548eebdcfc9a8b8ffea3cb6c06846230a022f436ba006bf11bf669b1e7fcf375349410e1f2d920b42531cd1f5b4
   languageName: node
   linkType: hard
 
@@ -48942,23 +48979,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.2.2, typescript@npm:^4.6.4 || ^5.0.0":
+"typescript@npm:5.5.2":
+  version: 5.5.2
+  resolution: "typescript@npm:5.5.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/9118b20f248e76b0dbff8737fef65dfa89d02668d4e633d2c5ceac99033a0ca5e8a1c1a53bc94da68e8f67677a88f318663dde859c9e9a09c1e116415daec2ba
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.6.4 || ^5.0.0":
   version: 5.2.2
   resolution: "typescript@npm:5.2.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/d65e50eb849bd21ff8677e5b9447f9c6e74777e346afd67754934264dcbf4bd59e7d2473f6062d9a015d66bd573311166357e3eb07fea0b52859cf9bb2b58555
-  languageName: node
-  linkType: hard
-
-"typescript@npm:5.3.3":
-  version: 5.3.3
-  resolution: "typescript@npm:5.3.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/6e4e6a14a50c222b3d14d4ea2f729e79f972fa536ac1522b91202a9a65af3605c2928c4a790a4a50aa13694d461c479ba92cedaeb1e7b190aadaa4e4b96b8e18
   languageName: node
   linkType: hard
 
@@ -48972,7 +49009,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^4.6.4 || ^5.0.0#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>":
+  version: 5.5.2
+  resolution: "typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>::version=5.5.2&hash=379a07"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/ac3145f65cf9e72ab29f2196e05d5816b355dc1a9195b9f010d285182a12457cfacd068be2dd22c877f88ebc966ac6e0e83f51c8586412b16499a27e3670ff4b
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^4.6.4 || ^5.0.0#optional!builtin<compat/typescript>":
   version: 5.2.2
   resolution: "typescript@patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:
@@ -48982,13 +49029,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>":
-  version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/c93786fcc9a70718ba1e3819bab56064ead5817004d1b8186f8ca66165f3a2d0100fee91fa64c840dcd45f994ca5d615d8e1f566d39a7470fc1e014dbb4cf15d
+"uc.micro@npm:^2.0.0, uc.micro@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "uc.micro@npm:2.1.0"
+  checksum: 10/37197358242eb9afe367502d4638ac8c5838b78792ab218eafe48287b0ed28aaca268ec0392cc5729f6c90266744de32c06ae938549aee041fc93b0f9672d6b2
   languageName: node
   linkType: hard
 
@@ -49899,20 +49943,6 @@ __metadata:
   version: 1.0.10
   resolution: "vscode-languageserver-textdocument@npm:1.0.10"
   checksum: 10/4edf7d190fccf1f0b8c2e3fe0e7a783844df22cf5ed66ff1a30854131a012b748b59c3e478a65e9471fbd8b7da18c668e5f0251aed6c9543399cbc5e71afd84b
-  languageName: node
-  linkType: hard
-
-"vscode-oniguruma@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "vscode-oniguruma@npm:1.7.0"
-  checksum: 10/7da9d21459f9788544b258a5fd1b9752df6edd8b406a19eea0209c6bf76507d5717277016799301c4da0d536095f9ca8c06afd1ab8f4001189090c804ca4814e
-  languageName: node
-  linkType: hard
-
-"vscode-textmate@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "vscode-textmate@npm:8.0.0"
-  checksum: 10/9fa7d66d6042cb090d116c2d8820d34c8870cfcbaed6e404da89f66b899970ed0ac47b59a2e30fc40a25af5414822bb3ea27974f714e9b91910d69c894be95f7
   languageName: node
   linkType: hard
 
@@ -53687,6 +53717,15 @@ __metadata:
   version: 2.3.3
   resolution: "yaml@npm:2.3.3"
   checksum: 10/3b1a974b9d3672c671d47099a41c0de77b7ff978d0849aa55a095587486e82cd072321d19f2b4c791a367f766310b5a82dff098839b0f4ddcbbbe477f82dfb07
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.4.5":
+  version: 2.4.5
+  resolution: "yaml@npm:2.4.5"
+  bin:
+    yaml: bin.mjs
+  checksum: 10/b09bf5a615a65276d433d76b8e34ad6b4c0320b85eb3f1a39da132c61ae6e2ff34eff4624e6458d96d49566c93cf43408ba5e568218293a8c6541a2006883f64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. Brings in size and performance improvements.
2. Also adds support for some new features such as Ecmascript setters

https://www.infoworld.com/article/3715246/typescript-adds-support-for-ecmascripts-set-methods.html

Fixes #3326

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.