### PR TITLE
refactor: Refactor negative test cases in refund.test to use Jest assertions 

### DIFF
--- a/extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript/integration/plugin-htlc-coordinator/refund.test.ts
+++ b/extensions/cactus-plugin-htlc-coordinator-besu/src/test/typescript/integration/plugin-htlc-coordinator/refund.test.ts
@@ -312,22 +312,24 @@ describe("HTLC Coordinator Besu", () => {
       gas: estimatedGas,
     };
 
-    try {
-      await htlcCoordinatorBesuApiClient.withdrawCounterpartyV1(
-        withdrawCounterparty,
-      );
-    } catch (exp: unknown) {
-      log.debug("Caught error as expected: %o", exp);
-      if (axios.isAxiosError(exp) && exp.response) {
-        log.debug("Caught response: %o", exp.response.data);
-        const revertReason = exp.response.data.cause.receipt.revertReason;
-        const regExp = new RegExp(/0e494e56414c49445f5345435245540/);
-        expect(revertReason).toMatch(regExp);
-        // t.match(revertReason, regExp, rejectMsg);
-      } else {
-        throw exp;
+await expect(
+  htlcCoordinatorBesuApiClient.withdrawCounterpartyV1(withdrawCounterparty)
+).rejects.toThrowErrorMatchingSnapshot();
+
+await expect(
+  htlcCoordinatorBesuApiClient.withdrawCounterpartyV1(withdrawCounterparty)
+).rejects.toThrow(expect.objectContaining({
+  response: {
+    data: {
+      cause: {
+        receipt: {
+          revertReason: expect.stringMatching(/0e494e56414c49445f5345435245540/)
+        }
       }
     }
+  }
+}));
+
 
     const responseFinalBalanceReceiver = await connector.invokeContract({
       contractName: TestTokenJSON.contractName,

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@types/benchmark": "2.1.5",
     "@types/debug": "4.1.12",
     "@types/fs-extra": "11.0.4",
-    "@types/jest": "29.5.3",
+    "@types/jest": "29.5.12",
     "@types/madge": "5.0.3",
     "@types/node": "18.11.9",
     "@types/node-fetch": "2.6.4",


### PR DESCRIPTION
Refactor Negative Test Cases in refund.test.ts to Use Jest Assertions

Replaced try-catch blocks with Jest’s .rejects matcher for error scenarios
in refund.test.ts. Updated test cases to use .toMatch and .toThrow for
error assertions, improving test readability and maintainability.

Test results remain consistent, and all assertions now leverage Jest’s
built-in methods.

- Rebased onto upstream/main
- Squashed into a single commit
- Signed-off commit

BREAKING CHANGE: None

Signed-off-by: Deepakchowdavarapu deepak.23bcs10092@ms.sst.scaler.com
