### PR TITLE
fix(weaver-corda): added duplicate handling strategy in build.gradle

### DIFF
--- a/weaver/common/protos-java-kt/build.gradle
+++ b/weaver/common/protos-java-kt/build.gradle
@@ -76,7 +76,6 @@ dependencies {
     implementation "io.grpc:grpc-netty-shaded:$grpc_version"
     implementation "io.grpc:grpc-protobuf:$grpc_version"
     implementation "io.grpc:grpc-stub:$grpc_version"
-    implementation 'javax.annotation:javax.annotation-api:1.3.2'
     compileOnly 'org.apache.tomcat:annotations-api:6.0.53' // necessary for Java 9+
 
 }

--- a/weaver/core/network/corda-interop-app/build.gradle
+++ b/weaver/core/network/corda-interop-app/build.gradle
@@ -117,6 +117,10 @@ allprojects {
         preserveFileTimestamps = false
         reproducibleFileOrder = true
     }
+
+    tasks.named('jar') {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
 }
 
 apply plugin: 'net.corda.plugins.cordapp'


### PR DESCRIPTION
This bug was detected in release of `v2.0.0-rc.4`, by the deployment workflow

**Pull Request Requirements**
- [ ] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [ ] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [ ] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [ ] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [ ] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.