### PR TITLE
test(connector-fabric): fix rename type to responseType getBlockV1()

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/query-system-chain-methods.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/query-system-chain-methods.test.ts
@@ -222,19 +222,19 @@ describe("Query system chain methods and endpoints tests", () => {
    * Can be reused throughout the tests.
    *
    * @param query how to find requested block
-   * @param type response type requested
+   * @param responseType response type requested
    *
    * @returns block object / block buffer
    */
   async function getBlock(
     query: GetBlockRequestV1Query,
-    type: GetBlockResponseTypeV1 = GetBlockResponseTypeV1.Full,
+    responseType: GetBlockResponseTypeV1 = GetBlockResponseTypeV1.Full,
   ): Promise<any> {
     const getBlockReq = {
       channelName: ledgerChannelName,
       gatewayOptions,
       query,
-      type,
+      responseType,
     };
 
     const getBlockResponse = await apiClient.getBlockV1(getBlockReq);
@@ -248,7 +248,7 @@ describe("Query system chain methods and endpoints tests", () => {
     expect(getBlockResponse.status).toEqual(200);
     expect(getBlockResponse.data).toBeTruthy();
 
-    switch (type) {
+    switch (responseType) {
       case GetBlockResponseTypeV1.Full:
         if (!("decodedBlock" in getBlockResponse.data)) {
           throw new Error(
@@ -283,7 +283,7 @@ describe("Query system chain methods and endpoints tests", () => {
         return getBlockResponse.data.cactiFullEvents;
       default:
         // Will not compile if any type was not handled by above switch.
-        const unknownType: never = type;
+        const unknownType: never = responseType;
         const validTypes = Object.keys(GetBlockResponseTypeV1).join(";");
         const errorMessage = `Unknown get block response type '${unknownType}'. Accepted types for GetBlockResponseTypeV1 are: [${validTypes}]`;
         throw new Error(errorMessage);


### PR DESCRIPTION
The system chaincode query method's returns were not decoded correctly
because the test request assembling code was not updated to call the
responseType as such (old name was type)

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.