### PR TITLE
ci(coverage): change coverage_ts.yaml condition to use success only

### DIFF
--- a/.github/workflows/coverage_ts.yaml
+++ b/.github/workflows/coverage_ts.yaml
@@ -13,7 +13,7 @@
     jobs:
       generate_coverage_report:
         runs-on: ubuntu-22.04
-        if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'success' }}
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
           - name: Check out repository
             uses: actions/checkout@v4.1.1


### PR DESCRIPTION
### **Commit** to be reviewed
---
ci(coverage): change coverage_ts.yaml condition to use success only 
```
Primary Changes
----------------
1. Updated the condition in coverage_ts.yaml to run only 
   when the CI run is successful
```
Fixes #3371

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.