### PR TITLE
ci(github): workflow to ensure PR commit parity

### DIFF
--- a/.github/workflows/pr-commit-parity.yaml
+++ b/.github/workflows/pr-commit-parity.yaml
@@ -1,0 +1,25 @@
+---
+name: PR - Commit Parity
+'on':
+  pull_request:
+    branches:
+      - main
+      - dev
+      - petermetz/**
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  pr-commit-parity:
+    name: PR and Commit messages Parity
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3.1.0
+    - name: Use Node.js v18.18.2
+      uses: actions/setup-node@v4.0.2
+      with:
+        node-version: v18.19.0
+    - name: Execute pr-commit-parity script
+      run: node tools/pr-commit-parity.js ${{ github.event.pull_request.url }}

--- a/tools/pr-commit-parity.js
+++ b/tools/pr-commit-parity.js
@@ -1,0 +1,61 @@
+export async function fetchJsonFromUrl(url) {
+  const fetchResponse = await fetch(url);
+  return fetchResponse.json();
+}
+
+//regex expressions
+const PULL_REQ_REQUIREMENTS_REGEX = /\*\*Pull\sRequest\sRequirements(.|\n)*/gim;
+const FIXES_OR_DEPENDS_REGEX = /(Fixes|Depends)(.|\n)*/gim;
+const SIGNED_OFF_REGEX = /(")*Signed-off-by:(.|\s)*/gim;
+const HYPHEN_REGEX = /(-)+/gm;
+const BACKTICK_REGEX = /`+/gm;
+const SPACE_REGEX = / +/gm;
+const COMMIT_TO_BE_REVIEWED_REGEX = /("#*\s*Commit\sto\sbe\sreviewed)/gim;
+const WHITESPACES_HARDCODED_REGEX = /(\r\n|\n|\r|\\r|\\n)/gm;
+
+const args = process.argv.slice(2);
+const pullReqUrl = args[0];
+
+const prMetadata = await fetchJsonFromUrl(pullReqUrl);
+const prBodyRaw = JSON.stringify(prMetadata.body);
+
+let commitMessageList = [];
+const commitMessagesMetadata = await fetchJsonFromUrl(pullReqUrl + "/commits");
+
+commitMessagesMetadata.forEach((commitMessageMetadata) => {
+  commitMessageList.push(
+    commitMessageMetadata["commit"]["message"]
+      .replace(SIGNED_OFF_REGEX, "")
+      .replace(HYPHEN_REGEX, "")
+      .replace(BACKTICK_REGEX, "")
+      .replace(WHITESPACES_HARDCODED_REGEX, "")
+      .replace(FIXES_OR_DEPENDS_REGEX, "")
+      .replace(SPACE_REGEX, ""),
+  );
+});
+
+let prBodyStriped = prBodyRaw
+  .replace(PULL_REQ_REQUIREMENTS_REGEX, "")
+  .replace(FIXES_OR_DEPENDS_REGEX, "")
+  .replace(WHITESPACES_HARDCODED_REGEX, "")
+  .replace(SIGNED_OFF_REGEX, "")
+  .replace(HYPHEN_REGEX, "")
+  .replace(BACKTICK_REGEX, "")
+  .replace(COMMIT_TO_BE_REVIEWED_REGEX, "")
+  .replace(SPACE_REGEX, "");
+
+let PR_BODY_IN_COMMIT_MESSAGES = false;
+for (let commitMessageListIndex in commitMessageList) {
+  let commitMessage = commitMessageList[commitMessageListIndex];
+  if (commitMessage == prBodyStriped) PR_BODY_IN_COMMIT_MESSAGES = true;
+}
+
+if (!PR_BODY_IN_COMMIT_MESSAGES) {
+  console.error(
+    "PR Body does not match any existing commit message\n" +
+      "Please make sure that the PR Body matches to minimum one of the commit messages\n" +
+      "Please refer the following PR for reference: https://github.com/hyperledger/cacti/pull/3338\n" +
+      "And the commit message here: https://github.com/hyperledger/cacti/pull/3338/commits/47ebdec442d30fa48c8518b876c47c38097cf028\n",
+  );
+  process.exit(-1);
+}


### PR DESCRIPTION
## Commit to be reviewed
 
ci(github): workflow to ensure PR commit parity 

    Primary Changes
    ---------------
    1. Added a script which ensures PR body and commit message
       parity

    Changes needed to incorporate 1)
    --------------------------------
    2. Added a new workflow to enable the same

Fixes #2214

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.