### PR TITLE
docs(examples/supply-chain-app): fix resource cleanup of shutdown logic

### DIFF
--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app-cli.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app-cli.ts
@@ -21,7 +21,7 @@ export async function launchApp(
     await supplyChainApp.start();
   } catch (ex) {
     console.error(`SupplyChainApp crashed. Existing...`, ex);
-    await supplyChainApp?.stop();
+    await supplyChainApp.stop();
     process.exit(-1);
   }
 }

--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
@@ -191,15 +191,28 @@ export class SupplyChainApp {
     this.log.debug(`Starting SupplyChainApp...`);
 
     if (!this.options.disableSignalHandlers) {
-      exitHook((callback: IAsyncExitHookDoneCallback) => {
-        console.log(`Executing Registered signal handler to stop container.`);
-        this.stop().then(callback);
+      exitHook((onHookDone: IAsyncExitHookDoneCallback) => {
+        this.log.info("Starting async-exit-hook for supply-chain-app ...");
+        this.stop()
+          .catch((ex: unknown) => {
+            this.log.warn("Failed async-exit-hook for supply-chain-app", ex);
+            throw ex;
+          })
+          .finally(() => {
+            this.log.info("Concluded async-exit-hook for supply-chain-app ...");
+            onHookDone();
+          });
+        this.log.info("Started async-exit-hook for supply-chain-app OK");
       });
-      this.log.debug(`Registered signal handlers for graceful auto-shutdown`);
+      this.log.info("Registered async-exit-hook for supply-chain-app shutdown");
     }
 
+    this.onShutdown(async () => {
+      this.log.info("SupplyChainApp onShutdown() - stopping ledgers...");
+      await this.ledgers.stop();
+      this.log.info("SupplyChainApp onShutdown() - stopped ledgers OK");
+    });
     await this.ledgers.start();
-    this.onShutdown(() => this.ledgers.stop());
 
     const contractsInfo = await this.ledgers.deployContracts();
 
@@ -441,8 +454,12 @@ export class SupplyChainApp {
   }
 
   public async stop(): Promise<void> {
+    let i = 0;
     for (const hook of this.shutdownHooks) {
+      i++;
+      this.log.info("Executing exit hook #%d...", i);
       await hook(); // FIXME add timeout here so that shutdown does not hang
+      this.log.info("Executed exit hook #%d OK", i);
     }
   }
 
@@ -590,15 +607,25 @@ export class SupplyChainApp {
     properties.authorizationConfigJson =
       await this.getOrCreateAuthorizationConfig();
     properties.crpcPort = 0;
+    // We must disable the API server's own shutdown hooks because if we didn't
+    // it would clash with the supply chain app's own shutdown hooks and the
+    // async functions wouldn't be waited for their conclusion leaving the containers
+    // running after the supply chain app NodeJS process has exited.
+    properties.enableShutdownHook = false;
 
     const apiServer = new ApiServer({
       config: properties,
       httpServerApi,
       httpServerCockpit,
       pluginRegistry,
+      enableShutdownHook: false,
     });
 
-    this.onShutdown(() => apiServer.shutdown());
+    this.onShutdown(async () => {
+      this.log.info("SupplyChainApp onShutdown() - stopping API server");
+      await apiServer.shutdown();
+      this.log.info("SupplyChainApp onShutdown() - stopped API server OK");
+    });
 
     await apiServer.start();
 


### PR DESCRIPTION
1. Now you can run the supply chain app example locally and then hit CTRL+C
on the terminal and it will gracefully shut down all the containers hosting
the infrastructure and only after that the NodeJS process itself will exit.
2. Previously we had a bug where it wouldn't wait for the containers to wind
down and it left them running which was causing problems when people didn't
notice this behavior and their machines would get into this broken state where
the previous execution's containers were hanging around and one of them blocking
ports too.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.