### PR TITLE
feat(satp-hermes): improve admin endpoints

### DIFF
--- a/packages/cactus-plugin-satp-hermes/src/main/json/openapi-blo-bundled.json
+++ b/packages/cactus-plugin-satp-hermes/src/main/json/openapi-blo-bundled.json
@@ -744,6 +744,58 @@
         }
       }
     },
+    "/api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids": {
+      "get": {
+        "summary": "Get SATP session ids",
+        "description": "Retrieve the all SATP session IDs",
+        "operationId": "GetSessionIds",
+        "tags": [
+          "admin"
+        ],
+        "x-hyperledger-cacti": {
+          "http": {
+            "verbLowerCase": "get",
+            "path": "/api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids"
+          }
+        },
+        "parameters": [
+          {
+            "name": "SessionsRequest",
+            "in": "query",
+            "schema": {
+              "type": "object",
+              "description": "Empty object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "nullable": false
+                  },
+                  "description": "Array with session Ids"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Transaction not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/api/v1/@hyperledger/cactus-plugin-satp-hermes/healthcheck": {
       "get": {
         "summary": "Health check endpoint",
@@ -2397,6 +2449,18 @@
           "X509"
         ],
         "example": "OAUTH"
+      },
+      "AllSessionIdsRequest": {
+        "type": "object",
+        "description": "Empty object"
+      },
+      "AllSessionIdsResponse": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "nullable": false
+        },
+        "description": "Array with session Ids"
       },
       "getAuditRequest": {
         "description": "Request schema for initiating an audit. Includes the start and end dates for the audit period and an option to include proofs.",

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/blo/admin/get-status-handler-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/blo/admin/get-status-handler-service.ts
@@ -2,20 +2,26 @@ import { GetStatusError } from "../../core/errors/satp-errors";
 import {
   StatusRequest,
   StatusResponse,
+  StatusResponseStageEnum,
+  StatusResponseStatusEnum,
+  StatusResponseSubstatusEnum,
   Transact200ResponseStatusResponseOriginChain,
 } from "../../generated/gateway-client/typescript-axios/api";
 import { Logger } from "@hyperledger/cactus-common";
+import { SATPManager } from "../../gol/satp-manager";
+import { SupportedChain } from "../../core/types";
 
 export async function ExecuteGetStatus(
   logger: Logger,
   req: StatusRequest,
+  manager: SATPManager,
 ): Promise<StatusResponse> {
   const fnTag = `GetStatusHandler`;
   logger.info(`${fnTag}, Obtaining status for sessionID=${req.sessionID}`);
 
   try {
     const processedRequest = req;
-    const result = await GetStatusService(logger, processedRequest);
+    const result = await GetStatusService(logger, processedRequest, manager);
     return result;
   } catch (error) {
     if (error instanceof GetStatusError) {
@@ -32,24 +38,94 @@ export async function ExecuteGetStatus(
 export async function GetStatusService(
   logger: Logger,
   req: StatusRequest,
+  manager: SATPManager,
 ): Promise<StatusResponse> {
   // Implement the logic for getting status here; call core
-  const originChain: Transact200ResponseStatusResponseOriginChain = {
-    dltProtocol: "besu",
-    dltSubnetworkID: "v24.4.0-RC1",
-  };
 
-  const destinationChain: Transact200ResponseStatusResponseOriginChain = {
-    dltProtocol: "fabric",
-    dltSubnetworkID: "v2.0.0",
-  };
+  const session = manager.getSession(req.sessionID);
+  if (!session) {
+    throw new GetStatusError(req.sessionID, " Session not found.");
+  }
+  let sessionData;
+  if (session.hasClientSessionData()) {
+    sessionData = session.getClientSessionData();
+  } else if (session.hasServerSessionData()) {
+    sessionData = session.getServerSessionData();
+  } else {
+    throw new GetStatusError(
+      req.sessionID,
+      " Session does not have session data.",
+    );
+  }
+  let status: StatusResponseStatusEnum = StatusResponseStatusEnum.Invalid;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let substatus: StatusResponseSubstatusEnum =
+    StatusResponseSubstatusEnum.Completed;
+  const startTime =
+    sessionData.receivedTimestamps?.stage0?.newSessionRequestMessageTimestamp;
+  let originChain: Transact200ResponseStatusResponseOriginChain;
+  let destinationChain: Transact200ResponseStatusResponseOriginChain;
+  if (sessionData.senderGatewayNetworkId === SupportedChain.BESU) {
+    originChain = {
+      dltProtocol: "besu",
+      dltSubnetworkID: "v24.4.0-RC1",
+    };
+    destinationChain = {
+      dltProtocol: "fabric",
+      dltSubnetworkID: "v2.0.0",
+    };
+  } else {
+    originChain = {
+      dltProtocol: "fabric",
+      dltSubnetworkID: "v2.0.0",
+    };
+    destinationChain = {
+      dltProtocol: "besu",
+      dltSubnetworkID: "v24.4.0-RC1",
+    };
+  }
+  if (!sessionData.hashes) {
+    return {
+      status: StatusResponseStatusEnum.Invalid,
+      substatus: StatusResponseSubstatusEnum.UnknownError,
+      stage: StatusResponseStageEnum.Stage0,
+      step: "transfer-complete-message",
+      startTime: startTime || "undefined",
+      originChain: originChain,
+      destinationChain: destinationChain,
+    };
+  }
+  logger.info("completed? " + sessionData.completed);
+  logger.info("stage0: " + sessionData.hashes.stage0);
+  logger.info("stage1: " + sessionData.hashes.stage1);
+  logger.info("stage2: " + sessionData.hashes.stage2);
+  logger.info("stage3: " + sessionData.hashes.stage3);
+  if (sessionData.hashes?.stage3 && sessionData.completed) {
+    substatus = StatusResponseSubstatusEnum.Completed;
+    status = StatusResponseStatusEnum.Done;
+  } else {
+    status = StatusResponseStatusEnum.Pending;
+    if (sessionData.hashes?.stage0) {
+      substatus = StatusResponseSubstatusEnum.Partial;
+    } else {
+      status = StatusResponseStatusEnum.Invalid;
+      substatus = StatusResponseSubstatusEnum.UnknownError;
+    }
+  }
+
+  let count = -1;
+  Object.entries(sessionData.hashes).forEach((stage) => {
+    if (stage[1]) {
+      ++count;
+    }
+  });
 
   const mock: StatusResponse = {
-    status: "DONE",
-    substatus: "COMPLETED",
-    stage: "STAGE3",
+    status: status,
+    substatus,
+    stage: ("STAGE" + count) as StatusResponseStageEnum,
     step: "transfer-complete-message",
-    startTime: "2023-03-14T16:50:06.662Z",
+    startTime: startTime || "undefined",
     originChain: originChain,
     destinationChain: destinationChain,
   };

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/blo/dispatcher.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/blo/dispatcher.ts
@@ -25,6 +25,7 @@ import { GatewayOrchestrator } from "../gol/gateway-orchestrator";
 import { SATPBridgesManager } from "../gol/satp-bridges-manager";
 import { ExecuteTransact } from "./transaction/transact-handler-service";
 import { TransactEndpointV1 } from "../web-services/transact-endpoint";
+import { GetSessionIdsEndpointV1 } from "../web-services/get-all-session-ids-endpoints";
 
 export interface BLODispatcherOptions {
   logger: Logger;
@@ -91,8 +92,12 @@ export class BLODispatcher {
       dispatcher: this,
       logLevel: this.options.logLevel,
     });
+    const getSessionIdsEndpointV1 = new GetSessionIdsEndpointV1({
+      dispatcher: this,
+      logLevel: this.options.logLevel,
+    });
 
-    const theEndpoints = [getStatusEndpointV1];
+    const theEndpoints = [getStatusEndpointV1, getSessionIdsEndpointV1];
     this.endpoints = theEndpoints;
     return theEndpoints;
   }
@@ -135,7 +140,7 @@ export class BLODispatcher {
   }
 
   public async GetStatus(req: StatusRequest): Promise<StatusResponse> {
-    return ExecuteGetStatus(this.logger, req);
+    return ExecuteGetStatus(this.logger, req, this.manager);
   }
 
   public async Transact(req: TransactRequest): Promise<TransactResponse> {
@@ -147,6 +152,12 @@ export class BLODispatcher {
       this.manager,
       this.orchestrator,
     );
+    return res;
+  }
+
+  public async GetSessionIds(): Promise<string[]> {
+    this.logger.info(`Get Session Ids request`);
+    const res = Array.from(await this.manager.getSessions().keys());
     return res;
   }
   // get channel by caller; give needed client from orchestrator to handler to call

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/blo/transaction/transact-handler-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/blo/transaction/transact-handler-service.ts
@@ -1,10 +1,5 @@
 import { Logger } from "@hyperledger/cactus-common";
-import {
-  TransactRequest,
-  TransactResponse,
-  Transact200ResponseStatusResponseOriginChain,
-  StatusResponse,
-} from "../../public-api";
+import { TransactRequest, TransactResponse } from "../../public-api";
 import { SATPManager } from "../../gol/satp-manager";
 import { populateClientSessionData } from "../../core/session-utils";
 import {
@@ -15,6 +10,7 @@ import {
 import { GatewayOrchestrator } from "../../gol/gateway-orchestrator";
 import { GatewayIdentity } from "../../core/types";
 import { SATP_VERSION } from "../../core/constants";
+import { GetStatusService } from "../admin/get-status-handler-service";
 
 // todo
 export async function ExecuteTransact(
@@ -83,33 +79,16 @@ export async function ExecuteTransact(
   );
   await manager.initiateTransfer(session);
 
-  //mock
-  const originChain: Transact200ResponseStatusResponseOriginChain = {
-    dltProtocol: "besu",
-    dltSubnetworkID: "v24.4.0-RC1",
-  };
-
-  const destinationChain: Transact200ResponseStatusResponseOriginChain = {
-    dltProtocol: "besu",
-    dltSubnetworkID: "v24.4.0-RC1",
-  };
-
-  const mock: StatusResponse = {
-    status: "DONE",
-    substatus: "COMPLETED",
-    stage: "STAGE3",
-    step: "transfer-complete-message",
-    startTime: "2023-03-14T16:50:06.662Z",
-    originChain: originChain,
-    destinationChain: destinationChain,
-  };
-
   logger.info(req);
   // logger.error("GetStatusService not implemented");
   // throw new GetStatusError(req.sessionID, "GetStatusService not implemented");
 
   return {
     sessionID: session.getSessionId(),
-    statusResponse: mock,
+    statusResponse: await GetStatusService(
+      logger,
+      { sessionID: session.getSessionId() },
+      manager,
+    ),
   };
 }

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage3-client-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/client/stage3-client-service.ts
@@ -282,7 +282,7 @@ export class Stage3ClientService extends SATPService {
       MessageType.COMMIT_TRANSFER_COMPLETE,
       messageSignature,
     );
-
+    sessionData.completed = true;
     saveHash(
       sessionData,
       MessageType.COMMIT_TRANSFER_COMPLETE,

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage3-server-service.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/core/stage-services/server/stage3-server-service.ts
@@ -374,6 +374,7 @@ export class Stage3ServerService extends SATPService {
     this.Log.info(
       `${fnTag}, TransferCompleteRequestMessage passed all checks.`,
     );
+    sessionData.completed = true;
 
     saveHash(
       sessionData,

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/generated/gateway-client/typescript-axios/api.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/generated/gateway-client/typescript-axios/api.ts
@@ -2122,6 +2122,41 @@ export const AdminApiAxiosParamCreator = function (configuration?: Configuration
             };
         },
         /**
+         * Retrieve the all SATP session IDs
+         * @summary Get SATP session ids
+         * @param {object} [sessionsRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getSessionIds: async (sessionsRequest?: object, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (sessionsRequest !== undefined) {
+                localVarQueryParameter['SessionsRequest'] = sessionsRequest;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Retrieve the status of a SATP session
          * @summary Get SATP current session data
          * @param {string} sessionID Unique identifier for the session.
@@ -2239,6 +2274,17 @@ export const AdminApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
+         * Retrieve the all SATP session IDs
+         * @summary Get SATP session ids
+         * @param {object} [sessionsRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getSessionIds(sessionsRequest?: object, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<string>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getSessionIds(sessionsRequest, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
          * Retrieve the status of a SATP session
          * @summary Get SATP current session data
          * @param {string} sessionID Unique identifier for the session.
@@ -2300,6 +2346,16 @@ export const AdminApiFactory = function (configuration?: Configuration, basePath
          */
         getHealthCheck(options?: any): AxiosPromise<GetHealthCheck200Response> {
             return localVarFp.getHealthCheck(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Retrieve the all SATP session IDs
+         * @summary Get SATP session ids
+         * @param {object} [sessionsRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getSessionIds(sessionsRequest?: object, options?: any): AxiosPromise<Array<string>> {
+            return localVarFp.getSessionIds(sessionsRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * Retrieve the status of a SATP session
@@ -2366,6 +2422,18 @@ export class AdminApi extends BaseAPI {
      */
     public getHealthCheck(options?: AxiosRequestConfig) {
         return AdminApiFp(this.configuration).getHealthCheck(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Retrieve the all SATP session IDs
+     * @summary Get SATP session ids
+     * @param {object} [sessionsRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AdminApi
+     */
+    public getSessionIds(sessionsRequest?: object, options?: AxiosRequestConfig) {
+        return AdminApiFp(this.configuration).getSessionIds(sessionsRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/gol/satp-manager.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/gol/satp-manager.ts
@@ -164,7 +164,7 @@ export class SATPManager {
     return SATPManager.CLASS_NAME;
   }
 
-  public getSessions(): Map<string, SATPSession> | undefined {
+  public getSessions(): Map<string, SATPSession> {
     return this.sessions;
   }
 

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/plugin-satp-hermes-gateway.ts
@@ -533,6 +533,8 @@ export class SATPGateway implements IPluginWebService, ICactusPlugin {
     this.logger.debug(`Entering ${fnTag}`);
     if (this.BLOServer) {
       try {
+        await this.GOLServer?.close();
+        await this.BLOServer.closeAllConnections();
         await this.BLOServer.close();
         this.BLOServer = undefined;
         this.logger.info("Server shut down");

--- a/packages/cactus-plugin-satp-hermes/src/main/typescript/web-services/get-all-session-ids-endpoints.ts
+++ b/packages/cactus-plugin-satp-hermes/src/main/typescript/web-services/get-all-session-ids-endpoints.ts
@@ -1,0 +1,98 @@
+import type { Express, Request, Response } from "express";
+
+import {
+  IWebServiceEndpoint,
+  IExpressRequestHandler,
+  IEndpointAuthzOptions,
+} from "@hyperledger/cactus-core-api";
+import {
+  Logger,
+  Checks,
+  LoggerProvider,
+  IAsyncProvider,
+} from "@hyperledger/cactus-common";
+
+import { registerWebServiceEndpoint } from "@hyperledger/cactus-core";
+
+import OAS from "../../json/openapi-blo-bundled.json";
+import { IRequestOptions } from "../core/types";
+
+export class GetSessionIdsEndpointV1 implements IWebServiceEndpoint {
+  public static readonly CLASS_NAME = "GetSessionIdsEndpointV1";
+
+  private readonly log: Logger;
+
+  public get className(): string {
+    return GetSessionIdsEndpointV1.CLASS_NAME;
+  }
+
+  constructor(public readonly options: IRequestOptions) {
+    const fnTag = `${this.className}#constructor()`;
+    Checks.truthy(options, `${fnTag} arg options`);
+    Checks.truthy(options.dispatcher, `${fnTag} arg options.connector`);
+
+    const level = this.options.logLevel || "INFO";
+    const label = this.className;
+    this.log = LoggerProvider.getOrCreate({ level, label });
+  }
+
+  public getPath(): string {
+    const apiPath =
+      OAS.paths[
+        "/api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids"
+      ];
+    return apiPath.get["x-hyperledger-cacti"].http.path;
+  }
+
+  public getVerbLowerCase(): string {
+    const apiPath =
+      OAS.paths[
+        "/api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids"
+      ];
+    return apiPath.get["x-hyperledger-cacti"].http.verbLowerCase;
+  }
+
+  public getOperationId(): string {
+    return OAS.paths[
+      "/api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids"
+    ].get.operationId;
+  }
+
+  getAuthorizationOptionsProvider(): IAsyncProvider<IEndpointAuthzOptions> {
+    // TODO: make this an injectable dependency in the constructor
+    return {
+      get: async () => ({
+        isProtected: true,
+        requiredRoles: [],
+      }),
+    };
+  }
+
+  public async registerExpress(
+    expressApp: Express,
+  ): Promise<IWebServiceEndpoint> {
+    await registerWebServiceEndpoint(expressApp, this);
+    return this;
+  }
+
+  public getExpressRequestHandler(): IExpressRequestHandler {
+    return this.handleRequest.bind(this);
+  }
+
+  // TODO discover way to inherit OAS schema and have request types here
+  // parameter checks should be enforced by the type system
+  public async handleRequest(req: Request, res: Response): Promise<void> {
+    const reqTag = `${this.getVerbLowerCase()} - ${this.getPath()}`;
+    this.log.debug(reqTag);
+    try {
+      const result = await this.options.dispatcher.GetSessionIds();
+      res.status(200).json(result);
+    } catch (ex) {
+      this.log.error(`Crash while serving ${reqTag}`, ex);
+      res.status(500).json({
+        message: "Internal Server Error",
+        error: ex?.stack || ex?.message,
+      });
+    }
+  }
+}

--- a/packages/cactus-plugin-satp-hermes/src/main/yml/bol/openapi-blo-bundled.yml
+++ b/packages/cactus-plugin-satp-hermes/src/main/yml/bol/openapi-blo-bundled.yml
@@ -577,6 +577,40 @@ paths:
           description: Transaction not found
         '500':
           description: Internal server error
+  /api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids:
+    get:
+      summary: Get SATP session ids
+      description: Retrieve the all SATP session IDs
+      operationId: GetSessionIds
+      tags:
+        - admin
+      x-hyperledger-cacti:
+        http:
+          verbLowerCase: get
+          path: /api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids
+      parameters:
+        - name: SessionsRequest
+          in: query
+          schema:
+            type: object
+            description: Empty object
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  nullable: false
+                description: Array with session Ids
+        '400':
+          description: Bad request
+        '404':
+          description: Transaction not found
+        '500':
+          description: Internal server error
   /api/v1/@hyperledger/cactus-plugin-satp-hermes/healthcheck:
     get:
       summary: Health check endpoint
@@ -1821,6 +1855,15 @@ components:
         - OAUTH
         - X509
       example: OAUTH
+    AllSessionIdsRequest:
+      type: object
+      description: Empty object
+    AllSessionIdsResponse:
+      type: array
+      items:
+        type: string
+        nullable: false
+      description: Array with session Ids
     getAuditRequest:
       description: Request schema for initiating an audit. Includes the start and end dates for the audit period and an option to include proofs.
       type: object

--- a/packages/cactus-plugin-satp-hermes/src/main/yml/bol/openapi-blo.yml
+++ b/packages/cactus-plugin-satp-hermes/src/main/yml/bol/openapi-blo.yml
@@ -129,6 +129,35 @@ paths:
           description: Transaction not found
         '500':
           description: Internal server error
+  /api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids:
+    get:
+      summary: Get SATP session ids
+      description: Retrieve the all SATP session IDs
+      operationId: GetSessionIds
+      tags:
+        - admin
+      x-hyperledger-cacti:
+        http:
+          verbLowerCase: get
+          path: /api/v1/@hyperledger/cactus-plugin-satp-hermes/get-sessions-ids
+      parameters:
+        - name: SessionsRequest
+          in: query
+          schema:
+            $ref: "./schemas.yml#/AllSessionIdsRequest"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas.yml#/AllSessionIdsResponse"
+        '400':
+          description: Bad request
+        '404':
+          description: Transaction not found
+        '500':
+          description: Internal server error
   /api/v1/@hyperledger/cactus-plugin-satp-hermes/healthcheck:
     get:
       summary: Health check endpoint

--- a/packages/cactus-plugin-satp-hermes/src/main/yml/bol/schemas.yml
+++ b/packages/cactus-plugin-satp-hermes/src/main/yml/bol/schemas.yml
@@ -27,6 +27,16 @@ CredentialProfile:
     - OAUTH
     - X509
   example: OAUTH
+AllSessionIdsRequest:
+  type: object
+  description: Empty object
+
+AllSessionIdsResponse:
+  type: array
+  items:
+    type: string
+    nullable: false
+  description: Array with session Ids
 getAuditRequest:
   description: "Request schema for initiating an audit. Includes the start and end dates for the audit period and an option to include proofs."
   type: object

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/satp-end-to-end-transfer-1-gateway.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/satp-end-to-end-transfer-1-gateway.test.ts
@@ -171,7 +171,7 @@ beforeAll(async () => {
       imageName: "ghcr.io/hyperledger/cactus-fabric2-all-in-one",
       imageVersion: FABRIC_25_LTS_AIO_IMAGE_VERSION,
       envVars: new Map([["FABRIC_VERSION", FABRIC_25_LTS_AIO_FABRIC_VERSION]]),
-      logLevel,
+      logLevel: "INFO",
     });
 
     await fabricLedger.start();
@@ -1002,7 +1002,6 @@ describe("SATPGateway sending a token from Besu to Fabric", () => {
       toDLTNetworkID: SupportedChain.FABRIC,
       fromAmount: "100",
       toAmount: "1",
-      mode: "transfer",
       originatorPubkey: assigneeEthAccount.address,
       beneficiaryPubkey: fabricUser.credentials.certificate,
       sourceAsset,
@@ -1078,7 +1077,7 @@ describe("SATPGateway sending a token from Besu to Fabric", () => {
     expect(responseBalance2.data).not.toBeUndefined();
     expect(responseBalance2.data.functionOutput).toBe("1");
     log.info("Amount was transfer correctly to the Owner account");
-
+    log.info(res?.statusResponse);
     await gateway.shutdown();
   });
 });

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/satp-end-to-end-transfer-2-gateways-openapi.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/satp-end-to-end-transfer-2-gateways-openapi.test.ts
@@ -1053,10 +1053,15 @@ describe("2 SATPGateway sending a token from Besu to Fabric using openApi to req
       port,
       log,
     );
+    const adminApi = createClient("AdminApi", address, port, log);
 
     const res = await transactionApiClient.transact(req as TransactRequest);
-
     log.info(res?.data.statusResponse);
+
+    const sessions = await adminApi.getSessionIds({});
+    expect(sessions.data).toBeTruthy();
+    expect(sessions.data.length).toBe(1);
+    expect(sessions.data[0]).toBe(res.data.sessionID);
 
     const responseBalanceOwner = await testing_connector.invokeContract({
       contractName: erc20TokenContract,

--- a/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/satp-end-to-end-transfer-2-gateways.test.ts
+++ b/packages/cactus-plugin-satp-hermes/src/test/typescript/integration/satp-end-to-end-transfer-2-gateways.test.ts
@@ -1034,7 +1034,6 @@ describe("2 SATPGateway sending a token from Besu to Fabric", () => {
       toDLTNetworkID: SupportedChain.FABRIC,
       fromAmount: "100",
       toAmount: "1",
-      mode: "transfer",
       originatorPubkey: assigneeEthAccount.address,
       beneficiaryPubkey: fabricUser.credentials.certificate,
       sourceAsset,


### PR DESCRIPTION
Some small improves in the GetStatus endpoint for a little more information when asking for status (instead of the default return). there is still room for improvement.
Created a getAllSessionsIds endpoint which may be useful in the admin api.

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.