### PR TITLE
ci(connector-corda): fix insufficient disk space errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1132,6 +1132,7 @@ jobs:
       - compute_changed_packages
     if: needs.compute_changed_packages.outputs.plugin-ledger-connector-corda-changed == 'true'
     env:
+      FREE_UP_GITHUB_RUNNER_DISK_SPACE_DISABLED: false
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-ledger-connector-corda/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
       JEST_TEST_RUNNER_DISABLED: false


### PR DESCRIPTION
We have the disk clean-up in the CI off by default because it takes a few
minutes to perform and most jobs don't need it, but for Corda it seems
necessary because our tests started failing with the message below
(lines wrapped to make sure we don't run over the 100 character limit
for the git commit message)

cactus-corda-4-8-all-in-one-flowdb:2024-07-08-hotfix-1]
[WARN] 09:48:28+0000 [Thread-2
(ActiveMQ-server-org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl$6@11a43807)]
core.server. -
AMQ222210: Free storage space is at 145.7MB of 77.9GB total. Usage rate is 99.8% which is
beyond the configured <max-disk-usage>. System will start blocking producers.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.