### PR TITLE
fix(plugin-persistence-ethereum): make created_at TIMESTAMPTZ in schema

### DIFF
--- a/packages/cactus-plugin-persistence-ethereum/src/main/sql/schema.sql
+++ b/packages/cactus-plugin-persistence-ethereum/src/main/sql/schema.sql
@@ -39,10 +39,10 @@ GRANT ALL ON TABLE public.plugin_status TO service_role;
 CREATE TABLE IF NOT EXISTS public.block
 (
     "number" numeric NOT NULL,
-    created_at timestamp without time zone NOT NULL,
+    created_at timestamptz NOT NULL,
     hash text COLLATE pg_catalog."default" NOT NULL,
     number_of_tx numeric NOT NULL,
-    sync_at timestamp with time zone NOT NULL DEFAULT now(),
+    sync_at timestamptz NOT NULL DEFAULT now(),
     CONSTRAINT block_pkey PRIMARY KEY ("number"),
     CONSTRAINT block_hash_key UNIQUE (hash),
     CONSTRAINT block_number_key UNIQUE ("number")


### PR DESCRIPTION
1. The problem was that the database schema was defined in a way that was
destroying timestamp information during insertion of records.
2. Updating the schema to hold the timestamp information made the test pass.

More information about why it's recommended to store datetime data with
the TIMESTAMPTZ column type is explained by the author of the node-postgres
library which is an important part of the problem (it assumes local time
for columns that do not store the timestamp time zone).

https://node-postgres.com/features/types#date--timestamp--timestamptz

Fixes #3373

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.