### PR TITLE
test(test-tooling): add new besu AIO image builder utility

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -18,6 +18,7 @@
     "Authz",
     "authzn",
     "AWSSM",
+    "baio",
     "benchmarkjs",
     "Besu",
     "Bools",

--- a/packages/cactus-test-tooling/src/main/typescript/corda/build-image-besu-all-in-one-latest.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/corda/build-image-besu-all-in-one-latest.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { buildContainerImage } from "../public-api";
 import { LoggerProvider, LogLevelDesc } from "@hyperledger/cactus-common";
 
-export interface IBuildImageCordaAllInOneV412Response {
+export interface IBuildImageBesuAllInOneLatestResponse {
   readonly imageName: Readonly<string>;
   readonly imageVersion: Readonly<string>;
   /**
@@ -11,30 +11,30 @@ export interface IBuildImageCordaAllInOneV412Response {
   readonly imageTag: Readonly<string>;
 }
 
-export interface IBuildImageCordaAllInOneV412Request {
+export interface IBuildImageBesuAllInOneLatestRequest {
   readonly logLevel?: Readonly<LogLevelDesc>;
 }
 
-export async function buildImageCordaAllInOneV412(
-  req: IBuildImageCordaAllInOneV412Request,
-): Promise<IBuildImageCordaAllInOneV412Response> {
+export async function buildImageBesuAllInOneLatest(
+  req: IBuildImageBesuAllInOneLatestRequest,
+): Promise<IBuildImageBesuAllInOneLatestResponse> {
   if (!req) {
     throw new Error("Expected arg req to be truthy.");
   }
   const logLevel: LogLevelDesc = req.logLevel || "WARN";
   const log = LoggerProvider.getOrCreate({
     level: logLevel,
-    label: "build-image-corda-all-in-one-v4-12.ts",
+    label: "build-image-besu-all-in-one-latest.ts",
   });
   const projectRoot = path.join(__dirname, "../../../../../../../");
 
-  const buildDirRel = "./tools/docker/corda-all-in-one/corda-v4_12/";
+  const buildDirRel = "./tools/docker/besu-all-in-one/";
 
   const buildDirAbs = path.join(projectRoot, buildDirRel);
 
   log.info("Invoking container build with build dir: %s", buildDirAbs);
 
-  const imageName = "caio412";
+  const imageName = "baio";
   const imageVersion = "latest";
   const imageTag = `${imageName}:${imageVersion}`;
 

--- a/packages/cactus-test-tooling/src/main/typescript/public-api.ts
+++ b/packages/cactus-test-tooling/src/main/typescript/public-api.ts
@@ -218,3 +218,9 @@ export {
   IBuildImageCordaAllInOneV412Response,
   buildImageCordaAllInOneV412,
 } from "./corda/build-image-corda-all-in-one-v4-12";
+
+export {
+  IBuildImageBesuAllInOneLatestRequest,
+  IBuildImageBesuAllInOneLatestResponse,
+  buildImageBesuAllInOneLatest,
+} from "./corda/build-image-besu-all-in-one-latest";


### PR DESCRIPTION
1. This will help author test cases for the Besu connector that are designed
to be testing the latest version of the image instead of a pinned one that
we pull from the registry as part of the test case.
2. We need tests for both latest and pinned image versions if we want to
make sure that the connector is backward compatible with older ledger versions.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.