### PR TITLE
fix(ci): updated permissioning and versioning in GitHub Actions

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -18,11 +18,15 @@ on:
 env:
   SITE_URL: https://${{ github.repository_owner }}.github.io/cacti
   NODEJS_VERSION: v18.18.2
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
 jobs:
   deploy-docs:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pages: write
     steps:
       - name: Use Node.js ${{ env.NODEJS_VERSION }}
         uses: actions/setup-node@v4.0.3

--- a/.github/workflows/test_weaver-asset-exchange-fabric.yaml
+++ b/.github/workflows/test_weaver-asset-exchange-fabric.yaml
@@ -144,7 +144,7 @@ jobs:
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
 
       # PROTOS
       - name: Build JS Protos

--- a/.github/workflows/test_weaver-asset-transfer.yaml
+++ b/.github/workflows/test_weaver-asset-transfer.yaml
@@ -728,7 +728,7 @@ jobs:
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
 
       # PROTOS
       - name: Build GO Protos

--- a/.github/workflows/test_weaver-data-sharing.yaml
+++ b/.github/workflows/test_weaver-data-sharing.yaml
@@ -456,7 +456,7 @@ jobs:
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
           rm -rf protoc-3.15.6-linux-x86_64.zip
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
 
       - name: CI script for cleanup
         run: ./tools/ci.sh
@@ -896,7 +896,7 @@ jobs:
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
 
       # PROTOS
       - name: Build GO Protos

--- a/.github/workflows/test_weaver-fabric-fabric-satp.yaml
+++ b/.github/workflows/test_weaver-fabric-fabric-satp.yaml
@@ -73,7 +73,7 @@ jobs:
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
           unzip protoc-3.15.6-linux-x86_64.zip -d protoc
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
 
       # PROTOS GO
       - name: Build GO Protos

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Using and Developing with Hyperledger Cacti
-site_url: !ENV [SITE_URL, 'https://hyperledger.github.io/cacti']
+site_url: !ENV [SITE_URL, 'https://${{ github.repository_owner }}.github.io/cacti']
 repo_name: hyperledger/cacti
 repo_url: https://github.com/hyperledger/cacti
 theme:

--- a/weaver/samples/corda/corda-simple-application/clients/build.gradle
+++ b/weaver/samples/corda/corda-simple-application/clients/build.gradle
@@ -49,7 +49,6 @@ repositories {
             dirs '../../../../core/network/corda-interop-app/interop-workflows/build/libs'
             dirs '../../../../sdks/corda/build/libs'
             dirs '../../../../common/protos-java-kt/build/libs'
-            dirs 'libs'
         }
     }
 }

--- a/weaver/samples/corda/corda-simple-application/makefile
+++ b/weaver/samples/corda/corda-simple-application/makefile
@@ -1,5 +1,3 @@
-CLIKT_VERSION=$(shell grep cliktVersion ./constants.properties | cut -d '=' -f 2)
-
 .PHONY: build-local-weaver-dependencies
 build-local-weaver-dependencies:
 	echo "Building local protos..."
@@ -112,4 +110,3 @@ publish-cordapps:
 clean:
 	./gradlew clean
 	rm -rf .gradle
-	rm -rf clients/libs


### PR DESCRIPTION
- Fixes the failing `deploy_docs.yaml` action by adding token with appropriate permissioning.
- Pegs the `protoc-gen-go-grpc` version in the relevant actions to `v1.4.0` to match what's written in the documentation (this avoids test network setup failures when running integration tests.)
- Removed dead code from the Weaver Corda sample application.
- Made `mkdocs` publish URL customizable by owner.

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.