### PR TITLE
ci(connector-xdai): fix docker rate limit issues with openethereum im…

### DIFF
--- a/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai-json-object.test.ts
+++ b/packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/deploy-contract-from-json-xdai-json-object.test.ts
@@ -11,9 +11,7 @@ import {
 } from "../../../main/typescript/public-api";
 import {
   Containers,
-  K_DEV_WHALE_ACCOUNT_PRIVATE_KEY,
-  K_DEV_WHALE_ACCOUNT_PUBLIC_KEY,
-  OpenEthereumTestLedger,
+  BesuTestLedger,
   pruneDockerAllIfGithubAction,
 } from "@hyperledger/cactus-test-tooling";
 import {
@@ -45,8 +43,16 @@ test(testCase, async (t: Test) => {
     await Containers.logDiagnostics({ logLevel });
   });
 
-  const ledger = new OpenEthereumTestLedger({ logLevel });
-
+  const ledger = new BesuTestLedger({ logLevel });
+  const containerImageVersion = "2021-08-24--feat-1244";
+  const containerImageName =
+    "ghcr.io/hyperledger/cactus-besu-21-1-6-all-in-one";
+  const besuOptions = { containerImageName, containerImageVersion };
+  const besuTestLedger = new BesuTestLedger(besuOptions);
+  const besuKeyPair = {
+    privateKey: besuTestLedger.getGenesisAccountPrivKey(),
+  };
+  const firstHighNetWorthAccount = besuTestLedger.getGenesisAccountPubKey();
   test.onFinish(async () => {
     await ledger.stop();
     await ledger.destroy();
@@ -55,9 +61,6 @@ test(testCase, async (t: Test) => {
   await ledger.start();
 
   const rpcApiHttpHost = await ledger.getRpcApiHttpHost();
-
-  const whalePubKey = K_DEV_WHALE_ACCOUNT_PUBLIC_KEY;
-  const whalePrivKey = K_DEV_WHALE_ACCOUNT_PRIVATE_KEY;
 
   const web3 = new Web3(rpcApiHttpHost);
   const testEthAccount = web3.eth.accounts.create(uuidv4());
@@ -92,12 +95,12 @@ test(testCase, async (t: Test) => {
 
   await connector.transact({
     web3SigningCredential: {
-      ethAccount: whalePubKey,
-      secret: whalePrivKey,
+      ethAccount: firstHighNetWorthAccount,
+      secret: besuKeyPair.privateKey,
       type: Web3SigningCredentialType.PrivateKeyHex,
     },
     transactionConfig: {
-      from: whalePubKey,
+      from: firstHighNetWorthAccount,
       to: testEthAccount.address,
       value: 10e9,
       gas: 1000000,
@@ -118,8 +121,8 @@ test(testCase, async (t: Test) => {
   test("deploys contract via .json file", async (t2: Test) => {
     const deployOut = await connector.deployContractJsonObject({
       web3SigningCredential: {
-        ethAccount: whalePubKey,
-        secret: whalePrivKey,
+        ethAccount: firstHighNetWorthAccount,
+        secret: besuKeyPair.privateKey,
         type: Web3SigningCredentialType.PrivateKeyHex,
       },
       gas: 1000000,
@@ -147,8 +150,8 @@ test(testCase, async (t: Test) => {
       methodName: "sayHello",
       params: [],
       web3SigningCredential: {
-        ethAccount: whalePubKey,
-        secret: whalePrivKey,
+        ethAccount: firstHighNetWorthAccount,
+        secret: besuKeyPair.privateKey,
         type: Web3SigningCredentialType.PrivateKeyHex,
       },
       gas: 1000000,


### PR DESCRIPTION
### **Commit** to be reviewed
---
ci(connector-xdai): fix docker rate limit issues with openethereum image pull 
```
Primary Changes
----------------
1. Migrated all the xdai connector tests to besu ledger
   images that is being pulled from ghcr
```
Fixes #3413

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.