### PR TITLE
test(test-tooling): fix WS identity server port publish configuration

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-with-ws-ids.test.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/test/typescript/integration/fabric-v2-2-x/run-transaction-with-ws-ids.test.ts
@@ -61,20 +61,20 @@ describe("PluginLedgerConnectorFabric", () => {
       logLevel,
     });
 
-    await ledger.start({ omitPull: false });
-
     wsTestContainer = new WsTestServer({});
     await wsTestContainer.start();
+
+    const ci = await Containers.getById(wsTestContainer.containerId);
+    const wsIpAddr = await internalIpV4();
+    const hostPort = await Containers.getPublicPort(WS_IDENTITY_HTTP_PORT, ci);
+
+    await ledger.start({ omitPull: false });
 
     const connectionProfile = await ledger.getConnectionProfileOrg1();
     expect(connectionProfile).toBeTruthy();
 
     const keychainInstanceId = uuidv4();
     keychainId = uuidv4();
-
-    const ci = await Containers.getById(wsTestContainer.containerId);
-    const wsIpAddr = await internalIpV4();
-    const hostPort = await Containers.getPublicPort(WS_IDENTITY_HTTP_PORT, ci);
 
     const wsUrl = `http://${wsIpAddr}:${hostPort}`;
 

--- a/packages/cactus-test-tooling/src/main/typescript/ws-test-server/ws-test-server.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/ws-test-server/ws-test-server.ts
@@ -94,12 +94,12 @@ export class WsTestServer {
           // to docker container's IP addresses directly...
           // https://stackoverflow.com/a/39217691
           PublishAllPorts: true,
-          /*Env: [`WS_IDENTITY_PATH=${WS_IDENTITY_PATH}`, ...this.envVars],
+          /*Env: [`WS_IDENTITY_PATH=${WS_IDENTITY_PATH}`, ...this.envVars],*/
           HostConfig: {
             // NetworkMode: "host",
-            CapAdd: ["IPC_LOCK"],
+            // CapAdd: ["IPC_LOCK"],
             PublishAllPorts: true,
-          },*/
+          },
           //Healthcheck: {
           //  Test: ["CMD-SHELL", "wget -O- http://127.0.0.1:8200/v1/sys/health"],
           //  Interval: 100 * 1000000,


### PR DESCRIPTION
1. The hostconfig portion of the container start configuration was not
being set up correctly which made it so that the exposed ports were not
published on randomized ports like they were supposed to.
2. This caused  the `fabric-v2-2-x/run-transaction-with-ws-ids.test.ts`
test to fail because it couldn't map the container port to a host machine
port.
3. Setting up the ws-test-server.ts class so that it does map the ports
to the host machine solved the issue.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.