### PR TITLE
test(supply-chain-app-backend): fix via-npm-script.test.ts hanging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2280,6 +2280,8 @@ jobs:
       JEST_TEST_RUNNER_DISABLED: false
       TAPE_TEST_PATTERN: ./packages/cactus-test-plugin-consortium-manual/src/test/typescript/integration/plugin-consortium-manual/openapi/openapi-validation.test.ts
       TAPE_TEST_RUNNER_DISABLED: false
+      JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cpt-consortium-manual
+      JEST_TEST_CODE_COVERAGE_ENABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
     steps:

--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/public-api.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/public-api.ts
@@ -1,3 +1,4 @@
+export { SUPPLY_CHAIN_APP_OK_LOG_MSG_PATTERN } from "./supply-chain-app";
 export { SupplyChainApp } from "./supply-chain-app";
 export { ISupplyChainAppOptions } from "./supply-chain-app";
 export { launchApp } from "./supply-chain-app-cli";

--- a/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
+++ b/examples/cactus-example-supply-chain-backend/src/main/typescript/supply-chain-app.ts
@@ -70,6 +70,13 @@ import {
 import { SupplyChainCactusPlugin } from "@hyperledger/cactus-example-supply-chain-business-logic-plugin";
 import { DiscoveryOptions } from "fabric-network";
 
+/**
+ * The log pattern message that will be printed on stdout when the
+ * Supply Chain Application finished booting (it can take a long time).
+ */
+export const SUPPLY_CHAIN_APP_OK_LOG_MSG_PATTERN =
+  "Cacti API Server - REST API reachable at:";
+
 export interface ISupplyChainAppOptions {
   disableSignalHandlers?: true;
   logLevel?: LogLevelDesc;
@@ -633,7 +640,7 @@ export class SupplyChainApp {
     await apiServer.start();
 
     const restApiUrl = `http://127.0.0.1:${properties.apiPort}`;
-    this.log.info("Cacti API Server - REST API reachable at: %s", restApiUrl);
+    this.log.info("%s: %s", SUPPLY_CHAIN_APP_OK_LOG_MSG_PATTERN, restApiUrl);
 
     const guiUrl = `http://127.0.0.1:${properties.cockpitPort}`;
     this.log.info("SupplyChainApp Web GUI - reachable at: %s", guiUrl);

--- a/examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-cli-via-npm-script.test.ts
+++ b/examples/cactus-example-supply-chain-backend/src/test/typescript/integration/supply-chain-cli-via-npm-script.test.ts
@@ -6,6 +6,7 @@ import test, { Test } from "tape-promise/tape";
 import { LogLevelDesc } from "@hyperledger/cactus-common";
 import { pruneDockerAllIfGithubAction } from "@hyperledger/cactus-test-tooling";
 import * as publicApi from "../../../main/typescript/public-api";
+import { SUPPLY_CHAIN_APP_OK_LOG_MSG_PATTERN } from "../../../main/typescript/public-api";
 
 const testCase = "SupplyChainApp can launch via root package.json script";
 const logLevel: LogLevelDesc = "TRACE";
@@ -91,7 +92,7 @@ test(testCase, async (t: Test) => {
   const logs = [];
   for await (const data of child.stdout) {
     console.log(`[child]: ${data}`);
-    if (data.includes("Cactus API reachable http")) {
+    if (data.includes(SUPPLY_CHAIN_APP_OK_LOG_MSG_PATTERN)) {
       console.log("Sending kill signal to child process...");
       apiIsHealthy = true;
       const killedOK = child.kill("SIGKILL");


### PR DESCRIPTION
1. The test case was hanging at the end because it was waiting  for a
magic string to appear in the logs to indicate that the booting has finished.
2. The problems began when we changed the supply chain app's log message
from mentioning Cactus to Cacti which then invalidated the condition forever.
3. This left it hanging indefinitely and the test case was broken.
4. Now to fix the problem and avoid this happening again in the future
the supply chain app exports the log message pattern as a variable and the
test case imports that directly so if we change the log message in the
future it will automatically make sure that the test is also waiting for
the updated log message pattern to show up in the logs making this class
of bugs impossible to happen.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.