### PR TITLE
ci(actionlint): exclude files with very large number of linter errors

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -46,14 +46,34 @@ jobs:
     # npm ERR! this command with --force or --legacy-peer-deps
     # npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
     - name: wipe_non_yaml_sources
-      run: rm -rf packages/ examples/ extensions/ package.json .github/workflows/test_weaver*.yaml .github/workflows/weaver_deploy*.yml weaver/
+      run: rm -rf packages/ examples/ extensions/ package.json weaver/
+
+    # We need to exclude these from the linting process for now because these files have 
+    # hundreds of linter errors that we didn't yet have time to fix. Once the errors are fixed
+    # we can add the files.
+    - name: Set env.CACTI_ACTIONLINT_FILES_TO_LINT
+      id: set_env_cacti_actionlint_files_to_lint
+      run: |
+          echo "CACTI_ACTIONLINT_FILES_TO_LINT=$(find .github/workflows/ -name "*.yml" -o -name "*.yaml" ! -name "*weaver*" -exec echo -n '{},' \;)" >> "$GITHUB_ENV"
+
+    - name: Print env.CACTI_ACTIONLINT_FILES_TO_LINT
+      id: print_env_cacti_actionlint_files_to_lint
+      run: |
+          echo "${{ env.CACTI_ACTIONLINT_FILES_TO_LINT }}" 
+
+    - name: Print Line-byLine env.CACTI_ACTIONLINT_FILES_TO_LINT
+      id: print_line_by_line_env_cacti_actionlint_files_to_lint
+      run: |
+          echo "${{ env.CACTI_ACTIONLINT_FILES_TO_LINT }}" | tr ',' '\n'
 
     - name: actionlint
       id: actionlint
-      uses: raven-actions/actionlint@v1.0.3
+      uses: raven-actions/actionlint@v2.0.0
       with:
-        version: 1.6.27
+        version: 1.7.1
         cache: true
+        files: ${{ env.CACTI_ACTIONLINT_FILES_TO_LINT }}
+        flags: "--verbose"
 
     - name: actionlint_summary
       if: ${{ steps.actionlint.outputs.exit-code != 0 }} # example usage, do echo only when actionlint action failed

--- a/.github/workflows/weaver_deploy_go-pkgs.yml
+++ b/.github/workflows/weaver_deploy_go-pkgs.yml
@@ -408,7 +408,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
       
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
1. There is a set of yaml workflow files that have to be removed prior to the
action lint task because they have hundreds of unfixed errors that we didn't
yet have time to address and the action lint github action has no easy way
to ignore files unfortunately so the easiest way to achieve that is to wipe
the fiels we don't want linting. This workaround caused a problem with the
workflow reuse improvements we were recently trying to introduce. So now
the way they get excluded is that we feed an explicit list of workflow files
to the linter that we want to get linted and we exclued the problematic files
from that list.
2. Also fixed on linter warning with the docker login action being outdated.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.