### PR TITLE
test(aries): refactor jest test negative test cases

### DIFF
--- a/packages/cactus-plugin-ledger-connector-aries/src/test/typescript/integration/aries-setup-and-connections.test.ts
+++ b/packages/cactus-plugin-ledger-connector-aries/src/test/typescript/integration/aries-setup-and-connections.test.ts
@@ -177,33 +177,31 @@ describe("Aries connector setup tests", () => {
   test("Adding aries agent with invalid inbound url throws error", async () => {
     const agentName = `shouldThrow-${uuidV4()}`;
 
-    try {
-      await connector.addAriesAgent({
+    await expect(
+      connector.addAriesAgent({
         name: agentName,
         walletKey: agentName,
         indyNetworks: [fakeIndyNetworkConfig],
         inboundUrl: "foo",
-      });
-      expect("should throw!").toBe(0);
-    } catch (error) {
-      log.info(
-        "Adding aries agent with inbound url 'foo' throws error as expected",
-      );
-    }
+      }),
+    ).rejects.toThrow();
 
-    try {
-      await connector.addAriesAgent({
+    log.info(
+      "Adding aries agent with inbound url 'foo' throws error as expected",
+    );
+
+    await expect(
+      connector.addAriesAgent({
         name: agentName,
         walletKey: agentName,
         indyNetworks: [fakeIndyNetworkConfig],
         inboundUrl: "http://127.0.0.1",
-      });
-      expect("should throw!").toBe(0);
-    } catch (error) {
-      log.info(
-        "Adding aries agent without inbound url port throws error as expected",
-      );
-    }
+      }),
+    ).rejects.toThrow();
+
+    log.info(
+      "Adding aries agent without inbound url port throws error as expected",
+    );
 
     const allAgents = await connector.getAgents();
     expect(allAgents.length).toBe(0);


### PR DESCRIPTION
## **Commit** to be reviewed
test(aries): refactor jest test negative test cases
``` 
Primary Changes
----------------
1. Refactored all the negative test case exception assertions for
cactus-plugin-ledger-connector-aries. Removed try-catch blocks,
replaced with declarations through jest-extended's own API.
```
Fixes #3473


**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.