### PR TITLE
feat(connector-corda): add JSON classname->JVM class object deserialize

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/JsonJvmObjectDeserializer.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/JsonJvmObjectDeserializer.kt
@@ -74,6 +74,10 @@ class JsonJvmObjectDeserializer(
                 val constructorArgs: Array<Any?> = jvmObject.jvmCtorArgs.map { x -> instantiate(x) }.toTypedArray()
 
                 when {
+                    Class::class.java.isAssignableFrom(clazz) -> {
+                        val x = constructorArgs.map { ca -> ca as String }.first()
+                        return Class.forName(x)
+                    }
                     DoubleArray::class.java.isAssignableFrom(clazz) -> {
                         return constructorArgs
                             .map { ca -> ca as Double }

--- a/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/test/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/JsonJvmObjectDeserializerTest.kt
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/test/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/impl/JsonJvmObjectDeserializerTest.kt
@@ -9,12 +9,35 @@ enum class Direction {
     NORTH, SOUTH, WEST, EAST
 }
 
+class TestTxData {}
 class JsonJvmObjectDeserializerTest {
 
     companion object {
         val deserializer = JsonJvmObjectDeserializer()
     }
 
+
+    @Test
+    fun classForNameHappyPath() {
+        
+        val jvmObject = JvmObject(
+            jvmTypeKind = JvmTypeKind.REFERENCE,
+            jvmType = JvmType(
+                fqClassName = Class::class.java.name
+            ),
+            jvmCtorArgs = listOf(
+                JvmObject(
+                    jvmTypeKind = JvmTypeKind.PRIMITIVE,
+                    jvmType = JvmType(String::class.java.name),
+                    primitiveValue = TestTxData::class.java.name
+                )
+            )
+        )
+
+        val deserializedObject = deserializer.instantiate(jvmObject)
+
+        assert(deserializedObject == TestTxData::class.java)
+    }
     @Test
     fun enumHappyPath() {
         val actual = Direction.WEST


### PR DESCRIPTION
1. This allows the API clients to specify a class name from which the backend
will retrieve the JVM Class<?> object.
2. It is very simple under the hood it just uses `Class.forName(x)`
3. It is needed to be able to do this because when passing in flow parameters
sometimes the arguments are Class<?> objects and so this was a feature gap.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.