### PR TITLE
test(besu): refactor jest test negative test cases

### DIFF
--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/get-record-locator.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/get-record-locator.test.ts
@@ -265,8 +265,8 @@ describe("PluginLedgerConnectorBesu", () => {
     });
     expect(setNameOut).toBeTruthy();
 
-    try {
-      await connector.invokeContract({
+    await expect(
+      connector.invokeContract({
         contractName: HelloWorldContractJson.contractName,
         contractAbi: HelloWorldContractJson.abi,
         contractAddress,
@@ -280,19 +280,14 @@ describe("PluginLedgerConnectorBesu", () => {
           type: Web3SigningCredentialType.PrivateKeyHex,
         },
         nonce: 1,
-      });
-      throw new Error("This operation should not have succeeded, but it did.");
-    } catch (ex: unknown) {
-      // 'Returned error: Nonce too low'
-      expect(ex).toHaveProperty(
-        "message",
-        expect.stringContaining("Nonce too low"),
-      );
-      expect(ex).toHaveProperty(
-        "stack",
-        expect.stringContaining("Nonce too low"),
-      );
-    }
+      }),
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        message: expect.stringContaining("Nonce too low"),
+        stack: expect.stringContaining("Nonce too low"),
+      }),
+    );
+
     const req: InvokeContractV1Request = {
       contractName: HelloWorldContractJson.contractName,
       contractAbi: HelloWorldContractJson.abi,

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/invoke-contract.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/deploy-contract/invoke-contract.test.ts
@@ -183,8 +183,8 @@ describe(testCase, () => {
       });
       expect(setNameOut).toBeTruthy();
 
-      try {
-        const setNameOutInvalid = await connector.invokeContract({
+      await expect(
+        connector.invokeContract({
           contractName,
           keychainId: keychainPlugin.getKeychainId(),
           invocationType: EthContractInvocationType.Send,
@@ -197,11 +197,12 @@ describe(testCase, () => {
             type: Web3SigningCredentialType.PrivateKeyHex,
           },
           nonce: 1,
-        });
-        expect(setNameOutInvalid.transactionReceipt).toBeFalsy();
-      } catch (error) {
-        expect(error.message).toMatch("Nonce too low");
-      }
+        }),
+      ).rejects.toThrowError(
+        expect.objectContaining({
+          message: expect.stringContaining("Nonce too low"),
+        }),
+      );
 
       const { callOutput: getNameOut } = await connector.invokeContract({
         contractName,
@@ -286,8 +287,8 @@ describe(testCase, () => {
       });
       expect(setNameOut).toBeTruthy();
 
-      try {
-        const setNameOutInvalid = await connector.invokeContract({
+      await expect(
+        connector.invokeContract({
           contractName,
           keychainId: keychainPlugin.getKeychainId(),
           invocationType: EthContractInvocationType.Send,
@@ -296,11 +297,8 @@ describe(testCase, () => {
           gas: 1000000,
           signingCredential,
           nonce: 4,
-        });
-        expect(setNameOutInvalid.transactionReceipt).toBeFalsy();
-      } catch (error) {
-        expect(error.message).toMatch("Nonce too low");
-      }
+        }),
+      ).rejects.toThrow("Nonce too low");
 
       const { callOutput: getNameOut } = await connector.invokeContract({
         contractName,

--- a/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/openapi/openapi-validation.test.ts
+++ b/packages/cactus-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-ledger-connector-besu/openapi/openapi-validation.test.ts
@@ -198,58 +198,67 @@ describe("PluginLedgerConnectorBesu", () => {
   });
 
   test(`${testCase} - ${fDeploy} - ${cWithoutParams}`, async () => {
-    try {
-      const parameters = {
-        keychainId: keychainIdForUnsigned,
-        contractAbi: HelloWorldContractJson.abi,
-        constructorArgs: [],
-        web3SigningCredential: {
-          ethAccount: testEthAccount1.address,
-          secret: testEthAccount1.privateKey,
-          type: Web3SigningCredentialType.PrivateKeyHex,
-        },
-      };
-      await apiClient.deployContractSolBytecodeV1(
-        parameters as unknown as DeployContractSolidityBytecodeV1Request,
-      );
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
+    const parameters = {
+      keychainId: keychainIdForUnsigned,
+      contractAbi: HelloWorldContractJson.abi,
+      constructorArgs: [],
+      web3SigningCredential: {
+        ethAccount: testEthAccount1.address,
+        secret: testEthAccount1.privateKey,
+        type: Web3SigningCredentialType.PrivateKeyHex,
+      },
+    };
 
-      expect(fields.includes("contractName")).toBeTrue();
-      expect(fields.includes("bytecode")).toBeTrue();
-      expect(fields.includes("gas")).toBeFalse();
-    }
+    await expect(
+      apiClient.deployContractSolBytecodeV1(
+        parameters as unknown as DeployContractSolidityBytecodeV1Request,
+      ),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/contractName"),
+          }),
+          expect.objectContaining({
+            path: expect.stringContaining("/body/bytecode"),
+          }),
+          expect.not.objectContaining({
+            path: expect.stringContaining("/body/gas"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fDeploy} - ${cInvalidParams}`, async () => {
-    try {
-      const parameters = {
-        keychainId: keychainIdForUnsigned,
-        contractName: HelloWorldContractJson.contractName,
-        contractAbi: HelloWorldContractJson.abi,
-        constructorArgs: [],
-        web3SigningCredential: {
-          ethAccount: testEthAccount1.address,
-          secret: testEthAccount1.privateKey,
-          type: Web3SigningCredentialType.PrivateKeyHex,
-        },
-        bytecode: HelloWorldContractJson.bytecode,
-        gas: 1000000,
-        fake: 4,
-      };
-      await apiClient.deployContractSolBytecodeV1(
+    const parameters = {
+      keychainId: keychainIdForUnsigned,
+      contractName: HelloWorldContractJson.contractName,
+      contractAbi: HelloWorldContractJson.abi,
+      constructorArgs: [],
+      web3SigningCredential: {
+        ethAccount: testEthAccount1.address,
+        secret: testEthAccount1.privateKey,
+        type: Web3SigningCredentialType.PrivateKeyHex,
+      },
+      bytecode: HelloWorldContractJson.bytecode,
+      gas: 1000000,
+      fake: 4,
+    };
+
+    await expect(
+      apiClient.deployContractSolBytecodeV1(
         parameters as DeployContractSolidityBytecodeV1Request,
-      );
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("fake")).toBeTrue();
-    }
+      ),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({ path: "/body/fake" }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fInvoke} - ${cOk}`, async () => {
@@ -274,54 +283,62 @@ describe("PluginLedgerConnectorBesu", () => {
   });
 
   test(`${testCase} - ${fInvoke} - ${cWithoutParams}`, async () => {
-    try {
-      const parameters = {
-        keychainId: keychainIdForUnsigned,
-        invocationType: EthContractInvocationType.Call,
-        methodName: "sayHello",
-        params: [],
-        signingCredential: {
-          ethAccount: testEthAccount1.address,
-          secret: testEthAccount1.privateKey,
-          type: Web3SigningCredentialType.PrivateKeyHex,
-        },
-      };
-      await apiClient.invokeContractV1(
-        parameters as any as InvokeContractV1Request,
-      );
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("contractName")).toBeTrue();
-      expect(fields.includes("gas")).toBeFalse();
-    }
+    const parameters = {
+      keychainId: keychainIdForUnsigned,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "sayHello",
+      params: [],
+      signingCredential: {
+        ethAccount: testEthAccount1.address,
+        secret: testEthAccount1.privateKey,
+        type: Web3SigningCredentialType.PrivateKeyHex,
+      },
+    };
+
+    await expect(
+      apiClient.invokeContractV1(parameters as any as InvokeContractV1Request),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/contractName"),
+          }),
+          expect.not.objectContaining({
+            path: expect.stringContaining("/body/gas"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fInvoke} - ${cInvalidParams}`, async () => {
-    try {
-      const parameters = {
-        contractName: "HelloWorld",
-        keychainId: keychainIdForUnsigned,
-        invocationType: EthContractInvocationType.Call,
-        methodName: "sayHello",
-        params: [],
-        signingCredential: {
-          ethAccount: testEthAccount1.address,
-          secret: testEthAccount1.privateKey,
-          type: Web3SigningCredentialType.PrivateKeyHex,
-        },
-        fake: 4,
-      };
-      await apiClient.invokeContractV1(parameters as InvokeContractV1Request);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const parameters = {
+      contractName: "HelloWorld",
+      keychainId: keychainIdForUnsigned,
+      invocationType: EthContractInvocationType.Call,
+      methodName: "sayHello",
+      params: [],
+      signingCredential: {
+        ethAccount: testEthAccount1.address,
+        secret: testEthAccount1.privateKey,
+        type: Web3SigningCredentialType.PrivateKeyHex,
+      },
+      fake: 4,
+    };
+
+    await expect(
+      apiClient.invokeContractV1(parameters as InvokeContractV1Request),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/fake"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fRun} - ${cOk}`, async () => {
@@ -353,59 +370,67 @@ describe("PluginLedgerConnectorBesu", () => {
   });
 
   test(`${testCase} - ${fRun} - ${cWithoutParams}`, async () => {
-    try {
-      const parameters = {
-        web3SigningCredential: {
-          ethAccount: testEthAccount1.address,
-          secret: testEthAccount1.privateKey,
-          type: Web3SigningCredentialType.PrivateKeyHex,
-        },
-        transactionConfig: {
-          from: testEthAccount1.address,
-          to: testEthAccount2.address,
-          value: 10e7,
-          gas: 1000000,
-        },
-      };
-      await apiClient.runTransactionV1(parameters as RunTransactionRequest);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("consistencyStrategy")).toBeTrue();
-    }
+    const parameters = {
+      web3SigningCredential: {
+        ethAccount: testEthAccount1.address,
+        secret: testEthAccount1.privateKey,
+        type: Web3SigningCredentialType.PrivateKeyHex,
+      },
+      transactionConfig: {
+        from: testEthAccount1.address,
+        to: testEthAccount2.address,
+        value: 10e7,
+        gas: 1000000,
+      },
+    };
+
+    await expect(
+      apiClient.runTransactionV1(parameters as RunTransactionRequest),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/consistencyStrategy"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fRun} - ${cInvalidParams}`, async () => {
-    try {
-      const parameters = {
-        web3SigningCredential: {
-          ethAccount: testEthAccount1.address,
-          secret: testEthAccount1.privateKey,
-          type: Web3SigningCredentialType.PrivateKeyHex,
-        },
-        transactionConfig: {
-          from: testEthAccount1.address,
-          to: testEthAccount2.address,
-          value: 10e7,
-          gas: 1000000,
-        },
-        consistencyStrategy: {
-          blockConfirmations: 0,
-          receiptType: ReceiptType.NodeTxPoolAck,
-          timeoutMs: 5000,
-        },
-        fake: 4,
-      };
-      await apiClient.runTransactionV1(parameters as RunTransactionRequest);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const parameters = {
+      web3SigningCredential: {
+        ethAccount: testEthAccount1.address,
+        secret: testEthAccount1.privateKey,
+        type: Web3SigningCredentialType.PrivateKeyHex,
+      },
+      transactionConfig: {
+        from: testEthAccount1.address,
+        to: testEthAccount2.address,
+        value: 10e7,
+        gas: 1000000,
+      },
+      consistencyStrategy: {
+        blockConfirmations: 0,
+        receiptType: ReceiptType.NodeTxPoolAck,
+        timeoutMs: 5000,
+      },
+      fake: 4,
+    };
+
+    await expect(
+      apiClient.runTransactionV1(parameters as RunTransactionRequest),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/fake"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fSign} - ${cOk}`, async () => {
@@ -482,21 +507,24 @@ describe("PluginLedgerConnectorBesu", () => {
     expect(runTxRes.data).toBeTruthy();
     expect((runTxRes.data as any).data.transactionReceipt).toBeTruthy();
 
-    try {
-      const parameters = {
-        keychainRef: keychainRefForSigned,
-        transactionHash: (runTxRes.data as any).data.transactionReceipt
-          .transactionHash,
-      };
+    const parameters = {
+      keychainRef: keychainRefForSigned,
+      transactionHash: (runTxRes.data as any).data.transactionReceipt
+        .transactionHash,
+    };
 
-      await apiClient.signTransactionV1(parameters as SignTransactionRequest);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: any) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("keychainId")).toBeTrue();
-    }
+    await expect(
+      apiClient.signTransactionV1(parameters as SignTransactionRequest),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/keychainId"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fSign} - ${cInvalidParams}`, async () => {
@@ -523,23 +551,26 @@ describe("PluginLedgerConnectorBesu", () => {
     expect(runTxRes.data).toBeTruthy();
     expect((runTxRes.data as any).data.transactionReceipt).toBeTruthy();
 
-    try {
-      const parameters = {
-        keychainId: keychainIdForSigned,
-        keychainRef: keychainRefForSigned,
-        transactionHash: (runTxRes.data as any).data.transactionReceipt
-          .transactionHash,
-        fake: 4,
-      };
+    const parameters = {
+      keychainId: keychainIdForSigned,
+      keychainRef: keychainRefForSigned,
+      transactionHash: (runTxRes.data as any).data.transactionReceipt
+        .transactionHash,
+      fake: 4,
+    };
 
-      await apiClient.signTransactionV1(parameters as SignTransactionRequest);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    await expect(
+      apiClient.signTransactionV1(parameters as SignTransactionRequest),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/fake"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fBalance} - ${cOk}`, async () => {
@@ -550,32 +581,40 @@ describe("PluginLedgerConnectorBesu", () => {
   });
 
   test(`${testCase} - ${fBalance} - ${cWithoutParams}`, async () => {
-    try {
-      const parameters = {};
-      await apiClient.getBalanceV1(parameters as GetBalanceV1Request);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("address")).toBeTrue();
-    }
+    const parameters = {}; // Empty parameters object
+
+    await expect(
+      apiClient.getBalanceV1(parameters as GetBalanceV1Request),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/address"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fBalance} - ${cInvalidParams}`, async () => {
-    try {
-      const parameters = {
-        address: firstHighNetWorthAccount,
-        fake: 4,
-      };
-      await apiClient.getBalanceV1(parameters as GetBalanceV1Request);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const parameters = {
+      address: firstHighNetWorthAccount,
+      fake: 4,
+    };
+
+    await expect(
+      apiClient.getBalanceV1(parameters as GetBalanceV1Request),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/fake"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fBlock} - ${cOk}`, async () => {
@@ -586,32 +625,40 @@ describe("PluginLedgerConnectorBesu", () => {
   });
 
   test(`${testCase} - ${fBlock} - ${cWithoutParams}`, async () => {
-    try {
-      const parameters = {};
-      await apiClient.getBlockV1(parameters as GetBlockV1Request);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("blockHashOrBlockNumber")).toBeTrue();
-    }
+    const parameters = {}; // Empty parameters object
+
+    await expect(
+      apiClient.getBlockV1(parameters as GetBlockV1Request),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/blockHashOrBlockNumber"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fBlock} - ${cInvalidParams}`, async () => {
-    try {
-      const parameters = {
-        blockHashOrBlockNumber: 0,
-        fake: 4,
-      };
-      await apiClient.getBlockV1(parameters as GetBlockV1Request);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const parameters = {
+      blockHashOrBlockNumber: 0,
+      fake: 4,
+    };
+
+    await expect(
+      apiClient.getBlockV1(parameters as GetBlockV1Request),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/fake"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fPastLogs} - ${cOk}`, async () => {
@@ -626,7 +673,13 @@ describe("PluginLedgerConnectorBesu", () => {
   test(`${testCase} - ${fPastLogs} - ${cWithoutParams}`, async () => {
     try {
       const parameters = {};
-      await apiClient.getPastLogsV1(parameters as GetPastLogsV1Request);
+      const response = await apiClient.getPastLogsV1(
+        parameters as GetPastLogsV1Request,
+      );
+      console.log(
+        "e.response.status should be 400 but actually is,",
+        response.status,
+      );
     } catch (e) {
       expect(e.response.status).toEqual(400);
       const fields = e.response.data.map((param: { readonly path: string }) =>
@@ -634,22 +687,40 @@ describe("PluginLedgerConnectorBesu", () => {
       );
       expect(fields.includes("address")).toBeTrue();
     }
+
+    //since status code is actually 200 refactored approach does not work
+
+    // const parameters = {}; // Empty parameters object
+
+    // await expect(apiClient.getPastLogsV1(parameters as GetPastLogsV1Request))
+    // .rejects.toMatchObject({
+    //   response: {
+    //     status: 400,
+    //     data: expect.arrayContaining([
+    //       expect.objectContaining({ path: expect.stringContaining("/body/address") })
+    //     ])
+    //   }
+    // });
   });
 
   test(`${testCase} - ${fPastLogs} - ${cInvalidParams}`, async () => {
-    try {
-      const parameters = {
-        address: firstHighNetWorthAccount,
-        fake: 4,
-      };
-      await apiClient.getPastLogsV1(parameters as GetPastLogsV1Request);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const parameters = {
+      address: firstHighNetWorthAccount,
+      fake: 4,
+    };
+
+    await expect(
+      apiClient.getPastLogsV1(parameters as GetPastLogsV1Request),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/fake"),
+          }),
+        ]),
+      },
+    });
   });
 
   test(`${testCase} - ${fRecord} - ${cOk}`, async () => {
@@ -692,7 +763,13 @@ describe("PluginLedgerConnectorBesu", () => {
   test(`${testCase} - ${fRecord} - ${cWithoutParams}`, async () => {
     try {
       const parameters = {};
-      await apiClient.getBesuRecordV1(parameters as GetBesuRecordV1Request);
+      const response = await apiClient.getBesuRecordV1(
+        parameters as GetBesuRecordV1Request,
+      );
+      console.log(
+        "e.response.status should be 400 but actually is,",
+        response.status,
+      );
     } catch (e) {
       expect(e.response.status).toEqual(400);
       const fields = e.response.data.map((param: any) =>
@@ -700,22 +777,40 @@ describe("PluginLedgerConnectorBesu", () => {
       );
       expect(fields.includes("transactionHash")).toBeTrue();
     }
+
+    // since status code is actually 200 refactored approach does not work
+
+    // const parameters = {}; // Empty parameters object
+
+    // await expect(apiClient.getBesuRecordV1(parameters as GetBesuRecordV1Request))
+    //   .rejects.toMatchObject({
+    //     response: {
+    //       status: 400,
+    //       data: expect.arrayContaining([
+    //         expect.objectContaining({ path: expect.stringContaining("/body/transactionHash") })
+    //       ])
+    //     }
+    //   });
   });
 
   test(`${testCase} - ${fRecord} - ${cInvalidParams}`, async () => {
-    try {
-      const parameters = {
-        transactionHash: "",
-        fake: 5,
-      };
-      await apiClient.getBesuRecordV1(parameters as GetBesuRecordV1Request);
-    } catch (e) {
-      expect(e.response.status).toEqual(400);
-      const fields = e.response.data.map((param: { readonly path: string }) =>
-        param.path.replace("/body/", ""),
-      );
-      expect(fields.includes("fake")).toBeTrue();
-    }
+    const parameters = {
+      transactionHash: "",
+      fake: 5,
+    };
+
+    await expect(
+      apiClient.getBesuRecordV1(parameters as GetBesuRecordV1Request),
+    ).rejects.toMatchObject({
+      response: {
+        status: 400,
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("/body/fake"),
+          }),
+        ]),
+      },
+    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## **Commit** to be reviewed
test(besu): refactor jest test negative test cases
``` Primary Changes ----------------
1. Refactored all negative test case exception assertions for cactus-plugin-ledger-connector-besu.
Removed try-catch blocks, replaced with declarations through jest and jest-extended's own API.
2. Noted two tests within openapi-validation.test.ts
(GetPastLogsEndpoint and GetBesuRecordEndpointV1 with empty parameters) where the status
code returned should be 400 but is 200. This could be investigated in a seperate issue.
```

Fixes #3467

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.