### PR TITLE
ci(github): fix keychain-aws-sm no code coverage files/dir found

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1013,8 +1013,8 @@ jobs:
     env:
       FULL_BUILD_DISABLED: true
       JEST_TEST_PATTERN: packages/cactus-plugin-keychain-aws-sm/src/test/typescript/(unit|integration|benchmark)/.*/*.test.ts
-      JEST_TEST_RUNNER_DISABLED: true
-      TAPE_TEST_PATTERN: '--files={./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts,./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts,./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-keychain-aws-sm.test.ts}'
+      JEST_TEST_RUNNER_DISABLED: false
+      TAPE_TEST_PATTERN: '--files={./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts,./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-factory-keychain.test.ts}'
       JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cp-keychain-aws-sm
       JEST_TEST_CODE_COVERAGE_ENABLED: true
       TAPE_TEST_RUNNER_DISABLED: false

--- a/.taprc
+++ b/.taprc
@@ -24,7 +24,6 @@ files:
   - ./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts
   - ./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts
   - ./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts
-  - ./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-keychain-aws-sm.test.ts
   - ./packages/cactus-api-client/src/test/typescript/integration/default-consortium-provider.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-balance-endpoint.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-past-logs-endpoint.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,7 +36,6 @@ module.exports = {
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts`,
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts`,
     `./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts`,
-    `./packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/plugin-keychain-aws-sm.test.ts`,
     `./packages/cactus-api-client/src/test/typescript/integration/default-consortium-provider.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-balance-endpoint.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-past-logs-endpoint.test.ts`,

--- a/packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-keychain-aws-sm/src/test/typescript/integration/openapi/openapi-validation.test.ts
@@ -145,7 +145,7 @@ describe("PluginKeychainAwsSm", () => {
     try {
       await apiClient.setKeychainEntryV1({
         value,
-      } as any as SetKeychainEntryRequestV1);
+      } as SetKeychainEntryRequestV1);
     } catch (e) {
       expect(e.response.status).toBe(400);
       const fields = e.response.data.map((param: any) =>
@@ -157,9 +157,7 @@ describe("PluginKeychainAwsSm", () => {
 
   test(`${testCase} - ${fGet} - ${cWithoutParams}`, async () => {
     try {
-      await apiClient.getKeychainEntryV1(
-        {} as any as GetKeychainEntryRequestV1,
-      );
+      await apiClient.getKeychainEntryV1({} as GetKeychainEntryRequestV1);
     } catch (e) {
       expect(e.response.status).toBe(400);
       const fields = e.response.data.map((param: any) =>
@@ -171,9 +169,7 @@ describe("PluginKeychainAwsSm", () => {
 
   test(`${testCase} - ${fHas} - ${cWithoutParams}`, async () => {
     try {
-      await apiClient.hasKeychainEntryV1(
-        {} as any as HasKeychainEntryRequestV1,
-      );
+      await apiClient.hasKeychainEntryV1({} as HasKeychainEntryRequestV1);
     } catch (e) {
       expect(e.response.status).toBe(400);
       const fields = e.response.data.map((param: any) =>
@@ -185,9 +181,7 @@ describe("PluginKeychainAwsSm", () => {
 
   test(`${testCase} - ${fDelete} - ${cWithoutParams}`, async () => {
     try {
-      await apiClient.deleteKeychainEntryV1(
-        {} as any as DeleteKeychainEntryRequestV1,
-      );
+      await apiClient.deleteKeychainEntryV1({} as DeleteKeychainEntryRequestV1);
     } catch (e) {
       expect(e.response.status).toBe(400);
       const fields = e.response.data.map((param: any) =>
@@ -203,7 +197,7 @@ describe("PluginKeychainAwsSm", () => {
         key,
         value,
         fake: 4,
-      } as any as SetKeychainEntryRequestV1);
+      } as SetKeychainEntryRequestV1);
     } catch (e) {
       expect(e.response.status).toBe(400);
       const fields = e.response.data.map((param: any) =>
@@ -218,7 +212,7 @@ describe("PluginKeychainAwsSm", () => {
       await apiClient.getKeychainEntryV1({
         key,
         fake: 4,
-      } as any as GetKeychainEntryRequestV1);
+      } as GetKeychainEntryRequestV1);
     } catch (e) {
       expect(e.response.status).toBe(400);
       const fields = e.response.data.map((param: any) =>
@@ -233,7 +227,7 @@ describe("PluginKeychainAwsSm", () => {
       await apiClient.hasKeychainEntryV1({
         key,
         fake: 4,
-      } as any as HasKeychainEntryRequestV1);
+      } as HasKeychainEntryRequestV1);
     } catch (e) {
       expect(e.response.status).toBe(400);
       const fields = e.response.data.map((param: any) =>
@@ -248,7 +242,7 @@ describe("PluginKeychainAwsSm", () => {
       await apiClient.deleteKeychainEntryV1({
         key,
         fake: 4,
-      } as any as DeleteKeychainEntryRequestV1);
+      } as DeleteKeychainEntryRequestV1);
     } catch (e) {
       expect(e.response.status).toBe(400);
       const fields = e.response.data.map((param: any) =>

--- a/packages/cactus-plugin-keychain-aws-sm/src/test/typescript/unit/api-surface.test.ts
+++ b/packages/cactus-plugin-keychain-aws-sm/src/test/typescript/unit/api-surface.test.ts
@@ -1,0 +1,5 @@
+import * as apiSurface from "../../../main/typescript/public-api";
+
+test("Library can be loaded", async () => {
+  expect(apiSurface).toBeTruthy();
+});

--- a/packages/cactus-plugin-keychain-aws-sm/src/test/typescript/unit/api-surface.ts
+++ b/packages/cactus-plugin-keychain-aws-sm/src/test/typescript/unit/api-surface.ts
@@ -1,7 +1,0 @@
-import test, { Test } from "tape";
-import * as publicApi from "../../../main/typescript/public-api";
-
-test("Library can be loaded", (assert: Test) => {
-  assert.ok(publicApi);
-  assert.end();
-});


### PR DESCRIPTION
1. The Jest test execution was turned off for the AWS SM keychain plugin
for some reason so this PR enables it back and while at it
2. I also refactored one of the test cases to have less linter warnings
about us casting to `any`.
3. And on top of that I also migrated one of the test cases to Jest from
TAP/tape so that we are making some progress with the test coverage at
the same time.

One more notable thing is that I refactored the negative test assertions
while migrating to Jest so the test case now uses Jest native assertions
to check what exactly the error message returned by the API call for
deleting a non-existent item looks like. This is an example of the
refactoring that this issue is about:
https://github.com/hyperledger/cacti/issues/3455

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>