### PR TITLE
test(api-client): jestify default-consortium-provider.test.ts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -396,8 +396,7 @@ jobs:
       JEST_TEST_RUNNER_DISABLED: false
       JEST_TEST_COVERAGE_PATH: ./code-coverage-ts/cactus-api-client
       JEST_TEST_CODE_COVERAGE_ENABLED: true
-      TAPE_TEST_PATTERN: ./packages/cactus-api-client/src/test/typescript/integration/default-consortium-provider.test.ts
-      TAPE_TEST_RUNNER_DISABLED: false
+      TAPE_TEST_RUNNER_DISABLED: true
     needs: build-dev
     runs-on: ubuntu-22.04
     steps:

--- a/.taprc
+++ b/.taprc
@@ -24,7 +24,6 @@ files:
   - ./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts
   - ./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts
   - ./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts
-  - ./packages/cactus-api-client/src/test/typescript/integration/default-consortium-provider.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-balance-endpoint.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-past-logs-endpoint.test.ts
   - ./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-balance-endpoint.test.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,7 +36,6 @@ module.exports = {
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation.test.ts`,
     `./packages/cactus-plugin-ledger-connector-xdai/src/test/typescript/integration/openapi/openapi-validation-no-keychain.test.ts`,
     `./packages/cactus-common/src/test/typescript/unit/logging/logger.test.ts`,
-    `./packages/cactus-api-client/src/test/typescript/integration/default-consortium-provider.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/get-balance-endpoint.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-past-logs-endpoint.test.ts`,
     `./packages/cactus-test-plugin-ledger-connector-besu/src/test/typescript/integration/plugin-validator-besu/v21-get-balance-endpoint.test.ts`,

--- a/packages/cactus-api-client/package.json
+++ b/packages/cactus-api-client/package.json
@@ -63,6 +63,7 @@
     "@types/jsonwebtoken": "9.0.0",
     "@types/lodash": "4.14.195",
     "@types/node": "18.11.9",
+    "http-status-codes": "2.3.0",
     "lodash": "4.17.21"
   },
   "engines": {

--- a/packages/cactus-api-client/src/test/typescript/integration/default-consortium-provider.test.ts
+++ b/packages/cactus-api-client/src/test/typescript/integration/default-consortium-provider.test.ts
@@ -1,50 +1,61 @@
-import { AddressInfo } from "net";
+import http from "node:http";
+import { AddressInfo } from "node:net";
 
-import test, { Test } from "tape";
+import "jest-extended";
+import { StatusCodes } from "http-status-codes";
 
 import { DefaultApi as ConsortiumManualApi } from "@hyperledger/cactus-plugin-consortium-manual";
-import { LogLevelDesc, Servers } from "@hyperledger/cactus-common";
+import {
+  LoggerProvider,
+  LogLevelDesc,
+  Servers,
+} from "@hyperledger/cactus-common";
 import { DefaultConsortiumProvider } from "../../../main/typescript";
 import { Configuration } from "@hyperledger/cactus-core-api";
 
-test("Reports failures with meaningful information", async (t: Test) => {
-  const logLevel: LogLevelDesc = "TRACE";
+describe("DefaultConsortiumProvider", () => {
+  const logLevel: LogLevelDesc = "SILENT";
 
-  test("Handles timeout/connection refusal transparently", async (t2: Test) => {
-    const httpServer1 = await Servers.startOnPreferredPort(4050);
-    test.onFinish(() => Servers.shutdown(httpServer1));
-    const addressInfo1 = httpServer1.address() as AddressInfo;
-    const apiHost = `http://${addressInfo1.address}:${addressInfo1.port}`;
+  const log = LoggerProvider.getOrCreate({
+    label: "default-consortium-provider.test.ts",
+    level: logLevel,
+  });
 
-    const config = new Configuration({
+  let httpServer1: http.Server;
+  let apiClientConfig: Configuration;
+
+  beforeAll(async () => {
+    httpServer1 = await Servers.startOnPreferredPort(4050);
+    const { address, port } = httpServer1.address() as AddressInfo;
+    const apiHost = `http://${address}:${port}`;
+    log.info("API host: %s", apiHost);
+
+    apiClientConfig = new Configuration({
       basePath: apiHost,
       baseOptions: {
         timeout: 2000,
       },
     });
-
-    const provider = new DefaultConsortiumProvider({
-      logLevel,
-      apiClient: new ConsortiumManualApi(config),
-    });
-
-    try {
-      await provider.get();
-      t2.fail("Provider.get() did not throw despite API errors.");
-    } catch (ex) {
-      t2.ok(ex, "Thrown error truthy OK");
-      t2.ok(ex.message, "Thrown error.message truthy OK");
-      t2.equal(
-        typeof ex.message,
-        "string",
-        "Thrown error.message type string OK",
-      );
-      t2.true(ex.message.includes("timeout"), "Has timeout in msg OK");
-    }
-    t2.end();
   });
 
-  test("Handles 4xx transparently", async (t2: Test) => {
+  afterAll(async () => {
+    await Servers.shutdown(httpServer1);
+  });
+
+  it("Handles timeout/connection refusal transparently", async () => {
+    const provider = new DefaultConsortiumProvider({
+      logLevel,
+      apiClient: new ConsortiumManualApi(apiClientConfig),
+    });
+
+    expect(provider.get()).rejects.toMatchObject({
+      message: expect.stringMatching(
+        new RegExp(`connect ECONNREFUSED (.*):4050`),
+      ),
+    });
+  });
+
+  it("Handles 4xx transparently", async () => {
     const config = new Configuration({
       basePath: "https://httpbin.org/status/400",
     });
@@ -53,24 +64,9 @@ test("Reports failures with meaningful information", async (t: Test) => {
       apiClient: new ConsortiumManualApi(config),
     });
 
-    try {
-      await provider.get();
-      t2.fail("Provider.get() did not throw despite API errors.");
-    } catch (ex) {
-      t2.ok(ex, "Thrown error truthy OK");
-      t2.ok(ex.message, "Thrown error.message truthy OK");
-      t2.equal(
-        typeof ex.message,
-        "string",
-        "Thrown error.message type string OK",
-      );
-      t2.true(
-        ex.message.includes("status code 404"),
-        "Has Status Code in msg OK",
-      );
-    }
-    t2.end();
+    expect(provider.get()).rejects.toMatchObject({
+      code: "ERR_BAD_REQUEST",
+      message: expect.stringContaining("status code " + StatusCodes.NOT_FOUND),
+    });
   });
-
-  t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9370,6 +9370,7 @@ __metadata:
     "@types/jsonwebtoken": "npm:9.0.0"
     "@types/lodash": "npm:4.14.195"
     "@types/node": "npm:18.11.9"
+    http-status-codes: "npm:2.3.0"
     jsonwebtoken: "npm:9.0.0"
     lodash: "npm:4.17.21"
     rxjs: "npm:7.8.1"
@@ -32677,6 +32678,13 @@ __metadata:
   version: 2.1.4
   resolution: "http-status-codes@npm:2.1.4"
   checksum: 10/01db6e25c19fce4cb0da2251189c35c33a4d7eff26577b9652bbd841183132e0c8cf2042ff9a840cb196f4bef265ff2d3e1c40ef46a01580020f423314017658
+  languageName: node
+  linkType: hard
+
+"http-status-codes@npm:2.3.0":
+  version: 2.3.0
+  resolution: "http-status-codes@npm:2.3.0"
+  checksum: 10/1b8a01940b5e14d3c5b2f842313f4531469b41ce4fa40ca3aae5c82a3101828db2cc9406bfb2d50a46e6d521d106577b6656c2b065c76125b99ee54b2cbbac09
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This was the final test case that was still using TAP so now we got to
turn off the tape invocation in the ci completely which is also a performance
gain worth mentioning.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.