### PR TITLE
refactor(connector-fabric): reusable error handler in REST endpoints

### DIFF
--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/get-block/get-block-endpoint-v1.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/get-block/get-block-endpoint-v1.ts
@@ -28,10 +28,16 @@ export interface IGetBlockEndpointV1Options {
 }
 
 export class GetBlockEndpointV1 implements IWebServiceEndpoint {
+  public static readonly CLASS_NAME = "GetBlockEndpointV1";
+
   private readonly log: Logger;
 
+  public get className(): string {
+    return GetBlockEndpointV1.CLASS_NAME;
+  }
+
   constructor(public readonly opts: IGetBlockEndpointV1Options) {
-    const fnTag = "GetBlockEndpointV1#constructor()";
+    const fnTag = `${this.className}#constructor()`;
 
     Checks.truthy(opts, `${fnTag} options`);
     Checks.truthy(opts.connector, `${fnTag} options.connector`);
@@ -84,14 +90,21 @@ export class GetBlockEndpointV1 implements IWebServiceEndpoint {
   }
 
   async handleRequest(req: Request, res: Response): Promise<void> {
-    const fnTag = "GetBlockEndpointV1#handleRequest()";
-    this.log.debug(`POST ${this.getPath()}`);
+    const fnTag = `${this.className}#handleRequest()`;
+    const verbUpper = this.getVerbLowerCase().toUpperCase();
+    const reqTag = `${verbUpper} ${this.getPath()}`;
+    this.log.debug(reqTag);
 
     try {
       res.status(200).send(await this.opts.connector.getBlock(req.body));
-    } catch (error) {
-      const errorMsg = `Crash while serving ${fnTag}`;
-      handleRestEndpointException({ errorMsg, log: this.log, error, res });
+    } catch (ex) {
+      const errorMsg = `${fnTag} request handler fn crashed for: ${reqTag}`;
+      await handleRestEndpointException({
+        errorMsg,
+        log: this.log,
+        error: ex,
+        res,
+      });
     }
   }
 }

--- a/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/get-prometheus-exporter-metrics/get-prometheus-exporter-metrics-endpoint-v1.ts
+++ b/packages/cactus-plugin-ledger-connector-fabric/src/main/typescript/get-prometheus-exporter-metrics/get-prometheus-exporter-metrics-endpoint-v1.ts
@@ -16,7 +16,10 @@ import {
 
 import OAS from "../../json/openapi.json";
 
-import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
+import {
+  handleRestEndpointException,
+  registerWebServiceEndpoint,
+} from "@hyperledger/cactus-core";
 
 import { PluginLedgerConnectorFabric } from "../plugin-ledger-connector-fabric";
 
@@ -28,12 +31,18 @@ export interface IGetPrometheusExporterMetricsEndpointV1Options {
 export class GetPrometheusExporterMetricsEndpointV1
   implements IWebServiceEndpoint
 {
+  public static readonly CLASS_NAME = "GetPrometheusExporterMetricsEndpointV1";
+
   private readonly log: Logger;
+
+  public get className(): string {
+    return GetPrometheusExporterMetricsEndpointV1.CLASS_NAME;
+  }
 
   constructor(
     public readonly opts: IGetPrometheusExporterMetricsEndpointV1Options,
   ) {
-    const fnTag = "GetPrometheusExporterMetricsEndpointV1#constructor()";
+    const fnTag = `${this.className}#constructor()`;
 
     Checks.truthy(opts, `${fnTag} options`);
     Checks.truthy(opts.connector, `${fnTag} options.connector`);
@@ -83,19 +92,23 @@ export class GetPrometheusExporterMetricsEndpointV1
   }
 
   async handleRequest(req: Request, res: Response): Promise<void> {
-    const fnTag = "GetPrometheusExporterMetrics#handleRequest()";
+    const fnTag = `${this.className}#handleRequest()`;
     const verbUpper = this.getVerbLowerCase().toUpperCase();
-    this.log.debug(`${verbUpper} ${this.getPath()}`);
+    const reqTag = `${verbUpper} ${this.getPath()}`;
+    this.log.debug(reqTag);
 
     try {
       const resBody = await this.opts.connector.getPrometheusExporterMetrics();
       res.status(200);
       res.send(resBody);
     } catch (ex) {
-      this.log.error(`${fnTag} failed to serve request`, ex);
-      res.status(500);
-      res.statusMessage = ex.message;
-      res.json({ error: ex.stack });
+      const errorMsg = `${fnTag} request handler fn crashed for: ${reqTag}`;
+      await handleRestEndpointException({
+        errorMsg,
+        log: this.log,
+        error: ex,
+        res,
+      });
     }
   }
 }


### PR DESCRIPTION
1. Error-handling : Updates to the catch block of the Rest API endpoints of fabric package by importing the utility function handleRestEndpointException from cactus-core package that differentiates the user/developer errors.
2. Minor code changes in the endpoints like adding the functions and formulating the error messages.

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.