### PR TITLE
ci(github): fix commit parity running outside PR

### DIFF
--- a/.github/workflows/pr-commit-parity.yaml
+++ b/.github/workflows/pr-commit-parity.yaml
@@ -1,15 +1,6 @@
 ---
 name: PR - Commit Parity
-'on':
-  pull_request:
-    branches:
-      - main
-      - dev
-      - petermetz/**
-  push:
-    branches:
-      - main
-      - dev
+on: [pull_request]
 
 env:
   NODEJS_VERSION: v18.18.2


### PR DESCRIPTION
ci(github): fix commit parity running outside PR 
   
    Primary Changes
    ---------------
    1. Updated the workflow to run only on Pull Requests

Fixes #3515

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.