### PR TITLE
test(test-tooling: add negotiation-cordapp support from kotlin-samples

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/corda/corda-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/corda/corda-test-ledger.ts
@@ -341,20 +341,28 @@ export class CordaTestLedger implements ITestLedger {
     return Containers.getPublicPort(22, aContainerInfo);
   }
 
-  public async getCorDappsDirPartyA(): Promise<string> {
-    return "/samples-kotlin/Advanced/obligation-cordapp/build/nodes/ParticipantA/cordapps";
+  public async getCorDappsDirPartyA(
+    sampleCordapp: SampleCordappEnum = SampleCordappEnum.ADVANCED_OBLIGATION,
+  ): Promise<string> {
+    return SAMPLE_CORDAPP_DATA[sampleCordapp].cordappDirPartyA;
   }
 
-  public async getCorDappsDirPartyB(): Promise<string> {
-    return "/samples-kotlin/Advanced/obligation-cordapp/build/nodes/ParticipantB/cordapps";
+  public async getCorDappsDirPartyB(
+    sampleCordapp: SampleCordappEnum = SampleCordappEnum.ADVANCED_OBLIGATION,
+  ): Promise<string> {
+    return SAMPLE_CORDAPP_DATA[sampleCordapp].cordappDirPartyB;
   }
 
-  public async getCorDappsDirPartyC(): Promise<string> {
-    return "/samples-kotlin/Advanced/obligation-cordapp/build/nodes/ParticipantC/cordapps";
+  public async getCorDappsDirPartyC(
+    sampleCordapp: SampleCordappEnum = SampleCordappEnum.ADVANCED_OBLIGATION,
+  ): Promise<string> {
+    return SAMPLE_CORDAPP_DATA[sampleCordapp].cordappDirPartyC;
   }
 
-  public async getCorDappsDirPartyNotary(): Promise<string> {
-    return "/samples-kotlin/Advanced/obligation-cordapp/build/nodes/Notary/cordapps";
+  public async getCorDappsDirPartyNotary(
+    sampleCordapp: SampleCordappEnum = SampleCordappEnum.ADVANCED_OBLIGATION,
+  ): Promise<string> {
+    return SAMPLE_CORDAPP_DATA[sampleCordapp].cordappDirNotary;
   }
 
   public async getSshConfig(): Promise<SshConfig> {

--- a/packages/cactus-test-tooling/src/main/typescript/corda/sample-cordapp-enum.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/corda/sample-cordapp-enum.ts
@@ -6,6 +6,7 @@
  */
 export const enum SampleCordappEnum {
   ADVANCED_OBLIGATION = "ADVANCED_OBLIGATION",
+  ADVANCED_NEGOTIATION = "ADVANCED_NEGOTIATION",
   BASIC_CORDAPP = "BASIC_CORDAPP",
   BASIC_FLOW = "BASIC_FLOW",
 }
@@ -19,6 +20,14 @@ export const enum SampleCordappEnum {
 export const SAMPLE_CORDAPP_DATA = Object.freeze({
   [SampleCordappEnum.ADVANCED_OBLIGATION]: {
     rootDir: "/samples-kotlin/Advanced/obligation-cordapp/",
+    cordappDirPartyA:
+      "/samples-kotlin/Advanced/obligation-cordapp/build/nodes/ParticipantA/cordapps",
+    cordappDirPartyB:
+      "/samples-kotlin/Advanced/obligation-cordapp/build/nodes/ParticipantB/cordapps",
+    cordappDirPartyC:
+      "/samples-kotlin/Advanced/obligation-cordapp/build/nodes/ParticipantC/cordapps",
+    cordappDirNotary:
+      "/samples-kotlin/Advanced/obligation-cordapp/build/nodes/Notary/cordapps",
     jars: [
       {
         jarRelativePath: "contracts/build/libs/contracts-1.0.jar",
@@ -30,8 +39,36 @@ export const SAMPLE_CORDAPP_DATA = Object.freeze({
       },
     ],
   },
+  [SampleCordappEnum.ADVANCED_NEGOTIATION]: {
+    rootDir: "/samples-kotlin/Advanced/negotiation-cordapp/",
+    cordappDirPartyA:
+      "/samples-kotlin/Advanced/negotiation-cordapp/build/nodes/ParticipantA/cordapps",
+    cordappDirPartyB:
+      "/samples-kotlin/Advanced/negotiation-cordapp/build/nodes/ParticipantB/cordapps",
+    cordappDirPartyC: "NOT_APPLICABLE__THIS_SAMPLE_ONLY_HAS_A_AND_B_PARTIES",
+    cordappDirNotary:
+      "/samples-kotlin/Advanced/negotiation-cordapp/build/nodes/Notary/cordapps",
+    jars: [
+      {
+        jarRelativePath: "contracts/build/libs/contracts-0.2.jar",
+        fileName: "_contracts-0.2.jar",
+      },
+      {
+        jarRelativePath: "workflows/build/libs/workflows-0.2.jar",
+        fileName: "_workflows-0.2.jar",
+      },
+    ],
+  },
   [SampleCordappEnum.BASIC_CORDAPP]: {
     rootDir: "/samples-kotlin/Basic/cordapp-example/",
+    cordappDirPartyA:
+      "/samples-kotlin/Basic/cordapp-example/build/nodes/ParticipantA/cordapps",
+    cordappDirPartyB:
+      "/samples-kotlin/Basic/cordapp-example/build/nodes/ParticipantB/cordapps",
+    cordappDirPartyC:
+      "/samples-kotlin/Basic/cordapp-example/build/nodes/ParticipantC/cordapps",
+    cordappDirNotary:
+      "/samples-kotlin/Basic/cordapp-example/build/nodes/Notary/cordapps",
     jars: [
       {
         jarRelativePath: "contracts/build/libs/contracts-1.0.jar",
@@ -45,6 +82,14 @@ export const SAMPLE_CORDAPP_DATA = Object.freeze({
   },
   [SampleCordappEnum.BASIC_FLOW]: {
     rootDir: "/samples-kotlin/Basic/flow-database-access/",
+    cordappDirPartyA:
+      "/samples-kotlin/Basic/flow-database-access/build/nodes/ParticipantA/cordapps",
+    cordappDirPartyB:
+      "/samples-kotlin/Basic/flow-database-access/build/nodes/ParticipantB/cordapps",
+    cordappDirPartyC:
+      "/samples-kotlin/Basic/flow-database-access/build/nodes/ParticipantC/cordapps",
+    cordappDirNotary:
+      "/samples-kotlin/Basic/flow-database-access/build/nodes/Notary/cordapps",
     jars: [
       {
         jarRelativePath: "workflows/build/libs/workflows-0.1.jar",


### PR DESCRIPTION
1. This way we can have examples and test cases developed that use either
the negotiation or the obligation cordapps. Earlier we could only use
the obligation cordapp as it was the hardcoded directory path for contract
deployments.
2. Not an actual feature just an extension to the testing infrastructure
that we have and we need the additional possibilities here because of the
new Harmonia Labs examples coming up.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.