### PR TITLE
ci(release-automation): make release issuance atomic

### DIFF
--- a/.github/workflows/all-nodejs-packages-publish.yaml
+++ b/.github/workflows/all-nodejs-packages-publish.yaml
@@ -24,18 +24,7 @@ jobs:
           always-auth: true
           node-version: ${{ env.NODEJS_VERSION }}
           registry-url: "https://registry.npmjs.org/"
-
-      - run: cat /home/runner/work/_temp/.npmrc
-
-      - uses: actions/setup-node@v4.0.3
-        with:
-          always-auth: true
-          node-version: ${{ env.NODEJS_VERSION }}
-          registry-url: "https://npm.pkg.github.com/"
-
-      - run: cat /home/runner/work/_temp/.npmrc
-
-      - run: sed -i 's/npm.pkg.github.com\/:_authToken=${NODE_AUTH_TOKEN}/npm.pkg.github.com\/:_authToken=${GITHUB_TOKEN}/' /home/runner/work/_temp/.npmrc
+          scope: "@hyperledger"
 
       - run: cat /home/runner/work/_temp/.npmrc
 
@@ -47,10 +36,36 @@ jobs:
           JEST_TEST_RUNNER_DISABLED: true
           TAPE_TEST_RUNNER_DISABLED: true
 
-      - name: lerna-publish
+      - name: lerna-publish-npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "npm-ci@hyperledger.org"
+          git config --global user.name "hyperledger-ghci"
+          npm whoami
+          yarn lerna publish from-git --yes --loglevel=debug --ignore-scripts
+
+      - run: cat /home/runner/work/_temp/.npmrc
+
+      # Reset the .npmrc by deleting it. Invoking the setup-node action again below
+      # will set it up from scratch again but with a different registry  configuration
+      # so that we can publish to both registries instead of having to choose.
+      - run: rm /home/runner/work/_temp/.npmrc
+
+      - uses: actions/setup-node@v4.0.3
+        with:
+          always-auth: true
+          node-version: ${{ env.NODEJS_VERSION }}
+          registry-url: "https://npm.pkg.github.com/"
+          scope: "@hyperledger"
+
+      - run: cat /home/runner/work/_temp/.npmrc
+  
+      # We run the publish script a second time after having reconfigured the registry to be GHCR
+      # instead of npmjs.org so that we can publish the packages everywhere.
+      - name: lerna-publish-ghcr
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.email "npm-ci@hyperledger.org"
           git config --global user.name "hyperledger-ghci"


### PR DESCRIPTION
The NodeJS package publishing GitHub workflow job will now publish
all packages to both GHCR and npmjs.org registries.

It dynamically reconfigures the .npmrc file with the appropriate registry
URL and the correct token gets set through the environment variables as well.

The lerna publish script gets invoked twice, with different registry configurations
which was the only way I found to make sure that all the packages are deployed
to all the locations where they are to be used.

Fixes #451

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>

**Pull Request Requirements**
- [x] Rebased onto `upstream/main` branch and squashed into single commit to help maintainers review it more efficient and to avoid spaghetti git commit graphs that obfuscate which commit did exactly what change, when and, why.
- [x] Have git sign off at the end of commit message to avoid being marked red. You can add `-s` flag when using `git commit` command. You may refer to this [link](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more information.
- [x] Follow the Commit Linting specification. You may refer to this [link](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#specification) for more information. 

**Character Limit**
- [x] Pull Request Title and Commit Subject must not exceed 72 characters (including spaces and special characters).
- [x] Commit Message per line must not exceed 80 characters (including spaces and special characters).

**A Must Read for Beginners**
For rebasing and squashing, here's a [must read guide](https://github.com/servo/servo/wiki/Beginner's-guide-to-rebasing-and-squashing) for beginners.