### PR TITLE
feat(connector-corda): add initial set of JvmObject factory functions

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -162,6 +162,7 @@
     "Satp",
     "sbjpubkey",
     "Secp",
+    "serde",
     "shrn",
     "Smonitor",
     "socketio",

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.json
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.json
@@ -202,9 +202,7 @@
           "jvmTypeKind": {
             "$ref": "#/components/schemas/JvmTypeKind"
           },
-          "primitiveValue": {
-            "type": "object"
-          },
+          "primitiveValue": {},
           "jvmCtorArgs": {
             "type": "array",
             "items": {

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.tpl.json
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/json/openapi.tpl.json
@@ -203,7 +203,6 @@
             "$ref": "#/components/schemas/JvmTypeKind"
           },
           "primitiveValue": {
-            "type": "object"
           },
           "jvmCtorArgs": {
             "type": "array",

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -553,10 +553,10 @@ export interface JvmObject {
     'jvmTypeKind': JvmTypeKind;
     /**
      * 
-     * @type {object}
+     * @type {any}
      * @memberof JvmObject
      */
-    'primitiveValue'?: object;
+    'primitiveValue'?: any;
     /**
      * 
      * @type {Array<JvmObject>}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/index.web.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/index.web.ts
@@ -1,1 +1,31 @@
 export * from "./generated/openapi/typescript-axios/index";
+
+export { createJvmBoolean } from "./jvm/serde/factory/create-jvm-boolean";
+
+export {
+  ICreateJvmCactiPublicImplKeyOptions,
+  createJvmCactiPublicKeyImpl,
+} from "./jvm/serde/factory/create-jvm-cacti-public-key-impl";
+
+export {
+  ICreateJvmCordaIdentityPartyOptions,
+  createJvmCordaIdentityParty,
+} from "./jvm/serde/factory/create-jvm-corda-identity-party";
+
+export {
+  ICreateJvmCordaX500NameOptions,
+  createJvmCordaX500Name,
+} from "./jvm/serde/factory/create-jvm-corda-x500-name";
+
+export { createJvmLong } from "./jvm/serde/factory/create-jvm-long";
+export { createJvmCurrency } from "./jvm/serde/factory/create-jvm-currency";
+
+export {
+  ICreateJvmCordaAmountOptions,
+  createJvmCordaAmount,
+} from "./jvm/serde/factory/create-jvm-corda-amount";
+
+export {
+  ICreateJvmCordaUniqueIdentifierOptions,
+  createJvmCordaUniqueIdentifier,
+} from "./jvm/serde/factory/create-jvm-corda-unique-identifier";

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-boolean.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-boolean.ts
@@ -1,0 +1,12 @@
+import { JvmObject } from "../../../generated/openapi/typescript-axios/api";
+import { JvmTypeKind } from "../../../generated/openapi/typescript-axios/api";
+
+export function createJvmBoolean(data: boolean): JvmObject {
+  return {
+    jvmTypeKind: JvmTypeKind.Primitive,
+    jvmType: {
+      fqClassName: "boolean",
+    },
+    primitiveValue: data,
+  };
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-cacti-public-key-impl.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-cacti-public-key-impl.ts
@@ -1,0 +1,42 @@
+import { JvmObject } from "../../../generated/openapi/typescript-axios/api";
+import { JvmTypeKind } from "../../../generated/openapi/typescript-axios/api";
+import { PublicKey } from "../../../generated/openapi/typescript-axios/api";
+import { createJvmString } from "./create-jvm-string";
+
+export interface ICreateJvmCactiPublicImplKeyOptions {
+  readonly publicKey: PublicKey;
+}
+
+export function createJvmCactiPublicKeyImpl(
+  opts: Readonly<ICreateJvmCactiPublicImplKeyOptions>,
+): JvmObject {
+  if (!opts) {
+    throw new Error("Expected arg1 to be truthy");
+  }
+  if (!opts.publicKey) {
+    throw new Error("Expected arg1.publicKey to be truthy");
+  }
+  if (!opts.publicKey.algorithm) {
+    throw new Error("Expected arg1.publicKey.algorithm to be truthy");
+  }
+  if (!opts.publicKey.encoded) {
+    throw new Error("Expected arg1.publicKey.encoded to be truthy");
+  }
+  if (!opts.publicKey.format) {
+    throw new Error("Expected arg1.publicKey.format to be truthy");
+  }
+
+  return {
+    jvmTypeKind: JvmTypeKind.Reference,
+    jvmType: {
+      fqClassName:
+        "org.hyperledger.cactus.plugin.ledger.connector.corda.server.impl.PublicKeyImpl",
+    },
+
+    jvmCtorArgs: [
+      createJvmString({ data: opts.publicKey.algorithm }),
+      createJvmString({ data: opts.publicKey.format }),
+      createJvmString({ data: opts.publicKey.encoded }),
+    ],
+  };
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-corda-amount.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-corda-amount.ts
@@ -1,0 +1,43 @@
+import { JvmObject } from "../../../generated/openapi/typescript-axios/api";
+import { JvmTypeKind } from "../../../generated/openapi/typescript-axios/api";
+import { createJvmCurrency } from "./create-jvm-currency";
+import { createJvmLong } from "./create-jvm-long";
+
+export interface ICreateJvmCordaAmountOptions {
+  readonly currencyCode: Readonly<string>;
+  readonly amount: Readonly<number>;
+}
+
+export function createJvmCordaAmount(
+  opts: Readonly<ICreateJvmCordaAmountOptions>,
+): JvmObject {
+  if (!opts) {
+    throw new Error("Expected arg1 to be truthy");
+  }
+  if (!opts.amount) {
+    throw new Error("Expected arg1.amount to be truthy");
+  }
+  if (!isFinite(opts.amount)) {
+    throw new Error("Expected arg1.amount to be finite");
+  }
+  if (!opts.currencyCode) {
+    throw new Error("Expected arg1.currencyCode to be truthy");
+  }
+  if (typeof opts.currencyCode !== "string") {
+    throw new Error("Expected arg1.currencyCode to be string");
+  }
+  if (opts.currencyCode.length <= 0) {
+    throw new Error("Expected arg1.currencyCode to be non-blank string");
+  }
+  return {
+    jvmTypeKind: JvmTypeKind.Reference,
+    jvmType: {
+      fqClassName: "net.corda.core.contracts.Amount",
+    },
+
+    jvmCtorArgs: [
+      createJvmLong(opts.amount),
+      createJvmCurrency({ currencyCode: opts.currencyCode }),
+    ],
+  };
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-corda-identity-party.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-corda-identity-party.ts
@@ -1,0 +1,29 @@
+import { JvmObject } from "../../../generated/openapi/typescript-axios/api";
+import { Party } from "../../../generated/openapi/typescript-axios/api";
+import { JvmTypeKind } from "../../../generated/openapi/typescript-axios/api";
+import { createJvmCactiPublicKeyImpl } from "./create-jvm-cacti-public-key-impl";
+import { createJvmCordaX500Name } from "./create-jvm-corda-x500-name";
+
+export interface ICreateJvmCordaIdentityPartyOptions {
+  readonly party: Readonly<Party>;
+}
+
+export function createJvmCordaIdentityParty(
+  opts: Readonly<ICreateJvmCordaIdentityPartyOptions>,
+): JvmObject {
+  return {
+    jvmTypeKind: JvmTypeKind.Reference,
+    jvmType: {
+      fqClassName: "net.corda.core.identity.Party",
+    },
+
+    jvmCtorArgs: [
+      createJvmCordaX500Name({
+        country: opts.party.name.country,
+        locality: opts.party.name.locality,
+        organisation: opts.party.name.organisation,
+      }),
+      createJvmCactiPublicKeyImpl({ publicKey: opts.party.owningKey }),
+    ],
+  };
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-corda-unique-identifier.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-corda-unique-identifier.ts
@@ -1,0 +1,26 @@
+import { JvmObject } from "../../../generated/openapi/typescript-axios/api";
+import { JvmTypeKind } from "../../../generated/openapi/typescript-axios/api";
+import { createJvmString } from "./create-jvm-string";
+
+export interface ICreateJvmCordaUniqueIdentifierOptions {
+  readonly uniqueidentifier: Readonly<string>;
+}
+
+export function createJvmCordaUniqueIdentifier(
+  opts: Readonly<ICreateJvmCordaUniqueIdentifierOptions>,
+): JvmObject {
+  if (!opts) {
+    throw new Error("Expected arg1 to be truthy");
+  }
+  if (!opts.uniqueidentifier) {
+    throw new Error("Expected arg1.uniqueidentifier to be truthy");
+  }
+  return {
+    jvmTypeKind: JvmTypeKind.Reference,
+    jvmType: {
+      fqClassName: "net.corda.core.contracts.UniqueIdentifier",
+    },
+
+    jvmCtorArgs: [createJvmString({ data: opts.uniqueidentifier })],
+  };
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-corda-x500-name.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-corda-x500-name.ts
@@ -1,0 +1,32 @@
+import { JvmObject } from "../../../generated/openapi/typescript-axios/api";
+import { JvmTypeKind } from "../../../generated/openapi/typescript-axios/api";
+import { createJvmString } from "./create-jvm-string";
+
+export interface ICreateJvmCordaX500NameOptions {
+  readonly commonName?: string;
+  readonly organisationUnit?: string;
+  readonly organisation: string;
+  readonly locality: string;
+  readonly state?: string;
+  readonly country: string;
+}
+
+export function createJvmCordaX500Name(
+  opts: Readonly<ICreateJvmCordaX500NameOptions>,
+): JvmObject {
+  if (!opts) {
+    throw new Error("Expected arg1 to be truthy");
+  }
+  return {
+    jvmTypeKind: JvmTypeKind.Reference,
+    jvmType: {
+      fqClassName: "net.corda.core.identity.CordaX500Name",
+    },
+
+    jvmCtorArgs: [
+      createJvmString({ data: opts.organisation }),
+      createJvmString({ data: opts.locality }),
+      createJvmString({ data: opts.country }),
+    ],
+  };
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-currency.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-currency.ts
@@ -1,0 +1,37 @@
+import { JvmObject } from "../../../generated/openapi/typescript-axios/api";
+import { JvmTypeKind } from "../../../generated/openapi/typescript-axios/api";
+
+export interface ICreateJvmCurrencyOptions {
+  readonly currencyCode: Readonly<string>;
+}
+
+export function createJvmCurrency(
+  opts: Readonly<ICreateJvmCurrencyOptions>,
+): JvmObject {
+  if (!opts) {
+    throw new Error("Expected arg1 to be truthy");
+  }
+  if (!opts.currencyCode) {
+    throw new Error("Expected arg1.currencyCode to be truthy");
+  }
+  if (typeof opts.currencyCode !== "string") {
+    throw new Error("Expected arg1.currencyCode to be string");
+  }
+
+  return {
+    jvmTypeKind: JvmTypeKind.Reference,
+    jvmType: {
+      fqClassName: "java.util.Currency",
+      constructorName: "getInstance",
+    },
+    jvmCtorArgs: [
+      {
+        jvmTypeKind: JvmTypeKind.Primitive,
+        jvmType: {
+          fqClassName: "java.lang.String",
+        },
+        primitiveValue: opts.currencyCode,
+      },
+    ],
+  };
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-long.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-long.ts
@@ -1,0 +1,12 @@
+import { JvmObject } from "../../../generated/openapi/typescript-axios/api";
+import { JvmTypeKind } from "../../../generated/openapi/typescript-axios/api";
+
+export function createJvmLong(data: number): JvmObject {
+  return {
+    jvmTypeKind: JvmTypeKind.Primitive,
+    jvmType: {
+      fqClassName: "long",
+    },
+    primitiveValue: data,
+  };
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-string.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/jvm/serde/factory/create-jvm-string.ts
@@ -1,0 +1,28 @@
+import { JvmObject } from "../../../generated/openapi/typescript-axios/api";
+import { JvmTypeKind } from "../../../generated/openapi/typescript-axios/api";
+
+export interface ICreateJvmStringOptions {
+  readonly data: Readonly<string>;
+}
+
+export function createJvmString(
+  opts: Readonly<ICreateJvmStringOptions>,
+): JvmObject {
+  if (!opts) {
+    throw new Error("Expected arg1 to be truthy");
+  }
+  if (!opts.data) {
+    throw new Error("Expected arg1.data to be truthy");
+  }
+  if (typeof opts.data !== "string") {
+    throw new Error("Expected arg1.data to be string");
+  }
+
+  return {
+    jvmTypeKind: JvmTypeKind.Primitive,
+    jvmType: {
+      fqClassName: "java.lang.String",
+    },
+    primitiveValue: opts.data,
+  };
+}

--- a/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/public-api.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/main/typescript/public-api.ts
@@ -26,3 +26,33 @@ export {
   CordaApiClientOptions,
   watchBlocksV1Options,
 } from "./api-client/corda-api-client";
+
+export { createJvmBoolean } from "./jvm/serde/factory/create-jvm-boolean";
+
+export {
+  ICreateJvmCactiPublicImplKeyOptions,
+  createJvmCactiPublicKeyImpl,
+} from "./jvm/serde/factory/create-jvm-cacti-public-key-impl";
+
+export {
+  ICreateJvmCordaIdentityPartyOptions,
+  createJvmCordaIdentityParty,
+} from "./jvm/serde/factory/create-jvm-corda-identity-party";
+
+export {
+  ICreateJvmCordaX500NameOptions,
+  createJvmCordaX500Name,
+} from "./jvm/serde/factory/create-jvm-corda-x500-name";
+
+export { createJvmLong } from "./jvm/serde/factory/create-jvm-long";
+export { createJvmCurrency } from "./jvm/serde/factory/create-jvm-currency";
+
+export {
+  ICreateJvmCordaAmountOptions,
+  createJvmCordaAmount,
+} from "./jvm/serde/factory/create-jvm-corda-amount";
+
+export {
+  ICreateJvmCordaUniqueIdentifierOptions,
+  createJvmCordaUniqueIdentifier,
+} from "./jvm/serde/factory/create-jvm-corda-unique-identifier";

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.7.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.7.test.ts
@@ -11,6 +11,7 @@ import {
   SampleCordappEnum,
   CordaConnectorContainer,
 } from "@hyperledger/cactus-test-tooling";
+import { Configuration } from "@hyperledger/cactus-core-api";
 
 import {
   CordappDeploymentConfig,
@@ -20,10 +21,15 @@ import {
   InvokeContractV1Request,
   JvmTypeKind,
 } from "../../../main/typescript/generated/openapi/typescript-axios/index";
-import { Configuration } from "@hyperledger/cactus-core-api";
+
+import {
+  createJvmCordaIdentityParty,
+  createJvmCordaUniqueIdentifier,
+} from "../../../main/typescript/public-api";
+import { createJvmCordaAmount } from "../../../main/typescript/public-api";
 
 const testCase = "Tests are passing on the JVM side";
-const logLevel: LogLevelDesc = "TRACE";
+const logLevel: LogLevelDesc = "INFO";
 
 test.onFailure(async () => {
   await Containers.logDiagnostics({ logLevel });
@@ -145,15 +151,14 @@ test(testCase, async (t: Test) => {
   );
 
   const networkMapRes = await apiClient.networkMapV1();
+
   const partyA = networkMapRes.data.find((it) =>
     it.legalIdentities.some((it2) => it2.name.organisation === "ParticipantA"),
   );
-  const partyAPublicKey = partyA?.legalIdentities[0].owningKey;
 
   const partyB = networkMapRes.data.find((it) =>
     it.legalIdentities.some((it2) => it2.name.organisation === "ParticipantB"),
   );
-  const partyBPublicKey = partyB?.legalIdentities[0].owningKey;
 
   const req: InvokeContractV1Request = {
     flowFullClassName: "net.corda.samples.obligation.flows.IOUIssueFlow",
@@ -166,228 +171,17 @@ test(testCase, async (t: Test) => {
         },
 
         jvmCtorArgs: [
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.contracts.Amount",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Primitive,
-                jvmType: {
-                  fqClassName: "long",
-                },
-                primitiveValue: 42,
-              },
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName: "java.util.Currency",
-                  constructorName: "getInstance",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "USD",
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.identity.Party",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName: "net.corda.core.identity.CordaX500Name",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "ParticipantA",
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "London",
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "GB",
-                  },
-                ],
-              },
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName:
-                    "org.hyperledger.cactus.plugin.ledger.connector.corda.server.impl.PublicKeyImpl",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyAPublicKey?.algorithm,
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyAPublicKey?.format,
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyAPublicKey?.encoded,
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.identity.Party",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName: "net.corda.core.identity.CordaX500Name",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "ParticipantB",
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "New York",
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "US",
-                  },
-                ],
-              },
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName:
-                    "org.hyperledger.cactus.plugin.ledger.connector.corda.server.impl.PublicKeyImpl",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyBPublicKey?.algorithm,
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyBPublicKey?.format,
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyBPublicKey?.encoded,
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.contracts.Amount",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Primitive,
-                jvmType: {
-                  fqClassName: "long",
-                },
-                primitiveValue: 1,
-              },
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName: "java.util.Currency",
-                  constructorName: "getInstance",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "USD",
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.contracts.UniqueIdentifier",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Primitive,
-                jvmType: {
-                  fqClassName: "java.lang.String",
-                },
-                primitiveValue: "7fc2161e-f8d0-4c86-a596-08326bdafd56",
-              },
-            ],
-          },
+          createJvmCordaAmount({ currencyCode: "USD", amount: 42 }),
+          createJvmCordaIdentityParty({
+            party: partyA!.legalIdentities[0],
+          }),
+          createJvmCordaIdentityParty({
+            party: partyB!.legalIdentities[0],
+          }),
+          createJvmCordaAmount({ currencyCode: "USD", amount: 42 }),
+          createJvmCordaUniqueIdentifier({
+            uniqueidentifier: "7fc2161e-f8d0-4c86-a596-08326bdafd56",
+          }),
         ],
       },
     ],

--- a/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.8.test.ts
+++ b/packages/cactus-plugin-ledger-connector-corda/src/test/typescript/integration/jvm-kotlin-spring-server-v4.8.test.ts
@@ -21,9 +21,14 @@ import {
   JvmTypeKind,
 } from "../../../main/typescript/generated/openapi/typescript-axios/index";
 import { Configuration } from "@hyperledger/cactus-core-api";
+import {
+  createJvmCordaAmount,
+  createJvmCordaIdentityParty,
+  createJvmCordaUniqueIdentifier,
+} from "../../../main/typescript/public-api";
 
 const testCase = "Tests are passing on the JVM side";
-const logLevel: LogLevelDesc = "TRACE";
+const logLevel: LogLevelDesc = "INFO";
 
 test.onFailure(async () => {
   await Containers.logDiagnostics({ logLevel });
@@ -151,12 +156,10 @@ test(testCase, async (t: Test) => {
   const partyA = networkMapRes.data.find((it) =>
     it.legalIdentities.some((it2) => it2.name.organisation === "ParticipantA"),
   );
-  const partyAPublicKey = partyA?.legalIdentities[0].owningKey;
 
   const partyB = networkMapRes.data.find((it) =>
     it.legalIdentities.some((it2) => it2.name.organisation === "ParticipantB"),
   );
-  const partyBPublicKey = partyB?.legalIdentities[0].owningKey;
 
   const req: InvokeContractV1Request = {
     flowFullClassName: "net.corda.samples.obligation.flows.IOUIssueFlow",
@@ -169,228 +172,17 @@ test(testCase, async (t: Test) => {
         },
 
         jvmCtorArgs: [
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.contracts.Amount",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Primitive,
-                jvmType: {
-                  fqClassName: "long",
-                },
-                primitiveValue: 42,
-              },
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName: "java.util.Currency",
-                  constructorName: "getInstance",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "USD",
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.identity.Party",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName: "net.corda.core.identity.CordaX500Name",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "ParticipantA",
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "London",
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "GB",
-                  },
-                ],
-              },
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName:
-                    "org.hyperledger.cactus.plugin.ledger.connector.corda.server.impl.PublicKeyImpl",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyAPublicKey?.algorithm,
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyAPublicKey?.format,
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyAPublicKey?.encoded,
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.identity.Party",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName: "net.corda.core.identity.CordaX500Name",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "ParticipantB",
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "New York",
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "US",
-                  },
-                ],
-              },
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName:
-                    "org.hyperledger.cactus.plugin.ledger.connector.corda.server.impl.PublicKeyImpl",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyBPublicKey?.algorithm,
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyBPublicKey?.format,
-                  },
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: partyBPublicKey?.encoded,
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.contracts.Amount",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Primitive,
-                jvmType: {
-                  fqClassName: "long",
-                },
-                primitiveValue: 1,
-              },
-              {
-                jvmTypeKind: JvmTypeKind.Reference,
-                jvmType: {
-                  fqClassName: "java.util.Currency",
-                  constructorName: "getInstance",
-                },
-
-                jvmCtorArgs: [
-                  {
-                    jvmTypeKind: JvmTypeKind.Primitive,
-                    jvmType: {
-                      fqClassName: "java.lang.String",
-                    },
-                    primitiveValue: "USD",
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            jvmTypeKind: JvmTypeKind.Reference,
-            jvmType: {
-              fqClassName: "net.corda.core.contracts.UniqueIdentifier",
-            },
-
-            jvmCtorArgs: [
-              {
-                jvmTypeKind: JvmTypeKind.Primitive,
-                jvmType: {
-                  fqClassName: "java.lang.String",
-                },
-                primitiveValue: "7fc2161e-f8d0-4c86-a596-08326bdafd56",
-              },
-            ],
-          },
+          createJvmCordaAmount({ currencyCode: "USD", amount: 42 }),
+          createJvmCordaIdentityParty({
+            party: partyA!.legalIdentities[0],
+          }),
+          createJvmCordaIdentityParty({
+            party: partyB!.legalIdentities[0],
+          }),
+          createJvmCordaAmount({ currencyCode: "USD", amount: 1 }),
+          createJvmCordaUniqueIdentifier({
+            uniqueidentifier: "7fc2161e-f8d0-4c86-a596-08326bdafd56",
+          }),
         ],
       },
     ],


### PR DESCRIPTION
1. These functions are used so more easily construct the JSON representation
of JVM objects (references and primitive values) that we need to define when
interacting with the Corda JVM connector (which is used for Corda v4 ledgers)
2. This is not a comprehensive set but more like a trailblazing initial
implementation to showcase how to create and use these factory functions.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.