### PR TITLE
docs(connector-fabric): remove references to old Fabric v1.4.x tests

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -54,8 +54,6 @@ files:
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-sign-transaction-endpoint.test.ts
   - ./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/identity-client.test.ts
-  - ./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts
-  - ./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts
   - ./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts
   - ./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-with-identities.test.ts
   - ./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts

--- a/docs-cactus/source/support/fabric.md
+++ b/docs-cactus/source/support/fabric.md
@@ -10,7 +10,6 @@ The deployContract feature is for development and test case authoring only, not 
   | Fabric version | deployContract* | invokeContract | runTransaction |
   | --- | :---: | :---: | :---: |
   | Fabric 2.2.0 | ✅ [test]() | ✅ [test]() | ✅ [test]() |
-  | Fabric 1.4.8 | ✅ [test]() | ✅ [test]() | ✅ [test]() |
 
 </details>
 
@@ -20,7 +19,6 @@ The deployContract feature is for development and test case authoring only, not 
   | Fabric version | deployContract* | invokeContract | runTransaction |
   | --- | :---: | :---: | :---: |
   | Fabric 2.2.0 | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) |
-  | Fabric 1.4.8 | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) |
 
 </details>
 
@@ -30,7 +28,6 @@ The deployContract feature is for development and test case authoring only, not 
   | Fabric version | deployContract* | invokeContract | runTransaction |
   | --- | :---: | :---: | :---: |
   | Fabric 2.2.0 | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) |
-  | Fabric 1.4.8 | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) |
 
 </details>
 
@@ -40,7 +37,6 @@ The deployContract feature is for development and test case authoring only, not 
   | Fabric version | deployContract* | invokeContract | runTransaction |
   | --- | :---: | :---: | :---: |
   | Fabric 2.2.0 | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) |
-  | Fabric 1.4.8 | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) |
 
 </details>
 
@@ -50,7 +46,6 @@ The deployContract feature is for development and test case authoring only, not 
   | Fabric version | deployContract* | invokeContract | runTransaction |
   | --- | :---: | :---: | :---: |
   | Fabric 2.2.0 | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) |
-  | Fabric 1.4.8 | [✅](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) |
 
 </details>
 
@@ -60,7 +55,6 @@ The deployContract feature is for development and test case authoring only, not 
   | Fabric version | deployContract* | invokeContract | runTransaction |
   | --- | :---: | :---: | :---: |
   | Fabric 2.2.0 | ❌ | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.4.1/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.4.1/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts) |
-  | Fabric 1.4.8 | ✅ | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.4.1/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) | ✅ [test](https://github.com/hyperledger/cactus/blob/v0.4.1/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) |
 
 </details>
 

--- a/docs/docs/cactus/packages/cactus-plugin-ledger-connector-fabric.md
+++ b/docs/docs/cactus/packages/cactus-plugin-ledger-connector-fabric.md
@@ -502,7 +502,7 @@ To use Prometheus with this exporter make sure to install [Prometheus main compo
   static\_configs:
     - targets: \['{host}:{port}'\]
 
-Here the `host:port` is where the prometheus exporter metrics are exposed. The test cases (For example, packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) exposes it over `0.0.0.0` and a random port(). The random port can be found in the running logs of the test case and looks like (42379 in the below mentioned URL) `Metrics URL: http://0.0.0.0:42379/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/get-prometheus-exporter-metrics`
+Here the `host:port` is where the prometheus exporter metrics are exposed. The test cases (For example, `packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts`) exposes it over `0.0.0.0` and a random port(). The random port can be found in the running logs of the test case and looks like (42379 in the below mentioned URL) `Metrics URL: http://0.0.0.0:42379/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/get-prometheus-exporter-metrics`
 
 Once edited, you can start the prometheus service by referencing the above edited prometheus.yml file. On the prometheus graphical interface (defaulted to http://localhost:9090), choose **Graph** from the menu bar, then select the **Console** tab. From the **Insert metric at cursor** drop down, select **cactus\_fabric\_total\_tx\_count** and click **execute**
 

--- a/docs/docs/cactus/support/fabric.md
+++ b/docs/docs/cactus/support/fabric.md
@@ -49,14 +49,6 @@ Fabric 2.2.0
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
 
-Fabric 1.4.8
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts)
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.8.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
-
 Hyperledger Cactus v0.7.0
 
 Fabric version
@@ -75,13 +67,6 @@ Fabric 2.2.0
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
 
-Fabric 1.4.8
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts)
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.7.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
 
 Hyperledger Cactus v0.6.0
 
@@ -101,14 +86,6 @@ Fabric 2.2.0
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
 
-Fabric 1.4.8
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts)
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.6.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
-
 Hyperledger Cactus v0.5.0
 
 Fabric version
@@ -127,14 +104,6 @@ Fabric 2.2.0
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
 
-Fabric 1.4.8
-
-[✅](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts)
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.5.0/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
-
 Hyperledger Cactus v0.4.1
 
 Fabric version
@@ -152,15 +121,6 @@ Fabric 2.2.0
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.4.1/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
 
 ✅ [test](https://github.com/hyperledger/cactus/blob/v0.4.1/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts)
-
-Fabric 1.4.8
-
-✅
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.4.1/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
-
-✅ [test](https://github.com/hyperledger/cactus/blob/v0.4.1/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts)
-
 
 
 [Previous](corda.md "Corda Support") [Next](quorum.md "Quorum Support")

--- a/jest.config.js
+++ b/jest.config.js
@@ -67,8 +67,6 @@ module.exports = {
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-block-endpoint.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-sign-transaction-endpoint.test.ts`,
     `./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/identity-client.test.ts`,
-    `./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts`,
-    `./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/deploy-cc-from-golang-source.test.ts`,
     `./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-javascript-source.test.ts`,
     `./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-with-identities.test.ts`,
     `./packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/deploy-cc-from-golang-source.test.ts`,

--- a/packages/cactus-plugin-ledger-connector-fabric/README.md
+++ b/packages/cactus-plugin-ledger-connector-fabric/README.md
@@ -13,6 +13,8 @@
   - [1.5 Monitoring new blocks (WatchBlocks)](#15-monitoring-new-blocks-watchblocks)
     - [1.5.1 Example](#151-example)
     - [1.5.2 Listener Type](#152-listener-type)
+      - [Original](#original)
+      - [Cacti (custom)](#cacti-custom)
   - [1.6 Delegated Signature](#16-delegated-signature)
     - [1.6.1 Example](#161-example)
 - [2. Architecture](#2-architecture)
@@ -585,7 +587,7 @@ Once Prometheus is setup, the corresponding scrape_config needs to be added to t
     - targets: ['{host}:{port}']
 ```
 
-Here the `host:port` is where the prometheus exporter metrics are exposed. The test cases (For example, packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v1-4-x/run-transaction-endpoint-v1.test.ts) exposes it over `0.0.0.0` and a random port(). The random port can be found in the running logs of the test case and looks like (42379 in the below mentioned URL)
+Here the `host:port` is where the prometheus exporter metrics are exposed. The test cases (For example, `packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-endpoint-v1.test.ts`) exposes it over `0.0.0.0` and a random port(). The random port can be found in the running logs of the test case and looks like (42379 in the below mentioned URL)
 `Metrics URL: http://0.0.0.0:42379/api/v1/plugins/@hyperledger/cactus-plugin-ledger-connector-fabric/get-prometheus-exporter-metrics`
 
 Once edited, you can start the prometheus service by referencing the above edited prometheus.yml file.


### PR DESCRIPTION
1. We've removed the Fabric v1.4.x test cases a while back but I forgot
to delete them from the .taprc and jest.config.js files for example.
2. Also in a couple of places the documentation was referring to the
test cases as well so that had to be updated also.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.