### PR TITLE
fix(openapi): openapi-generator-ignore file

### DIFF
--- a/openapi-generator-ignore
+++ b/openapi-generator-ignore
@@ -1,9 +1,10 @@
 **/git_push.sh
 **/.npmignore
 **/.gitignore
+
+**/generated/openapi/go-client/docs/**
 **/generated/openapi/kotlin-client/docs/**
 **/generated/openapi/kotlin-client/gradle/**
-<<<<<<< HEAD
 **/generated/**/.openapi-generator-ignore
 
 # TODO: Figure out a better way to generalize these ignore patterns that are
@@ -12,7 +13,3 @@ packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-
 packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/build.gradle.kts
 packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/main/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/Application.kt
 packages/cactus-plugin-ledger-connector-corda/src/main-server/kotlin/gen/kotlin-spring/src/test/kotlin/org/hyperledger/cactus/plugin/ledger/connector/corda/server/api/ApiPluginLedgerConnectorCordaTest.kt
-=======
-**/generated/openapi/go-client/docs/**
-**/generated/**/.openapi-generator-ignore
->>>>>>> 5f00f4fc1 (build(api-client): generate go client)


### PR DESCRIPTION
## Commit to be reviewed

fix(openapi): openapi-generator-ignore file

    Primary Changes
    ---------------
    1. Fixed openapi-generator-ignore file to include the
       merge conflict error fix

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.