### PR TITLE
fix(test-tooling): use of hardcoded password

### DIFF
--- a/packages/cactus-test-tooling/src/main/typescript/openethereum/openethereum-test-ledger.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/openethereum/openethereum-test-ledger.ts
@@ -233,7 +233,7 @@ export class OpenEthereumTestLedger {
    */
   public async newEthPersonalAccount(
     seedMoney = 10e8,
-    password = "test",
+    password: string,
   ): Promise<string> {
     const account = await this.web3.eth.personal.newAccount(password);
 


### PR DESCRIPTION
### Commit to be reviewed
---
fix(test-tooling): use of hardcoded password

```
Primary Changes
----------------
1. BREAKING CHANGE: "password" is now a mandatory parameter of the newEthPersonalAccount function
defined in openethereum-test-ledger.ts. It was previously optional.
2. Updated line 236 in openethereum-test-ledger.ts so the default password argument to the
newEthPersonalAccount function is not hardcoded.
```

Fixes #2766

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.