### PR TITLE
chore(weaver): use specific fabric versions

### DIFF
--- a/weaver/tests/network-setups/fabric/dev/Makefile
+++ b/weaver/tests/network-setups/fabric/dev/Makefile
@@ -27,22 +27,22 @@ start-interop-local: start-interop-network1-local start-interop-network2-local
 
 .PHONY: start-network1
 start-network1:	.fabric-setup artifacts-network1 setup-cc
-	./network.sh up createChannel -ca -nw network1 -p $(PROFILE)
+	./network.sh up createChannel -ca -nw network1 -p $(PROFILE)  -i $(FABRIC_VERSION) -cai $(FABRIC_CA_VERSION)
 	./network.sh deployCC -ch $(CHAINCODE_NAME) -nw network1 -p $(PROFILE)
 
 .PHONY: start-network1-local
 start-network1-local: .fabric-setup artifacts-network1 setup-cc-local
-	./network.sh up createChannel -ca -nw network1 -p $(PROFILE)
+	./network.sh up createChannel -ca -nw network1 -p $(PROFILE)  -i $(FABRIC_VERSION) -cai $(FABRIC_CA_VERSION)
 	./network.sh deployCC -ch $(CHAINCODE_NAME) -nw network1 -p $(PROFILE)
 
 .PHONY: start-network2
 start-network2: .fabric-setup artifacts-network2 setup-cc
-	./network.sh up createChannel -ca -nw network2 -p $(PROFILE)
+	./network.sh up createChannel -ca -nw network2 -p $(PROFILE) -i $(FABRIC_VERSION) -cai $(FABRIC_CA_VERSION)
 	./network.sh deployCC -ch $(CHAINCODE_NAME) -nw network2 -p $(PROFILE)
 
 .PHONY: start-network2-local
 start-network2-local: .fabric-setup artifacts-network2 setup-cc-local
-	./network.sh up createChannel -ca -nw network2 -p $(PROFILE)
+	./network.sh up createChannel -ca -nw network2 -p $(PROFILE) -i $(FABRIC_VERSION) -cai $(FABRIC_CA_VERSION)
 	./network.sh deployCC -ch $(CHAINCODE_NAME) -nw network2 -p $(PROFILE)
 
 .PHONY: start-interop-network1

--- a/weaver/tests/network-setups/fabric/dev/base.env
+++ b/weaver/tests/network-setups/fabric/dev/base.env
@@ -1,2 +1,1 @@
-IMAGE_TAG=latest
 SYS_CHANNEL=system-channel

--- a/weaver/tests/network-setups/fabric/dev/docker/docker-compose-ca.yaml
+++ b/weaver/tests/network-setups/fabric/dev/docker/docker-compose-ca.yaml
@@ -10,7 +10,7 @@ networks:
 
 services:
   ca_org1:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:${CA_IMAGE_TAG}
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca.org1.${COMPOSE_PROJECT_NAME}.com
@@ -27,7 +27,7 @@ services:
 
   ca_org2:
     profiles: ["2-nodes"]
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:${CA_IMAGE_TAG}
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca.org2.${COMPOSE_PROJECT_NAME}.com
@@ -43,7 +43,7 @@ services:
       - net
 
   ca_orderer:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:${CA_IMAGE_TAG}
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca.orderer.${COMPOSE_PROJECT_NAME}.com


### PR DESCRIPTION
While fabric setup for weaver tests downloads images specified in the Makefile, when the network is brought up the latest versions are pulled.

**Primary Change:**

- pass fabric versions from Makefile to network.sh, ensuring they are used

**Secondary Changes:**

network.sh:
- allow specifying fabric ca version
- set exit on error bash flag to avoid continuing if script is in error
- re-write unsupported version tests to not not generate error

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.