### PR TITLE
fix(cmd-api-server): stop changing LoggerProvider log level

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -160,8 +160,6 @@ export class ApiServer {
       exitHook(() => this.shutdown());
     }
 
-    LoggerProvider.setLogLevel(options.config.logLevel);
-
     if (this.options.httpServerApi) {
       this.httpServerApi = this.options.httpServerApi;
     } else if (this.options.config.apiTlsEnabled) {


### PR DESCRIPTION
1. The API server was mutating global shared state in it's own constructor
which was causing problems with other components (pretty much all of them)
2. I deleted the line that copies the API server's own log level to the
LoggerProvider so that the API server's log level can be it's own.
3. The way this bug came about is that in the supply chain app example
in the back-end the API server had to be muted (log level WARN) in order
for it to stop printing misleading logs due to us binding to the wildcard
host it would claim in its own logs that the WWW GUI is accessible on the
wildcard host in a web browser, but this was wrong and caused many people
a lot of confusion unfortunately.
4. The fix for the supply chain app is to set the API server's log level to
WARN and have the supply chain app itself log the correct URLs to the console.
5. The issue I ran into with that fix is that as soon as I set the log level
of the API server to WARN, everything else also stopped logging which resulted
in my fix making everything worse since now the users had absolutely no
idea what was happening or if the example application had even finished booting
up or not.
6. Upon further debugging I discovered that the API server was forcing its
own log level onto everybody else as the root cause.
7. A follow-up PR is about to drop with the supply chain app fixes which are
dependent on this one making it in first.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.