### PR TITLE
build(sync-ts-config): integrating the weaver packages to the monorepo build

### DIFF
--- a/tools/sync-npm-deps-to-tsc-projects.ts
+++ b/tools/sync-npm-deps-to-tsc-projects.ts
@@ -45,7 +45,7 @@ const main = async (argv: string[], env: NodeJS.ProcessEnv) => {
       "**/weaver/common/protos-js/**",
       "**/weaver/samples/besu/simpleasset/**",
       "**/weaver/samples/besu/simplestate/**",
-    ], // Follow-up issue regarding these hardcoded paths (https://github.com/hyperledger/cacti/issues/3366)
+    ], //Follow-up issue regarding these hardcoded paths (https://github.com/hyperledger/cacti/issues/3366)
   };
   const pkgJsonPaths = await globby(pkgJsonGlobPatterns, globbyOptions);
   console.log(`Package paths (${pkgJsonPaths.length}): `, pkgJsonPaths);


### PR DESCRIPTION
### **Commit** to be reviewed
---
build(sync-ts-config): integrating the weaver packages to the monorepo build
```
Primary Changes
---------------

1. Relocated tsconfig file to cacti-plugin-weaver-driver-fabric
2. Added comment regarding the other package not having tsconfig and will be ignoring till then
```

Fixes: #3366
Related to: #3069

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.