### PR TITLE
test(connector-corda): fix deploy-cordapp-jars-to-nodes-v4.8-express

### DIFF
--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.8-express.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/deploy-cordapp-jars-to-nodes-v4.8-express.test.ts
@@ -1,10 +1,10 @@
+import type { AddressInfo } from "net";
 import test, { Test } from "tape-promise/tape";
 import { v4 as internalIpV4 } from "internal-ip";
 import { v4 as uuidv4 } from "uuid";
 import http from "http";
 import bodyParser from "body-parser";
 import express from "express";
-import { AddressInfo } from "net";
 
 import { Containers, CordaTestLedger } from "@hyperledger/cactus-test-tooling";
 import {
@@ -16,6 +16,7 @@ import {
   SampleCordappEnum,
   CordaConnectorContainer,
 } from "@hyperledger/cactus-test-tooling";
+import { Configuration } from "@hyperledger/cactus-core-api";
 
 import {
   CordappDeploymentConfig,
@@ -25,7 +26,6 @@ import {
   InvokeContractV1Request,
   JvmTypeKind,
 } from "../../../main/typescript/generated/openapi/typescript-axios/index";
-import { Configuration } from "@hyperledger/cactus-core-api";
 
 import {
   IPluginLedgerConnectorCordaOptions,
@@ -33,18 +33,16 @@ import {
 } from "../../../main/typescript/plugin-ledger-connector-corda";
 import { K_CACTUS_CORDA_TOTAL_TX_COUNT } from "../../../main/typescript/prometheus-exporter/metrics";
 
-const logLevel: LogLevelDesc = "TRACE";
+const logLevel: LogLevelDesc = "INFO";
 
-// Skipping this until we figure out how to make the test case stable
-// https://github.com/hyperledger/cactus/issues/1598
-test.skip("Tests are passing on the JVM side", async (t: Test) => {
+test("Tests are passing on the JVM side", async (t: Test) => {
   test.onFailure(async () => {
     await Containers.logDiagnostics({ logLevel });
   });
 
   const ledger = new CordaTestLedger({
     imageName: "ghcr.io/hyperledger/cactus-corda-4-8-all-in-one-obligation",
-    imageVersion: "2021-08-31--feat-889",
+    imageVersion: "2023-11-03-86d6b38",
     logLevel,
   });
   t.ok(ledger, "CordaTestLedger v4.8 instantaited OK");
@@ -111,7 +109,7 @@ test.skip("Tests are passing on the JVM side", async (t: Test) => {
   const connector = new CordaConnectorContainer({
     logLevel,
     imageName: "ghcr.io/hyperledger/cactus-connector-corda-server",
-    imageVersion: "2021-11-23--feat-1493",
+    imageVersion: "2023-08-25-ea5522b",
     envVars: [envVarSpringAppJson],
   });
   t.ok(CordaConnectorContainer, "CordaConnectorContainer instantiated OK");


### PR DESCRIPTION
1. Upgrading the images that were being used made it so that now the test
is no longer flaky/broken (or at least that's what a series of executions
of it made it looked like on my local machine)
2. Based on the above it might be worthwhile to put this test back into the
ones that are running (previously it was marked to be skipped).
3. We should keep an eye on it to make sure it's not flaky on the CI either
(which has resources much more constrained than my local development machine)

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.