### PR TITLE
test(test-tooling): fix BesuTestLedger start cfg: publish all ports

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/besu/besu-test-ledger.ts
@@ -261,10 +261,9 @@ export class BesuTestLedger implements ITestLedger {
             Retries: 299,
             StartPeriod: 3000000000, // 1 second
           },
-          // This is a workaround needed for macOS which has issues with routing
-          // to docker container's IP addresses directly...
-          // https://stackoverflow.com/a/39217691
-          PublishAllPorts: true,
+          HostConfig: {
+            PublishAllPorts: true,
+          },
           Env: this.envVars,
         },
         {},


### PR DESCRIPTION
1. Previously we specified the publish all ports flag of the Docker Engine
incorrectly and this lead to the ports not actually being published on
randomized ports.
2. This broke the supply chain app example when we tried to migrate it to
use 2 separate besu test ledger instances in tandem because they were
conflicting on the ports due to the lack of randomization.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.